### PR TITLE
Corrects issue with customer refunds and partner lookup for imported lines.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ include =
     */bank-statement-reconcile/*
 
 omit =
+    */test/*
     */tests/*
     *__init__.py
 

--- a/account_statement_base_completion/__openerp__.py
+++ b/account_statement_base_completion/__openerp__.py
@@ -19,18 +19,21 @@
 #
 ##############################################################################
 
-{'name': "Bank statement base completion",
- 'version': '1.0.3',
- 'author': 'Camptocamp',
- 'maintainer': 'Camptocamp',
- 'category': 'Finance',
- 'complexity': 'normal',
- 'depends': ['account_statement_ext',
-             'account_report_company'],
- 'description': """
- The goal of this module is to improve the basic bank statement, help dealing with huge volume of
- reconciliation by providing basic rules to identify the partner of a bank statement line.
- Each bank statement profile can have its own rules to be applied according to a sequence order.
+{
+    'name': "Bank statement base completion",
+    'version': '1.0.3',
+    'author': 'Camptocamp',
+    'maintainer': 'Camptocamp',
+    'category': 'Finance',
+    'complexity': 'normal',
+    'depends': ['account_statement_ext',
+                'account_report_company'],
+    'description': """
+ The goal of this module is to improve the basic bank statement, help dealing
+ with huge volume of reconciliation by providing basic rules to identify the
+ partner of a bank statement line.
+ Each bank statement profile can have its own rules to be applied according to
+ a sequence order.
 
  Some basic rules are provided in this module:
 
@@ -38,13 +41,15 @@
  2) Match from statement line label (based on partner name)
  3) Match from statement line reference (based on Invoice number)
 
- You can easily override this module and add your own rules in your own one. The basic rules only
- fill in  the partner, but you can use them to fill in any value of the line (in the future, we will
- add a rule to automatically match and reconcile the line).
+ You can easily override this module and add your own rules in your own one.
+ The basic rules only fill in  the partner, but you can use them to fill in
+ any value of the line (in the future, we will add a rule to automatically
+ match and reconcile the line).
 
- It adds as well a label on the bank statement line (on which the pre-define rules can match) and
- a char field on the partner called 'Bank Statement Label'. Using the pre-define rules, you will be
- able to match various labels for a partner.
+ It adds as well a label on the bank statement line (on which the pre-define
+ rules can match) and a char field on the partner called 'Bank Statement
+ Label'.  Using the pre-define rules, you will be able to match various
+ labels for a partner.
 
  The reference of the line is always used by the reconciliation process. We're supposed to copy
  there (or write manually) the matching string. This can be: the order Number or an invoice number,
@@ -53,27 +58,27 @@
  You can use it with  our account_advanced_reconcile module to automatize the reconciliation process.
 
 
- TODO: The rules that look for invoices to find out the partner should take back the payable / receivable
-       account from there directly instead of retrieving it from partner properties !
-
- """,
- 'website': 'http://www.camptocamp.com',
- 'data': [
-     'statement_view.xml',
-     'partner_view.xml',
-     'data.xml',
-     'security/ir.model.access.csv',
- ],
- 'demo': [],
- 'test': [
-    'test/partner.yml',
-    'test/invoice.yml',
-    'test/supplier_invoice.yml',
+ TODO: The rules that look for invoices to find out the partner should take
+ back the payable / receivable account from there directly instead of
+ retrieving it from partner properties!
+    """,
+    'website': 'http://www.camptocamp.com',
+    'data': [
+        'statement_view.xml',
+        'partner_view.xml',
+        'data.xml',
+        'security/ir.model.access.csv',
+    ],
+    'demo': [],
+    'test': [
+        'test/partner.yml',
+        'test/invoice.yml',
+        'test/supplier_invoice.yml',
     'test/refund.yml',
-    'test/completion_test.yml'
- ],
- 'installable': True,
- 'images': [],
- 'auto_install': False,
- 'license': 'AGPL-3',
+        'test/completion_test.yml'
+    ],
+    'installable': True,
+    'images': [],
+    'auto_install': False,
+    'license': 'AGPL-3',
 }

--- a/account_statement_base_completion/__openerp__.py
+++ b/account_statement_base_completion/__openerp__.py
@@ -19,68 +19,61 @@
 #
 ##############################################################################
 
-{
-    'name': "Bank statement base completion",
-    'version': '1.0.3',
-    'author': 'Camptocamp',
-    'maintainer': 'Camptocamp',
-    'category': 'Finance',
-    'complexity': 'normal',
-    'depends': ['account_statement_ext',
-                'account_report_company'],
-    'description': """
- The goal of this module is to improve the basic bank statement, help dealing
- with huge volume of reconciliation by providing basic rules to identify the
- partner of a bank statement line.
- Each bank statement profile can have its own rules to be applied according to a
- sequence order.
+{'name': "Bank statement base completion",
+ 'version': '1.0.3',
+ 'author': 'Camptocamp',
+ 'maintainer': 'Camptocamp',
+ 'category': 'Finance',
+ 'complexity': 'normal',
+ 'depends': ['account_statement_ext',
+             'account_report_company'],
+ 'description': """
+ The goal of this module is to improve the basic bank statement, help dealing with huge volume of
+ reconciliation by providing basic rules to identify the partner of a bank statement line.
+ Each bank statement profile can have its own rules to be applied according to a sequence order.
 
  Some basic rules are provided in this module:
 
- 1) Match from statement line label (based on partner field 'Bank Statement
-    Label')
+ 1) Match from statement line label (based on partner field 'Bank Statement Label')
  2) Match from statement line label (based on partner name)
  3) Match from statement line reference (based on Invoice number)
 
- You can easily override this module and add your own rules in your own one. The
- basic rules only fill in  the partner, but you can use them to fill in any
- value of the line (in the future, we will add a rule to automatically match and
- reconcile the line).
+ You can easily override this module and add your own rules in your own one. The basic rules only
+ fill in  the partner, but you can use them to fill in any value of the line (in the future, we will
+ add a rule to automatically match and reconcile the line).
 
- It adds as well a label on the bank statement line (on which the pre-define
- rules can match) and a char field on the partner called 'Bank Statement Label'.
- Using the pre-define rules, you will be able to match various labels for a
- partner.
+ It adds as well a label on the bank statement line (on which the pre-define rules can match) and
+ a char field on the partner called 'Bank Statement Label'. Using the pre-define rules, you will be
+ able to match various labels for a partner.
 
- The reference of the line is always used by the reconciliation process. We're
- supposed to copy there (or write manually) the matching string. This can be:
- the order Number or an invoice number, or anything that will be found in the
- invoice accounting entry part to make the match.
+ The reference of the line is always used by the reconciliation process. We're supposed to copy
+ there (or write manually) the matching string. This can be: the order Number or an invoice number,
+ or anything that will be found in the invoice accounting entry part to make the match.
 
- You can use it with  our account_advanced_reconcile module to automatize the
- reconciliation process.
+ You can use it with  our account_advanced_reconcile module to automatize the reconciliation process.
 
 
- TODO: The rules that look for invoices to find out the partner should take back
- the payable / receivable account from there directly instead of retrieving it
- from partner properties !
-    """,
-    'website': 'http://www.camptocamp.com',
-    'data': [
-        'statement_view.xml',
-        'partner_view.xml',
-        'data.xml',
-        'security/ir.model.access.csv',
-    ],
-    'demo': [],
-    'test': [
-        'test/partner.yml',
-        'test/invoice.yml',
-        'test/supplier_invoice.yml',
-        'test/completion_test.yml'
-    ],
-    'installable': True,
-    'images': [],
-    'auto_install': False,
-    'license': 'AGPL-3',
+ TODO: The rules that look for invoices to find out the partner should take back the payable / receivable
+       account from there directly instead of retrieving it from partner properties !
+
+ """,
+ 'website': 'http://www.camptocamp.com',
+ 'data': [
+     'statement_view.xml',
+     'partner_view.xml',
+     'data.xml',
+     'security/ir.model.access.csv',
+ ],
+ 'demo': [],
+ 'test': [
+    'test/partner.yml',
+    'test/invoice.yml',
+    'test/supplier_invoice.yml',
+    'test/refund.yml',
+    'test/completion_test.yml'
+ ],
+ 'installable': True,
+ 'images': [],
+ 'auto_install': False,
+ 'license': 'AGPL-3',
 }

--- a/account_statement_base_completion/__openerp__.py
+++ b/account_statement_base_completion/__openerp__.py
@@ -26,7 +26,8 @@
     'maintainer': 'Camptocamp',
     'category': 'Finance',
     'complexity': 'normal',
-    'depends': ['account_statement_ext'],
+    'depends': ['account_statement_ext',
+                'account_report_company'],
     'description': """
  The goal of this module is to improve the basic bank statement, help dealing
  with huge volume of reconciliation by providing basic rules to identify the

--- a/account_statement_base_completion/__openerp__.py
+++ b/account_statement_base_completion/__openerp__.py
@@ -37,7 +37,8 @@
 
  Some basic rules are provided in this module:
 
- 1) Match from statement line label (based on partner field 'Bank Statement Label')
+ 1) Match from statement line label (based on partner field 'Bank Statement
+    Label')
  2) Match from statement line label (based on partner name)
  3) Match from statement line reference (based on Invoice number)
 
@@ -51,11 +52,13 @@
  Label'.  Using the pre-define rules, you will be able to match various
  labels for a partner.
 
- The reference of the line is always used by the reconciliation process. We're supposed to copy
- there (or write manually) the matching string. This can be: the order Number or an invoice number,
- or anything that will be found in the invoice accounting entry part to make the match.
+ The reference of the line is always used by the reconciliation process. We're
+ supposed to copy there (or write manually) the matching string. This can be:
+ the order Number or an invoice number, or anything that will be found in the
+ invoice accounting entry part to make the match.
 
- You can use it with  our account_advanced_reconcile module to automatize the reconciliation process.
+ You can use it with  our account_advanced_reconcile module to automatize the
+ reconciliation process.
 
 
  TODO: The rules that look for invoices to find out the partner should take
@@ -74,7 +77,7 @@
         'test/partner.yml',
         'test/invoice.yml',
         'test/supplier_invoice.yml',
-    'test/refund.yml',
+        'test/refund.yml',
         'test/completion_test.yml'
     ],
     'installable': True,

--- a/account_statement_base_completion/statement.py
+++ b/account_statement_base_completion/statement.py
@@ -189,13 +189,7 @@ class AccountStatementCompletionRule(orm.Model):
         res = {}
         inv = self._find_invoice(cr, uid, line, inv_type, context=context)
         if inv:
-            # FIXME use only commercial_partner_id of invoice in 7.1
-            # this is for backward compatibility in 7.0 before
-            # the refactoring of res.partner
-            if hasattr(inv, 'commercial_partner_id'):
-                partner_id = inv.commercial_partner_id.id
-            else:
-                partner_id = inv.partner_id.id
+            partner_id = inv.commercial_partner_id.id
             res = {'partner_id': partner_id,
                    'account_id': inv.account_id.id,
                    'type': inv_type}

--- a/account_statement_base_completion/test/completion_test.yml
+++ b/account_statement_base_completion/test/completion_test.yml
@@ -39,6 +39,15 @@
     date: '2013-12-19'
     amount: -65.0
 -
+  I create a statement line for a CR
+-
+  !record {model: account.bank.statement.line, id: statement_line_cr}:
+    name: Test autocompletion based on Customer Refund Number
+    statement_id: statement_test1
+    ref: CR0001
+    date: '2013-12-19'
+    amount: -210.0
+-
   I create a statement line for the Partner Name
 -
   !record {model: account.bank.statement.line, id: statement_line_partner_name}:
@@ -76,12 +85,18 @@
   !assert {model: account.bank.statement.line, id: statement_line_si, string: Check completion by SI number}:
     - partner_id.id == _ref("base.res_partner_17")
 -
-  Line 3. I check that the partner name has been recognised.
+  Line 3. I expect the Customer refund number to be recognised. It should be
+  the commercial partner, and not the regular partner.
+-
+  !assert {model: account.bank.statement.line, id: statement_line_cr, string: Check completion by CR number and commercial partner}:
+    - partner_id.id == _ref("base.res_partner_12")
+-
+  Line 4. I check that the partner name has been recognised.
 -
   !assert {model: account.bank.statement.line, id: statement_line_partner_name, string: Check completion by partner name}:
     - partner_id.name == 'Vauxoo'
 -
-  Line 4. I check that the partner special label has been recognised.
+  Line 5. I check that the partner special label has been recognised.
 -
   !assert {model: account.bank.statement.line, id: statement_line_partner_label, string: Check completion by partner label}:
     - partner_id.id == _ref("base.res_partner_6")

--- a/account_statement_base_completion/test/refund.yml
+++ b/account_statement_base_completion/test/refund.yml
@@ -1,0 +1,43 @@
+-
+  I create a "child" partner, to use in the invoice
+  (and have a different commercial_partner_id than itself)
+-
+  !record {model: res.partner, id: res_partner_12_child}:
+    name: Child Partner
+    supplier: False
+    customer: True
+    is_company: False
+    parent_id: base.res_partner_12
+-
+  I create a customer refund to be found by the completion.
+-
+  !record {model: account.invoice, id: refund_for_completion_1}:
+    account_id: account.a_pay
+    company_id: base.main_company
+    currency_id: base.EUR
+    internal_number: CR0001
+    invoice_line:
+      - account_id: account.a_expense
+        name: '[PCSC234] PC Assemble SC234'
+        price_unit: 210.0
+        quantity: 1.0
+        product_id: product.product_product_3
+        uos_id: product.product_uom_unit
+    journal_id: account.expenses_journal
+    partner_id: res_partner_12_child
+    type: 'out_refund'
+    reference_type: none
+-
+  I confirm the refund
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: refund_for_completion_1}
+-
+  I check that the refund state is "Open"
+-
+  !assert {model: account.invoice, id: refund_for_completion_1}:
+    - state == 'open'
+-
+  I check that it is given the number "CR0001"
+-
+  !assert {model: account.invoice, id: refund_for_completion_1, string: Check CI number}:
+    - number == 'CR0001'

--- a/account_statement_transactionid_completion/statement.py
+++ b/account_statement_transactionid_completion/statement.py
@@ -110,16 +110,7 @@ class AccountStatementCompletionRule(Model):
         elif len(invoice_id) == 1:
             invoice = invoice_obj.browse(cr, uid, invoice_id[0],
                                          context=context)
-            # if account_report_company is installed, the field to be
-            # used as partner is the commercial partner; otherwise,
-            # the basic partner must be used.
-            # 
-            # This is used to keep consistent behavior from the module
-            # account_statement_base_completion.
-            if hasattr(invoice, 'commercial_partner_id'):
-                res['partner_id'] = invoice.commercial_partner_id.id
-            else:
-                res['partner_id'] = invoice.partner_id.id
+            res['partner_id'] = invoice.commercial_partner_id.id
             # we want the move to have the same ref than the found
             # invoice's move, thus it will be easier to link them for the
             # accountants

--- a/account_statement_transactionid_completion/statement.py
+++ b/account_statement_transactionid_completion/statement.py
@@ -110,9 +110,12 @@ class AccountStatementCompletionRule(Model):
         elif len(invoice_id) == 1:
             invoice = invoice_obj.browse(cr, uid, invoice_id[0],
                                          context=context)
-            # FIXME use only commercial_partner_id of invoice in 7.1
-            # this is for backward compatibility in 7.0 before
-            # the refactoring of res.partner
+            # if account_report_company is installed, the field to be
+            # used as partner is the commercial partner; otherwise,
+            # the basic partner must be used.
+            # 
+            # This is used to keep consistent behavior from the module
+            # account_statement_base_completion.
             if hasattr(invoice, 'commercial_partner_id'):
                 res['partner_id'] = invoice.commercial_partner_id.id
             else:

--- a/account_statement_transactionid_completion/statement.py
+++ b/account_statement_transactionid_completion/statement.py
@@ -110,7 +110,13 @@ class AccountStatementCompletionRule(Model):
         elif len(invoice_id) == 1:
             invoice = invoice_obj.browse(cr, uid, invoice_id[0],
                                          context=context)
-            res['partner_id'] = invoice.partner_id.id
+            # FIXME use only commercial_partner_id of invoice in 7.1
+            # this is for backward compatibility in 7.0 before
+            # the refactoring of res.partner
+            if hasattr(invoice, 'commercial_partner_id'):
+                res['partner_id'] = invoice.commercial_partner_id.id
+            else:
+                res['partner_id'] = invoice.partner_id.id
             # we want the move to have the same ref than the found
             # invoice's move, thus it will be easier to link them for the
             # accountants


### PR DESCRIPTION
If you try to auto-complete a customer refund, the partner retrieve will be the partner_id, not the commercial_partner_id like in customer invoices. This fix is to homogenize the behaviour between invoices and refunds.
