### PR TITLE
7.0 fix account statement one move

### DIFF
--- a/account_statement_one_move/statement.py
+++ b/account_statement_one_move/statement.py
@@ -184,6 +184,7 @@ class AccountBankStatement(orm.Model):
 
     def button_confirm_bank(self, cr, uid, ids, context=None):
         st_line_obj = self.pool['account.bank.statement.line']
+        move_obj = self.pool['account.move']
         if context is None:
             context = {}
         for st in self.browse(cr, uid, ids, context=context):
@@ -191,6 +192,9 @@ class AccountBankStatement(orm.Model):
                 cr, uid, ids, context=context)
             if st.profile_id.one_move and context.get('move_id', False):
                 move_id = context['move_id']
+                move = move_obj.browse(cr, uid, move_id, context=context)
+                self.create_move_transfer_lines(
+                    cr, uid, move, st, context=context)
                 self._valid_move(cr, uid, move_id, context=context)
                 lines_ids = [x.id for x in st.line_ids]
                 st_line_obj.write(cr, uid, lines_ids,


### PR DESCRIPTION
The method def create_move_transfer_lines was never called. The bug was introduced here probably by mistake : 
https://github.com/OCA/bank-statement-reconcile/commit/d0a06fd532f4fc689f6952e6035e48f6a5be49e9

So no transfer lines are created, which is one of the main feature of this module.
