### PR TITLE
[IMP] Add statement line reference to search

### DIFF
--- a/account_statement_completion_label/statement.py
+++ b/account_statement_completion_label/statement.py
@@ -92,7 +92,7 @@ class AccountStatementCompletionRule(orm.Model):
                          ON
                             st_l.statement_id = s.id
                     WHERE
-                        st_l.name ~* l.label
+                        (st_l.name ~* l.label OR st_l.ref ~* l.label)
                     AND
                         l.profile_id = s.profile_id
                     AND


### PR DESCRIPTION
Add the reference to the search for matching statements. When importing CAMT (Dutch banking files) the description of the statement line is filled in the reference field. The name field only has the index (eg 001), not the full text.
