### PR TITLE
Display the transaction ref in the bank statement reconciliation view

### DIFF
--- a/base_transaction_id/__openerp__.py
+++ b/base_transaction_id/__openerp__.py
@@ -26,6 +26,7 @@
  'category': 'Hidden/Dependency',
  'complexity': 'easy',
  'depends': [
+     'account',
      'stock_account',
      'sale_stock',
  ],
@@ -46,6 +47,7 @@
      'invoice_view.xml',
      'sale_view.xml',
      'account_move_line_view.xml',
+     'views/base_transaction_id.xml',
  ],
  'test': [],
  'installable': True,

--- a/base_transaction_id/account_move.py
+++ b/base_transaction_id/account_move.py
@@ -35,3 +35,22 @@ class account_move_line(orm.Model):
         default['transaction_ref'] = False
         _super = super(account_move_line, self)
         return _super.copy_data(cr, uid, id, default=default, context=context)
+
+    def prepare_move_lines_for_reconciliation_widget(self, cr, uid, lines,
+                                                     target_currency=False,
+                                                     target_date=False,
+                                                     context=None):
+        _super = super(account_move_line, self)
+        prepare = _super.prepare_move_lines_for_reconciliation_widget
+        prepared_lines = []
+        for line in lines:
+            # The super method loop over the lines and returns a list of
+            # prepared lines. Here we'll have 1 line per call to super.
+            # If we called super on the whole list, we would need to
+            # browse again the lines, or match the 'lines' vs
+            # 'prepared_lines' to update the transaction_ref.
+            vals = prepare(cr, uid, [line], target_currency=target_currency,
+                           target_date=target_date, context=context)[0]
+            vals['transaction_ref'] = line.transaction_ref
+            prepared_lines.append(vals)
+        return prepared_lines

--- a/base_transaction_id/static/src/js/account_widgets.js
+++ b/base_transaction_id/static/src/js/account_widgets.js
@@ -1,0 +1,11 @@
+openerp.base_transaction_id = function (instance) {
+
+    instance.web.account.bankStatementReconciliationLine.include({
+        decorateMoveLine: function(line, currency_id) {
+            this._super(line, currency_id);
+            if (line.transaction_ref) {
+                line.q_label += ' (' + line.transaction_ref + ')';
+            }
+        },
+    });
+};

--- a/base_transaction_id/views/base_transaction_id.xml
+++ b/base_transaction_id/views/base_transaction_id.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
+      <xpath expr="." position="inside">
+        <script type="text/javascript" src="/base_transaction_id/static/src/js/account_widgets.js"></script>
+      </xpath>
+    </template>
+  </data>
+</openerp>
+


### PR DESCRIPTION
Now, only the name and the ref are displayed. Mostly useful with
https://github.com/OCA/bank-statement-reconcile/pull/54
