### PR TITLE
7.0 Conversion_dict is now created in the generic parser

### DIFF
--- a/account_statement_base_import/parser/file_parser.py
+++ b/account_statement_base_import/parser/file_parser.py
@@ -42,7 +42,7 @@ class FileParser(BankStatementImportParser):
         """
             :param char: parse_name: The name of the parser
             :param char: ftype: extension of the file (could be csv, xls or xlsx)
-            :param dict: extra_fields: extra fields to add to the conversion dict. In the format
+            :param dict: extra_fields: extra fields to put into the conversion dict. In the format
                                      {fieldname: fieldtype}
             :param list: header : specify header fields if the csv file has no header
             """
@@ -53,14 +53,7 @@ class FileParser(BankStatementImportParser):
         else:
             raise except_osv(_('User Error'),
                              _('Invalid file type %s. Please use csv, xls or xlsx') % ftype)
-        self.conversion_dict = {
-            'ref': unicode,
-            'label': unicode,
-            'date': datetime.datetime,
-            'amount': float_or_zero,
-        }
-        if extra_fields:
-            self.conversion_dict.update(extra_fields)
+        self.conversion_dict = extra_fields
         self.keys_to_validate = self.conversion_dict.keys()
         self.fieldnames = header
         self._datemode = 0  # used only for xls documents,

--- a/account_statement_base_import/parser/file_parser.py
+++ b/account_statement_base_import/parser/file_parser.py
@@ -46,7 +46,7 @@ class FileParser(BankStatementImportParser):
             :param char: parse_name: The name of the parser
             :param char: ftype: extension of the file (could be csv, xls or
               xlsx)
-            :param dict: extra_fields: extra fields to add to the conversion
+            :param dict: extra_fields: extra fields to put into the conversion
               dict. In the format {fieldname: fieldtype}
             :param list: header : specify header fields if the csv file has no
               header
@@ -58,14 +58,7 @@ class FileParser(BankStatementImportParser):
             raise except_orm(
                 _('User Error'),
                 _('Invalid file type %s. Please use csv, xls or xlsx') % ftype)
-        self.conversion_dict = {
-            'ref': unicode,
-            'label': unicode,
-            'date': datetime.datetime,
-            'amount': float_or_zero,
-        }
-        if extra_fields:
-            self.conversion_dict.update(extra_fields)
+        self.conversion_dict = extra_fields
         self.keys_to_validate = self.conversion_dict.keys()
         self.fieldnames = header
         self._datemode = 0  # used only for xls documents,

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -25,7 +25,7 @@ import tempfile
 import datetime
 from file_parser import FileParser
 from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
-from openerp.loglevels import ustr
+from openerp.tools import ustr
 try:
     import xlrd
 except:

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -21,6 +21,7 @@
 import datetime
 from file_parser import FileParser
 from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
+from openerp.loglevels import ustr
 try:
     import xlrd
 except:
@@ -36,8 +37,8 @@ class GenericFileParser(FileParser):
 
     def __init__(self, parse_name, ftype='csv', **kwargs):
         conversion_dict = {
-            'ref': unicode,
-            'label': unicode,
+            'ref': ustr,
+            'label': ustr,
             'date': datetime.datetime,
             'amount': float_or_zero,
         }

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -24,10 +24,6 @@ from openerp.addons.account_statement_base_import.parser.file_parser import (
     float_or_zero
 )
 from openerp.tools import ustr
-try:
-    import xlrd
-except:
-    raise Exception(_('Please install python lib xlrd'))
 
 
 class GenericFileParser(FileParser):
@@ -45,7 +41,7 @@ class GenericFileParser(FileParser):
             'amount': float_or_zero,
         }
         super(GenericFileParser, self).__init__(
-            parse_name, ftype=ftype, 
+            parse_name, ftype=ftype,
             extra_fields=conversion_dict,
             **kwargs)
 

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -20,6 +20,11 @@
 
 import datetime
 from file_parser import FileParser
+from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
+try:
+    import xlrd
+except:
+    raise Exception(_('Please install python lib xlrd'))
 
 
 class GenericFileParser(FileParser):
@@ -30,8 +35,16 @@ class GenericFileParser(FileParser):
     """
 
     def __init__(self, parse_name, ftype='csv', **kwargs):
+        conversion_dict = {
+            'ref': unicode,
+            'label': unicode,
+            'date': datetime.datetime,
+            'amount': float_or_zero,
+        }
         super(GenericFileParser, self).__init__(
-            parse_name, ftype=ftype, **kwargs)
+            parse_name, ftype=ftype, 
+            extra_fields=conversion_dict,
+            **kwargs)
 
     @classmethod
     def parser_for(cls, parser_name):

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -24,6 +24,7 @@ import csv
 import tempfile
 import datetime
 from file_parser import FileParser
++from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
 try:
     import xlrd
 except:
@@ -38,7 +39,13 @@ class GenericFileParser(FileParser):
     """
 
     def __init__(self, parse_name, ftype='csv', **kwargs):
-        super(GenericFileParser, self).__init__(parse_name, ftype=ftype, **kwargs)
+        conversion_dict = {
+            'ref': unicode,
+            'label': unicode,
+            'date': datetime.datetime,
+            'amount': float_or_zero,
+        }
+        super(GenericFileParser, self).__init__(parse_name, ftype=ftype, extra_fields=conversion_dict, **kwargs)
 
     @classmethod
     def parser_for(cls, parser_name):

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -24,7 +24,8 @@ import csv
 import tempfile
 import datetime
 from file_parser import FileParser
-+from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
+from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
+from openerp.loglevels import ustr
 try:
     import xlrd
 except:
@@ -40,8 +41,8 @@ class GenericFileParser(FileParser):
 
     def __init__(self, parse_name, ftype='csv', **kwargs):
         conversion_dict = {
-            'ref': unicode,
-            'label': unicode,
+            'ref': ustr,
+            'label': ustr,
             'date': datetime.datetime,
             'amount': float_or_zero,
         }

--- a/account_statement_base_import/parser/generic_file_parser.py
+++ b/account_statement_base_import/parser/generic_file_parser.py
@@ -24,7 +24,9 @@ import csv
 import tempfile
 import datetime
 from file_parser import FileParser
-from openerp.addons.account_statement_base_import.parser.file_parser import float_or_zero
+from openerp.addons.account_statement_base_import.parser.file_parser import (
+    float_or_zero
+)
 from openerp.tools import ustr
 try:
     import xlrd
@@ -46,7 +48,9 @@ class GenericFileParser(FileParser):
             'date': datetime.datetime,
             'amount': float_or_zero,
         }
-        super(GenericFileParser, self).__init__(parse_name, ftype=ftype, extra_fields=conversion_dict, **kwargs)
+        super(GenericFileParser, self).__init__(parse_name, ftype=ftype,
+                                                extra_fields=conversion_dict,
+                                                **kwargs)
 
     @classmethod
     def parser_for(cls, parser_name):


### PR DESCRIPTION
The conversion dict is displaced from the file_parser to the generic_parser in order to avoid the error of the validate function when creating a new parser which does not contain the 4 basc fields (ref, amount, date, label)

The old launchpad link : 
https://code.launchpad.net/~akretion-team/banking-addons/account_statement_base_import_conversion_dict/+merge/198235
