### PR TITLE
Add history line + error message if reconciliation fails

### DIFF
--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -291,12 +291,12 @@ class AccountEasyReconcile(orm.Model):
                 # In case of error, we log it in the mail thread, log the
                 # stack trace and create an empty history line; otherwise,
                 # the cron will just loop on this reconcile task.
+                _logger.exception("The reconcile task %s had an exception: %s",
+                                  rec.name, e.value)
                 message = "There was an error during reconciliation : %s" \
                     % e.value
                 self.message_post(cr, uid, rec.id,
                                   body=message, context=context)
-                _logger.exception("The reconcile task %s had an exception: %s",
-                                  rec.name, e.value)
                 self.pool.get('easy.reconcile.history').create(new_cr, uid, {
                     'easy_reconcile_id': rec.id,
                     'date': fields.datetime.now(),

--- a/account_easy_reconcile/easy_reconcile.xml
+++ b/account_easy_reconcile/easy_reconcile.xml
@@ -71,6 +71,10 @@ The lines should have the same amount (with the write-off) and the same referenc
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
This PR is to add an history line + a mail thread to easy reconciliation tasks. The reason is that the current cron can "loop" on a task since it takes the one with the oldest history, and no history was added in case of error.

I also added the error message in order to get basic logging on it.
