### PR TITLE
Errors args are not always string.

### DIFF
--- a/account_easy_reconcile/easy_reconcile.py
+++ b/account_easy_reconcile/easy_reconcile.py
@@ -291,10 +291,11 @@ class AccountEasyReconcile(orm.Model):
                 # In case of error, we log it in the mail thread, log the
                 # stack trace and create an empty history line; otherwise,
                 # the cron will just loop on this reconcile task.
-                _logger.exception("The reconcile task %s had an exception: %s",
-                                  rec.name, ", ".join(e.args))
+                _logger.exception(
+                    "The reconcile task %s had an exception: %s",
+                    rec.name, ", ".join([str(error) for error in e.args]))
                 message = "There was an error during reconciliation : %s" \
-                    % ", ".join(e.args)
+                    % ", ".join([str(error) for error in e.args])
                 self.message_post(cr, uid, rec.id,
                                   body=message, context=context)
                 self.pool.get('easy.reconcile.history').create(new_cr, uid, {


### PR DESCRIPTION
The fix proposed last time is still not working as error objects can have non-string arguments.
