### PR TITLE
Make unit tests use the current year

### DIFF
--- a/account_statement_cancel_line/test/cancel_line.yml
+++ b/account_statement_cancel_line/test/cancel_line.yml
@@ -22,7 +22,7 @@
     name: line1
     statement_id: statement_test
     ref: ref1
-    date: '2014-01-20'
+    date: !eval "'%s-01-20' %(datetime.now().year)"
     amount: 100.0
 -
   I create a second statement line
@@ -31,7 +31,7 @@
     name: line2
     statement_id: statement_test
     ref: ref2
-    date: '2014-01-25'
+    date: !eval "'%s-01-25' %(datetime.now().year)"
     amount: 200.0
 -
   I check that the state of the statement is "Draft"

--- a/account_statement_cancel_line/test/confirm_statement_no_double_moves.yml
+++ b/account_statement_cancel_line/test/confirm_statement_no_double_moves.yml
@@ -23,7 +23,7 @@
     name: line11
     statement_id: statement_test_10
     ref: ref11
-    date: '2014-01-20'
+    date: !eval "'%s-01-20' %(datetime.now().year)"
     amount: 100.0
 -
   I create a second statement line
@@ -32,7 +32,7 @@
     name: line12
     statement_id: statement_test_10
     ref: ref12
-    date: '2014-01-25'
+    date: !eval "'%s-01-25' %(datetime.now().year)"
     amount: 200.0
 -
   Now I confirm only the first statement line

--- a/account_statement_cancel_line/test/test_confirm_last_line_balance_check.yml
+++ b/account_statement_cancel_line/test/test_confirm_last_line_balance_check.yml
@@ -25,7 +25,7 @@
     name: line1
     statement_id: statement_test3
     ref: line1
-    date: '2014-01-20'
+    date: !eval "'%s-01-20' %(datetime.now().year)"
     amount: 10.0
 -
   Now I confirm the statement line. That should not pass the balance check

--- a/account_statement_cancel_line/test/test_confirm_last_line_no_balance_check.yml
+++ b/account_statement_cancel_line/test/test_confirm_last_line_no_balance_check.yml
@@ -25,7 +25,7 @@
     name: line1
     statement_id: statement_test4
     ref: line1
-    date: '2014-01-20'
+    date: !eval "'%s-01-20' %(datetime.now().year)"
     amount: 10.0
 -
   Now I confirm the statement line

--- a/account_statement_transactionid_completion/test/completion_transactionid_test.yml
+++ b/account_statement_transactionid_completion/test/completion_transactionid_test.yml
@@ -29,7 +29,7 @@
     statement_id: statement_transactionid_test1
     transaction_id: XXX66Z
     ref: 6
-    date: '2014-01-06'
+    date: !eval "'%s-01-06' %(datetime.now().year)"
     amount: 118.4
 -
   I run the auto complete


### PR DESCRIPTION
This PR is to fix https://github.com/OCA/bank-statement-reconcile/issues/80 .
