### PR TITLE
9.0 improve multi import moves

### DIFF
--- a/account_move_base_import/__openerp__.py
+++ b/account_move_base_import/__openerp__.py
@@ -18,6 +18,7 @@
         "views/account_move_view.xml",
         "views/journal_view.xml",
         "views/partner_view.xml",
+        "wizard/autocomplete_move_view.xml",
     ],
     'test': [
         'test/partner.yml',

--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -71,6 +71,11 @@ class AccountJournal(models.Model):
         help="Two counterparts will be automatically created : one for "
              "the refunds and one for the payments")
 
+    autovalidate_completed_move = fields.Boolean(
+        string="Validated fully completed moves",
+        help="Tic that box to automatically validate the move after the "
+        "completion")
+
     def _get_rules(self):
         # We need to respect the sequence order
         return sorted(self.rule_ids, key=attrgetter('sequence'))
@@ -118,7 +123,6 @@ class AccountJournal(models.Model):
             'account_id': account_id,
             'already_completed': True,
             'journal_id': self.id,
-            'company_id': self.company_id.id,
             'currency_id': self.currency_id.id,
             'company_currency_id': self.company_id.currency_id.id,
             'amount_residual': amount,

--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -58,7 +58,7 @@ class AccountJournal(models.Model):
 
     launch_import_completion = fields.Boolean(
         string="Launch completion after import",
-        help="Tic that box to automatically launch the completion "
+        help="Tick that box to automatically launch the completion "
         "on each imported file using this journal.")
 
     create_counterpart = fields.Boolean(
@@ -72,9 +72,9 @@ class AccountJournal(models.Model):
              "the refunds and one for the payments")
 
     autovalidate_completed_move = fields.Boolean(
-        string="Validated fully completed moves",
-        help="Tic that box to automatically validate the move after the "
-        "completion")
+        string="Validate fully completed moves",
+        help="Tick that box to automatically validate the journal entries "
+             "after the completion")
 
     def _get_rules(self):
         # We need to respect the sequence order

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -414,5 +414,8 @@ class AccountMove(models.Model):
                     if not compl_lines % 500:
                         self.env.cr.commit()
             msg = u'\n'.join(msg_lines)
-            self.write_completion_log(msg, compl_lines)
+            move.write_completion_log(msg, compl_lines)
+            if journal.autovalidate_completed_move and \
+                    all([l.already_completed for l in move.line_ids]):
+                move.post()
         return True

--- a/account_move_base_import/views/journal_view.xml
+++ b/account_move_base_import/views/journal_view.xml
@@ -15,6 +15,7 @@
                         <field name="launch_import_completion" attrs="{'invisible': ['|',
                                                                                      ('used_for_import', '=', False),
                                                                                      ('used_for_completion', '=', False)]}"/>
+                        <field name="autovalidate_completed_move" attrs="{'invisible': [('launch_import_completion', '=', False)]}"/>
                         <field name="last_import_date" readonly="1"/>
                         <field name="import_type" attrs="{'required': [('used_for_import', '=', True)]}"/>
                     </group>

--- a/account_move_base_import/wizard/__init__.py
+++ b/account_move_base_import/wizard/__init__.py
@@ -5,3 +5,4 @@
 # © 2014 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 from . import import_statement
+from . import account_autocomplete_move

--- a/account_move_base_import/wizard/account_autocomplete_move.py
+++ b/account_move_base_import/wizard/account_autocomplete_move.py
@@ -1,0 +1,30 @@
+from openerp import models, api, _
+from openerp.exceptions import UserError
+
+
+class AutocompleteAccountMove(models.TransientModel):
+    _name = "autocomplete.account.move"
+    _description = "Autocomplete Account Move"
+
+    @api.multi
+    def autocomplete_move(self):
+        context = dict(self._context or {})
+        moves = self.env['account.move'].browse(context.get('active_ids'))
+        draft_move_ids = []
+        journal_error_names = []
+        for move in moves:
+            if move.state != 'draft':
+                draft_move_ids.append(move.id)
+            if not move.used_for_completion:
+                if move.journal_id.name not in journal_error_names:
+                    journal_error_names.append(move.journal_id.name)
+        if draft_move_ids:
+            raise UserError(
+                _('Some journal entries are not at draft state : %s'
+                    % (draft_move_ids,)))
+        if journal_error_names:
+            raise UserError(
+                _('Autocompletion is not allowed on journals %s'
+                    % (journal_error_names,)))
+        moves.button_auto_completion()
+        return {'type': 'ir.actions.act_window_close'}

--- a/account_move_base_import/wizard/autocomplete_move_view.xml
+++ b/account_move_base_import/wizard/autocomplete_move_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!--Account Move lines-->
+        <record id="autocomplete_account_move_view" model="ir.ui.view">
+            <field name="name">Autocomplete Journal Entries</field>
+            <field name="model">autocomplete.account.move</field>
+            <field name="arch" type="xml">
+                <form string="Post Journal Entries">
+                    <label string="All selected journal entries will be autocompleted"/>
+                    <footer>
+                        <button string="Auto-complete" name="autocomplete_move" type="object" default_focus="1" class="btn-primary"/>
+                        <button string="Cancel" class="btn-default" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_autocomplete_account_move" model="ir.actions.act_window">
+            <field name="name">Autocomplete Journal Entries</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">autocomplete.account.move</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="autocomplete_account_move_view"/>
+            <field name="context">{}</field>
+            <field name="target">new</field>
+            <field name="help">This wizard will autocomplete all journal entries selected.</field>
+        </record>
+
+        <record model="ir.values" id="autocomplete_account_move_values">
+            <field name="model_id" ref="account.model_account_move" />
+            <field name="name">Autocomplete Journal Entries</field>
+            <field name="key2">client_action_multi</field>
+            <field name="value" eval="'ir.actions.act_window,' + str(ref('action_autocomplete_account_move'))" />
+            <field name="key">action</field>
+            <field name="model">account.move</field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_move_base_import/wizard/import_statement.py
+++ b/account_move_base_import/wizard/import_statement.py
@@ -84,6 +84,8 @@ class CreditPartnerStatementImporter(models.TransientModel):
         action = self.env['ir.actions.act_window'].for_xml_id(*xmlid)
         if len(moves) > 1:
             action['domain'] = [('id', 'in', moves.ids)]
+            if journal.autovalidate_completed_move:
+                action['context'] = {'group_by': 'state'}
         else:
             ref = self.env.ref('account.view_move_form')
             action['views'] = [(ref.id, 'form')]


### PR DESCRIPTION
Here are some small improvements to the module account_move_base_import, in case of multi move import.
- Add an option to automatically validate auto-completed moves.
  (Usefull if a user import a 100 moves file and does not want to auto-validates moves that are not auto-completed but does not want to validate everything one by one...)
  In case this option is checked and only in this case, we group the account.move by state so the user know which one are auto-completed/validated and which have some problems.
- Add a wizard to auto-complete multiple moves, the same way it exists a wizard to post multiple moves.

@mdietrichc2c @fclementic2c 
