### PR TITLE
Add implementation for matching POS moves

### DIFF
--- a/account_mass_reconcile_pos_ref/README.rst
+++ b/account_mass_reconcile_pos_ref/README.rst
@@ -1,0 +1,52 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============================
+Mass Reconcile Transaction Ref
+==============================
+
+This module extends the functionality of account_mass_reconcile
+to use the first part of 'ref' field before the ': ' defined in Point Of Sale.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/98/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/bank-statement-reconcile/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Romain Deheele <romain.deheele@camptocamp.com>
+* Matthieu Dietrich <matthieu.dietrich@camptocamp.com>
+* Florent THOMAS <florent.thomas@mind-and-go.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_mass_reconcile_pos_ref/__init__.py
+++ b/account_mass_reconcile_pos_ref/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from . import models

--- a/account_mass_reconcile_pos_ref/__openerp__.py
+++ b/account_mass_reconcile_pos_ref/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+{
+    'name': 'Mass Reconcile Point Of Sale Ref',
+    'version': '9.0.1.0.0',
+    'author': "Camptocamp,Odoo Community Association (OCA)",
+    'category': 'Finance',
+    'website': 'http://www.camptocamp.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'account_mass_reconcile',
+        'base_transaction_id'
+    ],
+    'data': [
+        'views/mass_reconcile_view.xml'
+    ],
+    'demo': [],
+    'test': [],
+    'auto_install': False,
+    'installable': True,
+    'images': []
+}

--- a/account_mass_reconcile_pos_ref/i18n/account_mass_reconcile_transaction_ref.pot
+++ b/account_mass_reconcile_pos_ref/i18n/account_mass_reconcile_transaction_ref.pot
@@ -1,0 +1,97 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_mass_reconcile_pos_ref
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-01-21 11:55+0000\n"
+"PO-Revision-Date: 2014-01-21 11:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,partner_ids:0
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,account_id:0
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: view:account.mass.reconcile:0
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: view:account.mass.reconcile:0
+msgid "Match multiple debit vs multiple credit entries. Allow partial reconciliation. The lines should have the partner, the credit entry transaction ref. is matched vs the debit entry transaction ref. or name."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_easy_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:account.move.line,pos_ref:0
+msgid "Transaction Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,journal_id:0
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,account_profit_id:0
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_move
+msgid "Account Move"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,filter:0
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,date_base_on:0
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_move_line
+msgid "Journal Items"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_easy_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,account_lost_id:0
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: field:mass.reconcile.advanced.pos_ref,write_off:0
+msgid "Write off allowed"
+msgstr ""
+

--- a/account_mass_reconcile_pos_ref/i18n/am.po
+++ b/account_mass_reconcile_pos_ref/i18n/am.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Amharic (https://www.transifex.com/oca/teams/23907/am/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: am\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/ca.po
+++ b/account_mass_reconcile_pos_ref/i18n/ca.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Creat per"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creat el"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Darrera Actualització per"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Darrera Actualització el"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/de.po
+++ b/account_mass_reconcile_pos_ref/i18n/de.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# Rudolf Schnapka <rs@techno-flex.de>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-30 02:44+0000\n"
+"PO-Revision-Date: 2016-06-30 02:44+0000\n"
+"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>, 2016\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Konto"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr "Konto für Verluste"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr "Konto für Umsätze"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Angelegt durch"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Angelegt am"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr "Ausgleichsdatum"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr "Filter"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr "Konto für Wechselkursgewinne"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Letztes Änderungsdatum"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Letzte Aktualisierung durch"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Letzte Aktualisierung am"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr "Konto für Wechselkursverluste "
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr "Schränke auf Partner ein"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr "Abschreibung erlaubt"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr "mass.reconcile.advanced"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.transaction.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr "Ausgleichsverfahren für account_mass_reconcile"

--- a/account_mass_reconcile_pos_ref/i18n/el_GR.po
+++ b/account_mass_reconcile_pos_ref/i18n/el_GR.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Δημιουργήθηκε από "
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Δημιουργήθηκε στις"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "Κωδικός"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Τελευταία ενημέρωση από"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Τελευταία ενημέρωση στις"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/es.po
+++ b/account_mass_reconcile_pos_ref/i18n/es.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Cuenta"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr "Cuenta de pérdidas"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr "Cuenta de ganancias"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr "Avanzada. Empresa y referencia de transacción"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr "Fecha de conciliación"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr "Filtro"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Diario"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr "Restringir a las empresas"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr "Desajuste permitido"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr "mass.reconcile.advanced"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr "método de conciliación para account_mass_reconcile"

--- a/account_mass_reconcile_pos_ref/i18n/es_ES.po
+++ b/account_mass_reconcile_pos_ref/i18n/es_ES.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Spanish (Spain) (https://www.transifex.com/oca/teams/23907/es_ES/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/fi.po
+++ b/account_mass_reconcile_pos_ref/i18n/fi.po
@@ -1,0 +1,168 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2016\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Luonut"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Luotu"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Nimi"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Viimeksi muokattu"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Viimeksi päivittänyt"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Viimeksi päivitetty"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/fr.po
+++ b/account_mass_reconcile_pos_ref/i18n/fr.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Compte"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr "Compte de charge"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr "Compte de produit"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr "Avancé. Partenaire et Référence de transaction"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Créée par"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Créée le"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr "Date de lettrage"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Nom à afficher"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr "Filtre"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Modifié le"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr "Restriction sur les partenaires"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr "Ecart autorisé"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr "mass.reconcile.advanced"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr "Méthode de lettrage pour le module account_mass_reconcile"

--- a/account_mass_reconcile_pos_ref/i18n/gl.po
+++ b/account_mass_reconcile_pos_ref/i18n/gl.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: gl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "ültima actualización por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/hr_HR.po
+++ b/account_mass_reconcile_pos_ref/i18n/hr_HR.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# Bole <bole@dajmi5.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-30 02:44+0000\n"
+"PO-Revision-Date: 2016-06-30 02:44+0000\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2016\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Konto"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr "Konto gubitka"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr "Konto dobiti"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Kreirao"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Kreirano"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr "Datum zatvaranja"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Naziv"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr "Filter"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Dnevnik"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Zadnja izmjena"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr "Ograniči na partnere"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr "mass.reconcile.advanced"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.transaction.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/it.po
+++ b/account_mass_reconcile_pos_ref/i18n/it.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Nome da visualizzare"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Ultimo aggiornamento di"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Ultimo aggiornamento il"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/pt.po
+++ b/account_mass_reconcile_pos_ref/i18n/pt.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Atualizado pela última vez por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Atualizado pela última vez em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/pt_BR.po
+++ b/account_mass_reconcile_pos_ref/i18n/pt_BR.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# Claudio Araujo Santos <claudioaraujosantos@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-08 02:45+0000\n"
+"PO-Revision-Date: 2016-07-08 02:45+0000\n"
+"Last-Translator: Claudio Araujo Santos <claudioaraujosantos@gmail.com>, 2016\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Conta"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Mostrar  Nome"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Diário"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Modificada pela última vez"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Atualizado em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/pt_PT.po
+++ b/account_mass_reconcile_pos_ref/i18n/pt_PT.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Portuguese (Portugal) (https://www.transifex.com/oca/teams/23907/pt_PT/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_PT\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Atualizado pela última vez por"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Atualizado pela última vez em"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/i18n/sl.po
+++ b/account_mass_reconcile_pos_ref/i18n/sl.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr "Konto"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr "Konto izgube"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr "Konto dobička"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Ustvaril"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Ustvarjeno"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr "Datum uskladitve"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr "Prikazni naziv"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr "Filter"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr "Konto menjalnega tečaja dobička"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr "Dnevnik"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr "Zadnjič spremenjeno"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Zadnji posodobil"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Zadnjič posodobljeno"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr "Konto menjalnega tečaja izgube"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr "Omejitev na partnerjih"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr "Dovoljen odpis"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr "metoda usklajevanja za preprosto usklajevanje konta"

--- a/account_mass_reconcile_pos_ref/i18n/tr.po
+++ b/account_mass_reconcile_pos_ref/i18n/tr.po
@@ -1,0 +1,167 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_mass_reconcile_pos_ref
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-12 11:12+0000\n"
+"PO-Revision-Date: 2016-09-12 11:12+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_id
+msgid "Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_lost_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_lost_id
+msgid "Account Lost"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_account_profit_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_account_profit_id
+msgid "Account Profit"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid "Advanced. Partner and POS Transaction Ref. vs Ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_uid
+msgid "Created by"
+msgstr "Oluşturan"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_create_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_create_date
+msgid "Created on"
+msgstr "Oluşturuldu"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_date_base_on
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_date_base_on
+msgid "Date of reconciliation"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_display_name
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_filter
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_filter
+msgid "Filter"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_income_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_income_exchange_account_id
+msgid "Gain Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_journal_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref___last_update
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_uid
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_uid
+msgid "Last Updated by"
+msgstr "Son güncelleyen"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_date
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_date
+msgid "Last Updated on"
+msgstr "Son güncelleme"
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_expense_exchange_account_id
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_expense_exchange_account_id
+msgid "Loss Exchange Rate Account"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"reference is matched vs the debit entry transaction reference."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.ui.view,arch_db:account_mass_reconcile_pos_ref.view_mass_reconcile_form
+msgid ""
+"Match multiple debit vs multiple credit entries. Allow partial "
+"reconciliation. The lines should have the partner, the credit entry "
+"transaction ref. is matched vs the debit entry transaction ref."
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_partner_ids
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_partner_ids
+msgid "Restrict on partners"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_vs_ref_write_off
+#: model:ir.model.fields,field_description:account_mass_reconcile_pos_ref.field_mass_reconcile_advanced_pos_ref_write_off
+msgid "Write off allowed"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced
+msgid "mass.reconcile.advanced"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref_vs_ref
+msgid "mass.reconcile.advanced.transaction.ref.vs.ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_mass_reconcile_advanced_pos_ref
+msgid "mass.reconcile.advanced.pos_ref"
+msgstr ""
+
+#. module: account_mass_reconcile_pos_ref
+#: model:ir.model,name:account_mass_reconcile_pos_ref.model_account_mass_reconcile_method
+msgid "reconcile method for account_mass_reconcile"
+msgstr ""

--- a/account_mass_reconcile_pos_ref/models/__init__.py
+++ b/account_mass_reconcile_pos_ref/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from . import mass_reconcile
+from . import base_advanced_reconciliation
+from . import advanced_reconciliation

--- a/account_mass_reconcile_pos_ref/models/advanced_reconciliation.py
+++ b/account_mass_reconcile_pos_ref/models/advanced_reconciliation.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from openerp import api, models
+
+
+class MassReconcileAdvancedTransactionRef(models.TransientModel):
+
+    _name = 'mass.reconcile.advanced.pos_ref'
+    _inherit = 'mass.reconcile.advanced'
+
+    @api.multi
+    def _skip_line(self, move_line):
+        """
+        When True is returned on some conditions, the credit move line
+        will be skipped for reconciliation. Can be inherited to
+        skip on some conditions. ie: ref or partner_id is empty.
+        """
+        return not (move_line.get('ref') and
+                    move_line.get('partner_id'))
+
+    @api.multi
+    def _matchers(self, move_line):
+        return (('partner_id', move_line['partner_id']),
+                ('ref', move_line['name'].lower()[:move_line['name'].find(': ')].strip()))
+
+    @api.multi
+    def _opposite_matchers(self, move_line):
+        yield ('partner_id', move_line['partner_id'])
+        yield ('ref', ((move_line['ref'] or '').lower().strip(),
+                       move_line['name'].lower().strip()))

--- a/account_mass_reconcile_pos_ref/models/base_advanced_reconciliation.py
+++ b/account_mass_reconcile_pos_ref/models/base_advanced_reconciliation.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from openerp import models
+
+
+class MassReconcileAdvanced(models.AbstractModel):
+
+    _inherit = 'mass.reconcile.advanced'
+
+    def _base_columns(self):
+        """ Mandatory columns for move lines queries
+        An extra column aliased as ``key`` should be defined
+        in each query."""
+        aml_cols = super(MassReconcileAdvanced, self)._base_columns()
+        aml_cols.append('account_move_line.ref')
+        aml_cols.append('account_move_line.name')
+        return aml_cols

--- a/account_mass_reconcile_pos_ref/models/mass_reconcile.py
+++ b/account_mass_reconcile_pos_ref/models/mass_reconcile.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from openerp import api, models
+
+
+class AccountMassReconcileMethod(models.Model):
+
+    _inherit = 'account.mass.reconcile.method'
+
+    @api.model
+    def _get_all_rec_method(self):
+        _super = super(AccountMassReconcileMethod, self)
+        methods = _super._get_all_rec_method()
+        methods += [
+            ('mass.reconcile.advanced.pos_ref',
+             'Advanced. Partner and Point Of Sale Ref.'),
+        ]
+        return methods

--- a/account_mass_reconcile_pos_ref/views/mass_reconcile_view.xml
+++ b/account_mass_reconcile_pos_ref/views/mass_reconcile_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_mass_reconcile_form" model="ir.ui.view">
+        <field name="name">account.mass.reconcile.form</field>
+        <field name="model">account.mass.reconcile</field>
+        <field name="inherit_id" ref="account_mass_reconcile.account_mass_reconcile_form"/>
+        <field name="arch" type="xml">
+            <page name="information" position="inside">
+                <group colspan="2" col="2">
+                    <separator colspan="4" string="Advanced. Partner and POS Transaction Ref"/>
+                    <label string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
+The lines should have the partner, the credit entry POS ref. is matched vs the debit entry ref." colspan="4"/>
+                </group>
+            </page>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Odoo POS add semicolon and return informations in the ref of the move so that the other reconcile schema are not matching.
This module has purpose to deal with this specifics
