### PR TITLE
[FIX] typo in model name prevent mass reconciliation to work on trans…

### DIFF
--- a/account_mass_reconcile_transaction_ref/models/advanced_reconciliation.py
+++ b/account_mass_reconcile_transaction_ref/models/advanced_reconciliation.py
@@ -6,7 +6,7 @@ from openerp import api, models
 
 class MassReconcileAdvancedTransactionRef(models.TransientModel):
 
-    _name = 'mass.reconcile.advanced.transaction.ref'
+    _name = 'mass.reconcile.advanced.transaction_ref'
     _inherit = 'mass.reconcile.advanced'
 
     @api.multi


### PR DESCRIPTION
Typo in model name prevent mass reconciliation to work on transaction_ref
