### PR TITLE
Correct missing underscore

### DIFF
--- a/account_mass_reconcile_ref_deep_search/models/mass_reconcile.py
+++ b/account_mass_reconcile_ref_deep_search/models/mass_reconcile.py
@@ -11,7 +11,7 @@ class AccountMassReconcileMethod(models.Model):
     @api.model
     def _get_all_rec_method(self):
         _super = super(AccountMassReconcileMethod, self)
-        methods = _super.get_all_rec_method()
+        methods = _super._get_all_rec_method()
         methods += [
             ('mass.reconcile.advanced.ref.deep.search',
              'Advanced. Partner and Ref. Deep Search'),


### PR DESCRIPTION
Small PR to correct a typo in the `super()` call (see https://github.com/OCA/bank-statement-reconcile/blob/9.0/account_mass_reconcile_transaction_ref/models/mass_reconcile.py#L14 for a correct example).
