### PR TITLE
Reconcile optimization: avoid to do a partial reconcile if it was already reconciled with the same lines

### DIFF
--- a/account_advanced_reconcile_transaction_ref/base_advanced_reconciliation.py
+++ b/account_advanced_reconcile_transaction_ref/base_advanced_reconciliation.py
@@ -30,8 +30,6 @@ class EasyReconcileAdvanced(orm.AbstractModel):
         """ Mandatory columns for move lines queries
         An extra column aliased as ``key`` should be defined
         in each query."""
-        aml_cols = super(easy_reconcile_advanced, self).\
-            _base_columns(rec)
-        aml_cols += ['account_move_line.transaction_ref']
+        aml_cols = super(EasyReconcileAdvanced, self)._base_columns(rec)
+        aml_cols.append('account_move_line.transaction_ref')
         return aml_cols
-

--- a/account_advanced_reconcile_transaction_ref/base_advanced_reconciliation.py
+++ b/account_advanced_reconcile_transaction_ref/base_advanced_reconciliation.py
@@ -30,16 +30,8 @@ class EasyReconcileAdvanced(orm.AbstractModel):
         """ Mandatory columns for move lines queries
         An extra column aliased as ``key`` should be defined
         in each query."""
-        aml_cols = (
-            'id',
-            'debit',
-            'credit',
-            'date',
-            'period_id',
-            'ref',
-            'name',
-            'partner_id',
-            'account_id',
-            'move_id',
-            'transaction_ref')
-        return ["account_move_line.%s" % col for col in aml_cols]
+        aml_cols = super(easy_reconcile_advanced, self).\
+            _base_columns(rec)
+        aml_cols += ['account_move_line.transaction_ref']
+        return aml_cols
+

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -71,6 +71,7 @@ class EasyReconcileBase(orm.AbstractModel):
             'name',
             'partner_id',
             'account_id',
+            'reconcile_partial_id',
             'move_id')
         return ["account_move_line.%s" % col for col in aml_cols]
 
@@ -195,6 +196,19 @@ class EasyReconcileBase(orm.AbstractModel):
                 context=rec_ctx)
             return True, True
         elif allow_partial:
+            # Check if the group of move lines was already partially
+            # reconciled and if all the lines were the same, in such
+            # case, just skip the group and consider it as partially
+            # reconciled (no change).
+            existing_partial_id = lines[0]['reconcile_partial_id']
+            if existing_partial_id:
+                partial_line_ids = set(ml_obj.search(
+                    cr, uid,
+                    [('reconcile_partial_id', '=', existing_partial_id)],
+                    context=context))
+                if set(line_ids) == partial_line_ids:
+                    return True, False
+
             ml_obj.reconcile_partial(
                 cr, uid,
                 line_ids,

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -200,14 +200,15 @@ class EasyReconcileBase(orm.AbstractModel):
             # reconciled and if all the lines were the same, in such
             # case, just skip the group and consider it as partially
             # reconciled (no change).
-            existing_partial_id = lines[0]['reconcile_partial_id']
-            if existing_partial_id:
-                partial_line_ids = set(ml_obj.search(
-                    cr, uid,
-                    [('reconcile_partial_id', '=', existing_partial_id)],
-                    context=context))
-                if set(line_ids) == partial_line_ids:
-                    return True, False
+            if lines:
+                existing_partial_id = lines[0]['reconcile_partial_id']
+                if existing_partial_id:
+                    partial_line_ids = set(ml_obj.search(
+                        cr, uid,
+                        [('reconcile_partial_id', '=', existing_partial_id)],
+                        context=context))
+                    if set(line_ids) == partial_line_ids:
+                        return True, False
 
             ml_obj.reconcile_partial(
                 cr, uid,


### PR DESCRIPTION
Before this optimization, the same partial reconciliation were created
at each run of the automatic reconcile.
