### PR TITLE
7.0 get first write off date available

### DIFF
--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -126,10 +126,42 @@ class EasyReconcileBase(orm.AbstractModel):
         writeoff_amount = round(debit - credit, precision)
         return bool(writeoff_limit >= abs(writeoff_amount)), debit, credit
 
+    def _check_period_state(self, cr, uid, date, context=None):
+        period_id = self.pool['account.period'].find(
+                cr, uid, dt=date, context=context)[0]
+        cr.execute("""
+            SELECT state 
+            FROM account_period 
+            WHERE id = %s
+        """, (period_id,))
+
+        state = cr.fetchall()[0][0]
+        if state == 'done':
+            return False
+        else:
+            return True
+
+    def _get_open_period_date(self, cr, uid, date, context=None):
+        cr.execute("""
+            SELECT date_start 
+            FROM account_period 
+            WHERE state = 'draft' 
+                AND date_start > %s 
+            ORDER BY date_start asc 
+            LIMIT 1
+        """, (date,))
+
+        first_date_available = cr.fetchall()
+        if first_date_available:
+            return first_date_available[0][0]
+        else:
+            return date
+
     def _get_rec_date(self, cr, uid, rec, lines,
                       based_on='end_period_last_credit', context=None):
         period_obj = self.pool['account.period']
-
+        date = None
+        import pdb;pdb.set_trace()
         def last_period(mlines):
             period_ids = [ml['period_id'] for ml in mlines]
             periods = period_obj.browse(
@@ -146,18 +178,23 @@ class EasyReconcileBase(orm.AbstractModel):
             return [l for l in mlines if l['debit'] > 0]
 
         if based_on == 'end_period_last_credit':
-            return last_period(credit(lines)).date_stop
+            data = last_period(credit(lines)).date_stop
         if based_on == 'end_period':
-            return last_period(lines).date_stop
+            date = last_period(lines).date_stop
         elif based_on == 'newest':
-            return last_date(lines)['date']
+            date = last_date(lines)['date']
         elif based_on == 'newest_credit':
-            return last_date(credit(lines))['date']
+            date = last_date(credit(lines))['date']
         elif based_on == 'newest_debit':
-            return last_date(debit(lines))['date']
+            date = last_date(debit(lines))['date']
+
+        if date:
+            if not self._check_period_state(cr, uid, date, context=context):
+                date = self._get_open_period_date(
+                    cr, uid, date, context=context)
         # reconcilation date will be today
         # when date is None
-        return None
+        return date
 
     def _reconcile_lines(self, cr, uid, rec, lines, allow_partial=False,
                          context=None):

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -128,10 +128,10 @@ class EasyReconcileBase(orm.AbstractModel):
 
     def _check_period_state(self, cr, uid, date, context=None):
         period_id = self.pool['account.period'].find(
-                cr, uid, dt=date, context=context)[0]
+            cr, uid, dt=date, context=context)[0]
         cr.execute("""
-            SELECT state 
-            FROM account_period 
+            SELECT state
+            FROM account_period
             WHERE id = %s
         """, (period_id,))
 
@@ -143,11 +143,11 @@ class EasyReconcileBase(orm.AbstractModel):
 
     def _get_open_period_date(self, cr, uid, date, context=None):
         cr.execute("""
-            SELECT date_start 
-            FROM account_period 
-            WHERE state = 'draft' 
-                AND date_start > %s 
-            ORDER BY date_start asc 
+            SELECT date_start
+            FROM account_period
+            WHERE state = 'draft'
+                AND date_start > %s
+            ORDER BY date_start asc
             LIMIT 1
         """, (date,))
 
@@ -161,7 +161,7 @@ class EasyReconcileBase(orm.AbstractModel):
                       based_on='end_period_last_credit', context=None):
         period_obj = self.pool['account.period']
         date = None
-        import pdb;pdb.set_trace()
+
         def last_period(mlines):
             period_ids = [ml['period_id'] for ml in mlines]
             periods = period_obj.browse(
@@ -178,7 +178,7 @@ class EasyReconcileBase(orm.AbstractModel):
             return [l for l in mlines if l['debit'] > 0]
 
         if based_on == 'end_period_last_credit':
-            data = last_period(credit(lines)).date_stop
+            date = last_period(credit(lines)).date_stop
         if based_on == 'end_period':
             date = last_period(lines).date_stop
         elif based_on == 'newest':

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -127,16 +127,10 @@ class EasyReconcileBase(orm.AbstractModel):
         return bool(writeoff_limit >= abs(writeoff_amount)), debit, credit
 
     def _check_period_state(self, cr, uid, date, context=None):
-        period_id = self.pool['account.period'].find(
-            cr, uid, dt=date, context=context)[0]
-        cr.execute("""
-            SELECT state
-            FROM account_period
-            WHERE id = %s
-        """, (period_id,))
-
-        state = cr.fetchall()[0][0]
-        if state == 'done':
+        period_obj = self.pool['account.period']
+        period_id = period_obj.find(cr, uid, dt=date, context=context)[0]
+        period = period_obj.browse(cr, uid, period_id, context=context)
+        if period.state == 'done':
             return False
         else:
             return True

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -126,30 +126,35 @@ class EasyReconcileBase(orm.AbstractModel):
         writeoff_amount = round(debit - credit, precision)
         return bool(writeoff_limit >= abs(writeoff_amount)), debit, credit
 
-    def _check_period_state(self, cr, uid, date, context=None):
+    def _is_period_close(self, cr, uid, date, context=None):
         period_obj = self.pool['account.period']
         period_id = period_obj.find(cr, uid, dt=date, context=context)[0]
         period = period_obj.browse(cr, uid, period_id, context=context)
         if period.state == 'done':
-            return False
-        else:
             return True
+        else:
+            return False
 
     def _get_open_period_date(self, cr, uid, date, context=None):
-        cr.execute("""
-            SELECT date_start
-            FROM account_period
-            WHERE state = 'draft'
-                AND date_start > %s
-            ORDER BY date_start asc
-            LIMIT 1
-        """, (date,))
-
-        first_date_available = cr.fetchall()
-        if first_date_available:
-            return first_date_available[0][0]
+        if context is None:
+            context = {}
+        if context.get('company_id', False):
+            company_id = context['company_id']
         else:
-            return date
+            company_id = self.pool.get('res.users').\
+                browse(cr, uid, uid, context=context).company_id.id
+        period_obj = self.pool['account.period']
+        period_ids = period_obj.search(cr, uid, [
+            ['state', '=', 'draft'],
+            ['company_id', '=', company_id],
+            ], context=context, order='date_start')
+        if period_ids:
+            period = period_obj.browse(cr, uid, period_ids[0], context=context)
+            return period.date_start
+        else:
+            raise orm.except_orm(
+                _('Error'),
+                _('There is no open period for your company'))
 
     def _get_rec_date(self, cr, uid, rec, lines,
                       based_on='end_period_last_credit', context=None):
@@ -183,7 +188,7 @@ class EasyReconcileBase(orm.AbstractModel):
             date = last_date(debit(lines))['date']
 
         if date:
-            if not self._check_period_state(cr, uid, date, context=context):
+            if self._is_period_close(cr, uid, date, context=context):
                 date = self._get_open_period_date(
                     cr, uid, date, context=context)
         # reconcilation date will be today

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -21,6 +21,7 @@
 
 from openerp.osv import fields, orm
 from operator import itemgetter, attrgetter
+from openerp.tools.translate import _
 
 
 class EasyReconcileBase(orm.AbstractModel):

--- a/account_easy_reconcile/base_reconciliation.py
+++ b/account_easy_reconcile/base_reconciliation.py
@@ -130,10 +130,7 @@ class EasyReconcileBase(orm.AbstractModel):
         period_obj = self.pool['account.period']
         period_id = period_obj.find(cr, uid, dt=date, context=context)[0]
         period = period_obj.browse(cr, uid, period_id, context=context)
-        if period.state == 'done':
-            return True
-        else:
-            return False
+        return period.state == 'done'
 
     def _get_open_period_date(self, cr, uid, date, context=None):
         if context is None:


### PR DESCRIPTION
When we search for the write off date, during the reconciliation process, we check if the corresponding period is still open. If not, we search for the nearest opened period so the reconciliation can be successful.
