### PR TITLE
[FIX] If balance_start is set by parser and equals 0.0, don't override it

### DIFF
--- a/account_statement_base_import/statement.py
+++ b/account_statement_base_import/statement.py
@@ -135,7 +135,7 @@ class AccountStatementProfil(orm.Model):
         """
         vals = {'profile_id': profile_id}
         vals.update(parser.get_st_vals())
-        if not vals.get('balance_start'):
+        if 'balance_start' not in vals.keys():
             # Get starting balance from journal balance if parser doesn't
             # fill this data, simulating the manual flow
             statement_obj = self.pool['account.bank.statement']

--- a/account_statement_base_import/statement.py
+++ b/account_statement_base_import/statement.py
@@ -135,7 +135,7 @@ class AccountStatementProfil(orm.Model):
         """
         vals = {'profile_id': profile_id}
         vals.update(parser.get_st_vals())
-        if 'balance_start' not in vals:
+        if vals.get('balance_start') is None:
             # Get starting balance from journal balance if parser doesn't
             # fill this data, simulating the manual flow
             statement_obj = self.pool['account.bank.statement']

--- a/account_statement_base_import/statement.py
+++ b/account_statement_base_import/statement.py
@@ -135,7 +135,7 @@ class AccountStatementProfil(orm.Model):
         """
         vals = {'profile_id': profile_id}
         vals.update(parser.get_st_vals())
-        if 'balance_start' not in vals.keys():
+        if 'balance_start' not in vals:
             # Get starting balance from journal balance if parser doesn't
             # fill this data, simulating the manual flow
             statement_obj = self.pool['account.bank.statement']


### PR DESCRIPTION
In account_statement_base_import, there is a problem if a parser wants to set the balance_start to zero, the value won't be retained. I propose to fix that in this small patch.
