### PR TITLE
New reconciliation rule, searching within the name

### DIFF
--- a/account_advanced_reconcile_ref_deep_search/__init__.py
+++ b/account_advanced_reconcile_ref_deep_search/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Matthieu Dietrich
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import easy_reconcile
+from . import advanced_reconciliation

--- a/account_advanced_reconcile_ref_deep_search/__openerp__.py
+++ b/account_advanced_reconcile_ref_deep_search/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Matthieu Dietrich
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{'name': 'Advanced Reconcile Reference Ref Deep Search',
+ 'description': """
+Advanced reconciliation method for the module account_advanced_reconcile
+========================================================================
+Reconcile rules as default rule "Advanced. Partner and Ref.", but by
+searching the credit entry ref. inside the debit entry ref. or name.
+""",
+ 'version': '1.0.0',
+ 'author': "Camptocamp,Odoo Community Association (OCA)",
+ 'category': 'Finance',
+ 'website': 'http://www.camptocamp.com',
+ 'depends': ['account_advanced_reconcile'],
+ 'data': ['easy_reconcile_view.xml'],
+ 'demo': [],
+ 'test': [],
+ 'auto_install': False,
+ 'installable': True,
+ 'images': []
+ }

--- a/account_advanced_reconcile_ref_deep_search/advanced_reconciliation.py
+++ b/account_advanced_reconcile_ref_deep_search/advanced_reconciliation.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Matthieu Dietrich
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+from itertools import product
+from openerp.tools.translate import _
+
+
+class easy_reconcile_advanced_ref_deep_search(orm.TransientModel):
+
+    _name = 'easy.reconcile.advanced.ref.deep.search'
+    _inherit = 'easy.reconcile.advanced.ref'
+
+    @staticmethod
+    def _compare_values(key, value, opposite_value):
+        """Can be inherited to modify the equality condition
+        specifically according to the matcher key (maybe using
+        a like operator instead of equality on 'ref' as instance)
+        """
+        # consider that empty vals are not valid matchers
+        # it can still be inherited for some special cases
+        # where it would be allowed
+        if not (value and opposite_value):
+            return False
+
+        if value == opposite_value or \
+                (key == 'ref' and value in opposite_value):
+            return True
+        return False
+
+    @staticmethod
+    def _compare_matcher_values(key, values, opposite_values):
+        """ Compare every values from a matcher vs an opposite matcher
+        and return True if it matches
+        """
+        for value, ovalue in product(values, opposite_values):
+            # we do not need to compare all values, if one matches
+            # we are done
+            if easy_reconcile_advanced_ref_deep_search._compare_values(
+                    key, value, ovalue):
+                return True
+        return False
+
+    @staticmethod
+    def _compare_matchers(matcher, opposite_matcher):
+        """
+        Prepare and check the matchers to compare
+        """
+        mkey, mvalue = matcher
+        omkey, omvalue = opposite_matcher
+        assert mkey == omkey, \
+            (_("A matcher %s is compared with a matcher %s, the _matchers and "
+               "_opposite_matchers are probably wrong") % (mkey, omkey))
+        if not isinstance(mvalue, (list, tuple)):
+            mvalue = mvalue,
+        if not isinstance(omvalue, (list, tuple)):
+            omvalue = omvalue,
+        return easy_reconcile_advanced_ref_deep_search.\
+            _compare_matcher_values(mkey, mvalue, omvalue)

--- a/account_advanced_reconcile_ref_deep_search/easy_reconcile.py
+++ b/account_advanced_reconcile_ref_deep_search/easy_reconcile.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Matthieu Dietrich
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class account_easy_reconcile_method(orm.Model):
+
+    _inherit = 'account.easy.reconcile.method'
+
+    def _get_all_rec_method(self, cr, uid, context=None):
+        methods = super(account_easy_reconcile_method, self).\
+            _get_all_rec_method(cr, uid, context=context)
+        methods += [
+            ('easy.reconcile.advanced.ref.deep.search',
+             'Advanced. Partner and Ref. Deep Search'),
+        ]
+        return methods

--- a/account_advanced_reconcile_ref_deep_search/easy_reconcile_view.xml
+++ b/account_advanced_reconcile_ref_deep_search/easy_reconcile_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+      <record id="view_easy_reconcile_form" model="ir.ui.view">
+          <field name="name">account.easy.reconcile.form</field>
+          <field name="model">account.easy.reconcile</field>
+          <field name="inherit_id" ref="account_easy_reconcile.account_easy_reconcile_form"/>
+          <field name="arch" type="xml">
+              <page name="information" position="inside">
+                  <group colspan="2" col="2">
+                      <separator colspan="4" string="Advanced. Partner and Ref. Deep Search"/>
+                      <label string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
+                             The lines should have the partner, the credit entry ref. is searched inside the debit entry ref. or name." colspan="4"/>
+                </group>
+              </page>
+          </field>
+      </record>
+    </data>
+</openerp>


### PR DESCRIPTION
New module, redefining the basic "Advanced. Partner and Ref." rule in `account_advanced_reconcile` to search the credit's reference in the debit's name or reference, instead of having the same value.
