### PR TITLE
Allow the new bank statement reconciliation to search in transaction_ref

### DIFF
--- a/base_transaction_id/__init__.py
+++ b/base_transaction_id/__init__.py
@@ -23,3 +23,4 @@ from . import invoice
 from . import sale
 from . import stock
 from . import account_move
+from . import account_bank_statement

--- a/base_transaction_id/account_bank_statement.py
+++ b/base_transaction_id/account_bank_statement.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class account_bank_statement_line(orm.Model):
+
+    _inherit = 'account.bank.statement.line'
+
+    def _domain_move_lines_for_reconciliation(self, cr, uid, st_line,
+                                              excluded_ids=None, str=False,
+                                              additional_domain=None,
+                                              context=None):
+        _super = super(account_bank_statement_line, self)
+        _get_domain = _super._domain_move_lines_for_reconciliation
+        domain = _get_domain(cr, uid, st_line, excluded_ids=excluded_ids,
+                             str=str, additional_domain=additional_domain,
+                             context=context)
+        if not str and str != '/':
+            return domain
+        domain = domain[:]
+        domain.insert(-1, '|')
+        domain.append(('transaction_ref', 'ilike', str))
+        return domain
+
+    def _domain_reconciliation_proposition(self, cr, uid, st_line,
+                                           excluded_ids=None, context=None):
+        _super = super(account_bank_statement_line, self)
+        _get_domain = _super._domain_reconciliation_proposition
+        domain = _get_domain(cr, uid, st_line, excluded_ids=excluded_ids,
+                             context=context)
+        new_domain = []
+        for criterium in domain:
+            if len(criterium) == 3:
+                field, op, value = criterium
+                if (field, op) == ('ref', '='):
+                    new_domain += [
+                        '|',
+                        ('transaction_ref', '=', value),
+                    ]
+            new_domain.append(criterium)
+        return new_domain

--- a/base_transaction_id/account_bank_statement.py
+++ b/base_transaction_id/account_bank_statement.py
@@ -49,13 +49,13 @@ class account_bank_statement_line(orm.Model):
         domain = _get_domain(cr, uid, st_line, excluded_ids=excluded_ids,
                              context=context)
         new_domain = []
-        for criterium in domain:
-            if len(criterium) == 3:
-                field, op, value = criterium
+        for criterion in domain:
+            if len(criterion) == 3:
+                field, op, value = criterion
                 if (field, op) == ('ref', '='):
                     new_domain += [
                         '|',
                         ('transaction_ref', '=', value),
                     ]
-            new_domain.append(criterium)
+            new_domain.append(criterion)
         return new_domain


### PR DESCRIPTION
**Work in progress** because a merge is needed in the core to be able to inherit the methods.
- [x] https://github.com/odoo/odoo/pull/3025 to be merged to work!
- [x] Also, the migration of `base_transaction_id` (pre-requisite before adding features) is there: https://github.com/OCA/bank-statement-reconcile/pull/47
