### PR TITLE
8.0 Add module account_statement_operation_multicompany

### DIFF
--- a/account_statement_operation_multicompany/README.rst
+++ b/account_statement_operation_multicompany/README.rst
@@ -1,0 +1,35 @@
+Account Statement Operation Multi-company
+=========================================
+
+This module fixes Odoo bug n°4706 *account.statement.operation.template is not multi-company aware* https://github.com/odoo/odoo/issues/4706 that OpenERP S.A. doesn't want to fix because it requires an update of the datamodel in version 8 and this is against their rules for fixes in the stable branch.
+
+Usage
+=====
+
+This module adds a read-only *company_id* field on the object *account.statement.operation.template* and a multi-company record rule.
+
+Roadmap
+=======
+
+The bug which is solved by this module is supposed to be fixed in version 9, so this module will not be ported to future versions.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_statement_operation_multicompany/__init__.py
+++ b/account_statement_operation_multicompany/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Statement Operation Multi-company module for Odoo
+#    Copyright (C) 2015 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import account

--- a/account_statement_operation_multicompany/__openerp__.py
+++ b/account_statement_operation_multicompany/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Statement Operation multi-company module for Odoo
+#    Copyright (C) 2015 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Account Statement Operation Multi-company',
+    'version': '0.2',
+    'category': 'Accounting & Finance',
+    'license': 'AGPL-3',
+    'summary': 'Fix multi-company issue on Statement Operation Templates',
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['account'],
+    'data': [
+        'account_view.xml',
+        'security/rule.xml',
+        ],
+    'installable': True,
+}

--- a/account_statement_operation_multicompany/account.py
+++ b/account_statement_operation_multicompany/account.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Statement Operation Multi-company module for Odoo
+#    Copyright (C) 2015 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class AccountStatementOperationTemplate(models.Model):
+    _inherit = 'account.statement.operation.template'
+
+    company_id = fields.Many2one(
+        'res.company', string='Company', related='account_id.company_id',
+        store=True, readonly=True)

--- a/account_statement_operation_multicompany/account_view.xml
+++ b/account_statement_operation_multicompany/account_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Copyright (C) 2015 Akretion (http://www.akretion.com/)
+   @author: Alexis de Lattre <alexis.delattre@akretion.com>
+   The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+<record id="view_account_statement_operation_template_form" model="ir.ui.view">
+    <field name="name">account.statement.operation.multicompany.form</field>
+    <field name="model">account.statement.operation.template</field>
+    <field name="inherit_id" ref="account.view_account_statement_operation_template_form"/>
+    <field name="arch" type="xml">
+        <field name="account_id" position="after">
+            <field name="company_id" groups="base.group_multi_company"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_account_statement_operation_template_tree" model="ir.ui.view">
+    <field name="name">account.statement.operation.multicompany.tree</field>
+    <field name="model">account.statement.operation.template</field>
+    <field name="inherit_id" ref="account.view_account_statement_operation_template_tree"/>
+    <field name="arch" type="xml">
+        <field name="account_id" position="after">
+            <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+        </field>
+        <field name="amount_type" position="after">
+            <field name="company_id" groups="base.group_multi_company"/>
+        </field>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/account_statement_operation_multicompany/i18n/account_statement_operation_multicompany.pot
+++ b/account_statement_operation_multicompany/i18n/account_statement_operation_multicompany.pot
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_statement_operation_multicompany
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-01-26 21:19+0000\n"
+"PO-Revision-Date: 2015-01-26 21:19+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_statement_operation_multicompany
+#: field:account.statement.operation.template,company_id:0
+msgid "Company"
+msgstr ""
+
+#. module: account_statement_operation_multicompany
+#: model:ir.model,name:account_statement_operation_multicompany.model_account_statement_operation_template
+msgid "Preset for the lines that can be created in a bank statement reconciliation"
+msgstr ""
+

--- a/account_statement_operation_multicompany/i18n/fr.po
+++ b/account_statement_operation_multicompany/i18n/fr.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_statement_operation_multicompany
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-01-26 21:20+0000\n"
+"PO-Revision-Date: 2015-01-26 21:20+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_statement_operation_multicompany
+#: field:account.statement.operation.template,company_id:0
+msgid "Company"
+msgstr "Société"
+
+#. module: account_statement_operation_multicompany
+#: model:ir.model,name:account_statement_operation_multicompany.model_account_statement_operation_template
+msgid "Preset for the lines that can be created in a bank statement reconciliation"
+msgstr "Preset for the lines that can be created in a bank statement reconciliation"
+

--- a/account_statement_operation_multicompany/security/rule.xml
+++ b/account_statement_operation_multicompany/security/rule.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2015 Akretion (http://www.akretion.com)
+    @author: Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+<record id="account_statement_operation_template_company_rule" model="ir.rule">
+    <field name="name">Account Statement Operation Template Multi-company</field>
+    <field name="model_id" ref="account.model_account_statement_operation_template"/>
+    <field name="global" eval="True"/>
+    <field name="domain_force">['|', ('company_id', '=', False), ('company_id', '=', user.company_id.id)]</field>
+    <!-- We need ('company_id', '=', False) even if company_id is a required field on account.account in order to avoid access rights issues when a regular user creates a new account.statement.operation.template -->
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
As suggested by @sbidoul, I propose to move my module account_statement_operation_multicompany from an Akretion branch to this OCA project. This is a new version of the module, because I changed things again, going back to a related stored "company_id" field.

This module fixes this bug in the account module: https://github.com/odoo/odoo/issues/4706
