### PR TITLE
check statement_id exist before adding it to the list we return

### DIFF
--- a/account_statement_base_import/statement.py
+++ b/account_statement_base_import/statement.py
@@ -167,7 +167,8 @@ class AccountStatementProfil(orm.Model):
             statement_id = self._statement_import(
                 cr, uid, ids, prof, parser, file_stream, ftype=ftype,
                 context=context)
-            res.append(statement_id)
+            if statement_id:
+                res.append(statement_id)
         return res
 
     def _statement_import(self, cr, uid, ids, prof, parser, file_stream,


### PR DESCRIPTION
In case of multi statements like CFONB files, it can happen we do not want to import some specific accounts.
In this case, we just return None in the method def statement_import.
We do not want to add None to the list of ids we return.
