### PR TITLE
Modify _last_history function

### DIFF
--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -169,10 +169,9 @@ class AccountEasyReconcile(orm.Model):
         for reconcile_id in ids:
             last_history = history_obj.search(
                 cr, uid, [('easy_reconcile_id', '=', reconcile_id)],
-                limit=1, order='date desc'
+                limit=1, order='date desc', context=context
             )
-            result[reconcile_id] = len(last_history) \
-                and last_history[0] or False
+            result[reconcile_id] = last_history[0] if last_history else False
         return result
 
     _columns = {

--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -171,10 +171,8 @@ class AccountEasyReconcile(orm.Model):
                 cr, uid, [('easy_reconcile_id', '=', reconcile_id)],
                 limit=1, order='date desc'
             )
-            if len(last_history) > 0:
-                result[reconcile_id] = last_history[0]
-            else:
-                result[reconcile_id] = False
+            result[reconcile_id] = len(last_history) \
+                and last_history[0] or False
         return result
 
     _columns = {

--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -162,11 +162,16 @@ class AccountEasyReconcile(orm.Model):
 
     def _last_history(self, cr, uid, ids, name, args, context=None):
         result = {}
-        for history in self.browse(cr, uid, ids, context=context):
-            result[history.id] = False
-            if history.history_ids:
-                # history is sorted by date desc
-                result[history.id] = history.history_ids[0].id
+        # do a search() for retrieving the latest history line,
+        # as a read() will badly split the list of ids with 'date desc'
+        # and return the wrong result.
+        for reconcile_id in ids:
+            history_obj = self.pool['easy.reconcile.history']
+            last_history = history_obj.search(
+                cr, uid, [('easy_reconcile_id', '=', reconcile_id)],
+                limit=1, order='date desc'
+            )
+            result[reconcile_id] = last_history
         return result
 
     _columns = {

--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -165,13 +165,12 @@ class AccountEasyReconcile(orm.Model):
         # do a search() for retrieving the latest history line,
         # as a read() will badly split the list of ids with 'date desc'
         # and return the wrong result.
+        history_obj = self.pool['easy.reconcile.history']
         for reconcile_id in ids:
-            history_obj = self.pool['easy.reconcile.history']
-            last_history = history_obj.search(
+            result[reconcile_id] = history_obj.search(
                 cr, uid, [('easy_reconcile_id', '=', reconcile_id)],
                 limit=1, order='date desc'
             )
-            result[reconcile_id] = last_history
         return result
 
     _columns = {

--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -167,10 +167,14 @@ class AccountEasyReconcile(orm.Model):
         # and return the wrong result.
         history_obj = self.pool['easy.reconcile.history']
         for reconcile_id in ids:
-            result[reconcile_id] = history_obj.search(
+            last_history = history_obj.search(
                 cr, uid, [('easy_reconcile_id', '=', reconcile_id)],
                 limit=1, order='date desc'
             )
+            if len(last_history) > 0:
+                result[reconcile_id] = last_history[0]
+            else:
+                result[reconcile_id] = False
         return result
 
     _columns = {


### PR DESCRIPTION
The old method, using a many2one and _read_flat(), returned the wrong date if there were more than 1000 history lines.
