### PR TITLE
[FIX] account_invoice_reference: Fall back to number consistently

### DIFF
--- a/account_invoice_reference/account_invoice.py
+++ b/account_invoice_reference/account_invoice.py
@@ -28,10 +28,16 @@ class AccountInvoice(models.Model):
     @api.v8
     def _ref_from_invoice(self):
         self.ensure_one()
-        if self.type in ('out_invoice', 'out_refund'):
-            return self.origin
-        elif self.type in ('in_invoice', 'in_refund'):
-            return self.supplier_invoice_number
+
+        def preferred_ref():
+            if self.type in ('out_invoice', 'out_refund'):
+                return self.origin
+            elif self.type in ('in_invoice', 'in_refund'):
+                return self.supplier_invoice_number
+            else:
+                return None
+
+        return preferred_ref() or self.number
 
     @api.v7
     def _ref_from_invoice(self, cr, uid, invoice, context=None):
@@ -45,8 +51,6 @@ class AccountInvoice(models.Model):
 
         for invoice in self:
             ref = invoice._ref_from_invoice()
-            if not ref:
-                ref = invoice.number
             move_id = invoice.move_id.id if invoice.move_id else False
 
             invoice.write({'internal_number': invoice.number})


### PR DESCRIPTION
Without an origin or supplier invoice number, `_ref_from_invoice()` could return a falsy value. This was checked when called from `AccountInvoice.action_number()` ([here](https://github.com/OCA/bank-statement-reconcile/blob/a330637277347a71fb83667a3d76915560175c1e/account_invoice_reference/account_invoice.py#L48)), but not when called from `AccountMove.create()` ([here](https://github.com/OCA/bank-statement-reconcile/blob/a330637277347a71fb83667a3d76915560175c1e/account_invoice_reference/account_move.py#L36)).

I'm not sure if this has ever caused a problem in practice. But looking at the code, it certainly could have.
