### PR TITLE
Put the field transaction_id in the group 'sale_pay'

### DIFF
--- a/base_transaction_id/sale_view.xml
+++ b/base_transaction_id/sale_view.xml
@@ -6,9 +6,9 @@
       <field name="model">sale.order</field>
       <field name="inherit_id" ref="sale.view_order_form"/>
       <field name="arch" type="xml">
-        <field name="payment_term" position="after">
+        <group name="sale_pay" position="inside">
           <field name="transaction_id"/>
-        </field>
+        </group>
       </field>
     </record>
   </data>


### PR DESCRIPTION
Add the field inside the group instead of after a field.  In another module, I
add a button right after 'payment_term' and it must be right after it.  Adding
the field in the group prevent it to be placed between the payment_term field
and the button.
