### PR TITLE
Port statement voucher killer patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ virtualenv:
   system_site_packages: true
 
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="account_statement_ext_point_of_sale"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="account_statement_ext_point_of_sale"
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="account_statement_ext_point_of_sale,statement_voucher_killer"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="account_statement_ext_point_of_sale,statement_voucher_killer"
+
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="statement_voucher_killer"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" INCLUDE="statement_voucher_killer"
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools

--- a/statement_voucher_killer/__openerp__.py
+++ b/statement_voucher_killer/__openerp__.py
@@ -42,6 +42,6 @@ line will be take from imported line in this order:
  'data': [
      'statement_view.xml',
  ],
- 'test': [],
+ 'test': [test/correct_date_in_move_line.yml],
  'installable': True,
  }

--- a/statement_voucher_killer/__openerp__.py
+++ b/statement_voucher_killer/__openerp__.py
@@ -42,6 +42,6 @@ line will be take from imported line in this order:
  'data': [
      'statement_view.xml',
  ],
- 'test': [test/correct_date_in_move_line.yml],
+ 'test': ['test/correct_date_in_move_line.yml'],
  'installable': True,
  }

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -10,20 +10,22 @@
 -
   I create a statement line for a SO
 -
-  !record {model: account.bank.statement.line, id: statement_line_so}:
+  !record {model: account.bank.statement.line, id: statement_line_date}:
     name: Test autocompletion based on Sale Order Number
     statement_id: statement_test_date1
     ref: DATE1
+    account_id : account.a_sale
     date: '2014-12-20'
     amount: 1000.0
 -
   I confirm the bank statement
 -
   !python {model: account.bank.statement}: |
-    result = self.button_confirm_bank(cr, uid, [ref("statement_test_sale1")])
+    result = self.button_confirm_bank(cr, uid, [ref("statement_test_date1")])
 -
-  Now I can check that all is nice and shiny, line 1. I expect the Sale Order
-  Number to be recognised.
+  Now I can check that that the date in move line is equal to line date
 -
-  !assert {model: account.move.line, statement_id: statement_test_date1, string: Check date in move line}:
-      -  date == '2014-12-20'
+  !python {model: account.move.line}: |
+    line_ids = self.search(cr, uid, [('statement_id', '=', ref('statement_test_date1'))],limit=1)
+    line = self.browse(cr, uid, line_ids)[0]
+    assert line.date == '2014-12-20', "Date (2014-12-20) not equal to = %s" % line.date

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -1,0 +1,29 @@
+-
+  In order to test if the correct date is set in the bank statement 
+  I create a bank statement
+-
+  !record {model: account.bank.statement, id: statement_test_date1}:
+    name: Statement for Date
+    journal_id: account.bank_journal
+    company_id: base.main_company
+    balance_end_real : 1000.0
+-
+  I create a statement line for a SO
+-
+  !record {model: account.bank.statement.line, id: statement_line_so}:
+    name: Test autocompletion based on Sale Order Number
+    statement_id: statement_test_date1
+    ref: DATE1
+    date: '2014-12-20'
+    amount: 1000.0
+-
+  I confirm the bank statement
+-
+  !python {model: account.bank.statement}: |
+    result = self.button_confirm_bank(cr, uid, [ref("statement_test_sale1")])
+-
+  Now I can check that all is nice and shiny, line 1. I expect the Sale Order
+  Number to be recognised.
+-
+  !assert {model: account.move.line, statement_id: statement_test_date1, string: Check date in move line}:
+      -  date == '2014-12-20'

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -1,10 +1,26 @@
 -
+  In order to test the bank statement date , I first need to
+  create a profile
+-
+  !record {model: account.statement.profile, id: profile_test_date}:
+    name: Bank EUR Profile for check date
+    journal_id: account.bank_journal
+    commission_account_id: account.a_expense
+    company_id: base.main_company
+    balance_check: True
+    rule_ids:
+      - account_statement_base_completion.bank_statement_completion_rule_4
+      - account_statement_base_completion.bank_statement_completion_rule_5
+      - account_statement_base_completion.bank_statement_completion_rule_2
+      - account_statement_base_completion.bank_statement_completion_rule_3
+      - bank_statement_completion_rule_1
+-
   In order to test if the correct date is set in the bank statement 
   I create a bank statement
 -
   !record {model: account.bank.statement, id: statement_test_date1}:
     name: Statement for Date
-    journal_id: account.bank_journal
+    profile_id: profile_test_date
     company_id: base.main_company
     balance_end_real : 1000.0
 -
@@ -15,7 +31,7 @@
     statement_id: statement_test_date1
     ref: DATE1
     account_id : account.a_sale
-    date: '2014-12-20'
+    date:  !eval time.strftime('%Y-12-20')
     amount: 1000.0
 -
   I confirm the bank statement
@@ -28,4 +44,4 @@
   !python {model: account.move.line}: |
     line_ids = self.search(cr, uid, [('statement_id', '=', ref('statement_test_date1'))],limit=1)
     line = self.browse(cr, uid, line_ids)[0]
-    assert line.date == '2014-12-20', "Date (2014-12-20) not equal to = %s" % line.date
+    assert line.date == !eval time.strftime('%Y-12-20'), "Date (year-12-20) not equal to = %s" % line.date

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -28,4 +28,4 @@
   !python {model: account.move.line}: |
     line_ids = self.search(cr, uid, [('statement_id', '=', ref('statement_test_date1'))],limit=1)
     line = self.browse(cr, uid, line_ids)[0]
-    assert line.date == !eval time.strftime('%Y-12-20'), "Date (year-12-20) not equal to = %s" % line.date
+    assert line.date == time.strftime('%Y-12-20'), "Date (year-12-20) not equal to = %s" % line.date

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -26,6 +26,7 @@
   Now I can check that that the date in move line is equal to line date
 -
   !python {model: account.move.line}: |
+    import time
     line_ids = self.search(cr, uid, [('statement_id', '=', ref('statement_test_date1'))],limit=1)
     line = self.browse(cr, uid, line_ids)[0]
     assert line.date == time.strftime('%Y-12-20'), "Date (year-12-20) not equal to = %s" % line.date

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -1,26 +1,10 @@
 -
-  In order to test the bank statement date , I first need to
-  create a profile
--
-  !record {model: account.statement.profile, id: profile_test_date}:
-    name: Bank EUR Profile for check date
-    journal_id: account.bank_journal
-    commission_account_id: account.a_expense
-    company_id: base.main_company
-    balance_check: True
-    rule_ids:
-      - account_statement_base_completion.bank_statement_completion_rule_4
-      - account_statement_base_completion.bank_statement_completion_rule_5
-      - account_statement_base_completion.bank_statement_completion_rule_2
-      - account_statement_base_completion.bank_statement_completion_rule_3
-      - bank_statement_completion_rule_1
--
   In order to test if the correct date is set in the bank statement 
   I create a bank statement
 -
   !record {model: account.bank.statement, id: statement_test_date1}:
     name: Statement for Date
-    profile_id: profile_test_date
+    journal_id: account.bank_journal
     company_id: base.main_company
     balance_end_real : 1000.0
 -

--- a/statement_voucher_killer/test/correct_date_in_move_line.yml
+++ b/statement_voucher_killer/test/correct_date_in_move_line.yml
@@ -1,3 +1,96 @@
+
+-
+  In order to test the process of payment order, I start with the supplier invoice.
+-
+  !python {model: account.invoice}: |
+     self.write(cr, uid, [ref('account.demo_invoice_0')], {'check_total': -14})
+
+-
+  In order to test account move line of journal, I check that there is no move attached to the invoice.
+-
+  !python {model: account.invoice}: |
+    invoice = self.browse(cr, uid, ref("account.demo_invoice_0"))
+    assert (not invoice.move_id), "Moves are wrongly created for invoice."
+-
+  I open the invoice.
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: account.demo_invoice_0}
+-
+  I check that the invoice state is now "Open".
+-
+  !assert {model: account.invoice, id: account.demo_invoice_0, severity: error, string: Invoice should be in 'Open' state}:
+    - state == 'open'
+-
+ I create a payment order
+-
+  !record {model: payment.order, id: date1_payment_order}:
+    #date_created
+    #date_done
+    date_prefered: due
+    #date_scheduled
+    #line_ids:
+    mode: account_payment.payment_mode_1
+    #reference
+    state: draft
+    total: -14
+    #user_id
+
+-
+  I confirm the payment order.
+-
+  !workflow {model: payment.order, action: open, ref: date1_payment_order}
+-
+  I check that payment order is now "Confirmed".
+-
+  !assert {model: payment.order, id: date1_payment_order, severity: error, string: Payment Order should be 'Confirmed'.}:
+    - state == 'open'
+-
+  !record {model: payment.order.create, id: payment_order_create_0}:
+    duedate: !eval time.strftime('%Y-%m-%d')
+
+-
+  I search for the invoice entries to make the payment.
+-
+  !python {model: payment.order.create}: |
+    self.search_entries(cr, uid, [ref("payment_order_create_0")], {
+      "active_model": "payment.order", "active_ids": [ref("date1_payment_order")],
+      "active_id": ref("date1_payment_order"), })
+-
+  I create payment lines entries.
+-
+  !python {model: payment.order.create}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account.demo_invoice_0"))
+    move_line = invoice.move_id.line_id[0]
+    self.write(cr, uid, [ref("payment_order_create_0")], {'entries': [(6,0,[move_line.id])]})
+    self.create_payment(cr, uid, [ref("payment_order_create_0")], {
+      "active_model": "payment.order", "active_ids": [ref("date1_payment_order")],
+      "active_id": ref("date1_payment_order")})
+
+-
+  After making all payments, I finish the payment order.
+-
+  !python {model: payment.order}: |
+    self.set_done(cr, uid, [ref("date1_payment_order")])
+-
+  I check that payment order is now "Done".
+-
+  !assert {model: payment.order, id: date1_payment_order, severity: error, string: Payment Order should be in 'Done' state}:
+    - state == 'done'
+
+-
+  I check that payment line is created with proper data.
+-
+  !python {model: payment.order}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account.demo_invoice_0"))
+    payment = self.browse(cr, uid, ref("date1_payment_order"))
+    payment_line = payment.line_ids[0]
+
+    assert payment_line.move_line_id, "move line is not created in payment line."
+    assert invoice.move_id.name == payment_line.ml_inv_ref.number, "invoice reference number is not same created."
+    assert invoice.partner_id == payment_line.partner_id, "Partner is not correct."
+    assert invoice.date_due == payment_line.ml_maturity_date, "Due date is not correct."
+    assert invoice.amount_total == payment_line.amount, "Payment amount is not correct."
+
 -
   In order to test if the correct date is set in the bank statement 
   I create a bank statement
@@ -6,17 +99,17 @@
     name: Statement for Date
     journal_id: account.bank_journal
     company_id: base.main_company
-    balance_end_real : 1000.0
+    balance_end_real : -14.0
 -
-  I create a statement line for a SO
+  I import payment order lines for the bank statement.
 -
-  !record {model: account.bank.statement.line, id: statement_line_date}:
-    name: Test autocompletion based on Sale Order Number
-    statement_id: statement_test_date1
-    ref: DATE1
-    account_id : account.a_sale
-    date:  !eval time.strftime('%Y-12-20')
-    amount: 1000.0
+  !python {model: account.payment.populate.statement}: |
+    payment = self.pool.get('payment.order').browse(cr, uid, ref("date1_payment_order"))
+    payment_line = payment.line_ids[0]
+    import_payment_id = self.create(cr, uid, {'lines': [(6,0,[payment_line.id])]})
+    self.populate_statement(cr, uid, [import_payment_id], {"statement_id": ref("statement_test_date1"),
+      "active_model": "account.bank.statement", "journal_type": "cash",
+      "active_id": ref("statement_test_date1")})
 -
   I confirm the bank statement
 -
@@ -29,4 +122,4 @@
     import time
     line_ids = self.search(cr, uid, [('statement_id', '=', ref('statement_test_date1'))],limit=1)
     line = self.browse(cr, uid, line_ids)[0]
-    assert line.date == time.strftime('%Y-12-20'), "Date (year-12-20) not equal to = %s" % line.date
+    assert line.date == time.strftime('%Y-01-31'), "Date (year-01-31) not equal to = %s" % line.date


### PR DESCRIPTION
In the module voucher killer ,
 when it import payment line into the bank statement it takes the maturity date of the payment line,
to define the bank statement line date, that is wrong it must take the date of the payment line or if not present the date of the payment order.

See bug : https://bugs.launchpad.net/banking-addons/+bug/1301781
