### PR TITLE
Remove id usage since it is done in account.move

### DIFF
--- a/account_mass_reconcile/models/base_reconciliation.py
+++ b/account_mass_reconcile/models/base_reconciliation.py
@@ -155,13 +155,13 @@ class MassReconcileBase(models.AbstractModel):
         )
         if below_writeoff:
             if sum_credit > sum_debit:
-                writeoff_account_id = self.account_profit_id.id
+                writeoff_account_id = self.account_profit_id
             else:
-                writeoff_account_id = self.account_lost_id.id
+                writeoff_account_id = self.account_lost_id
             line_rs = ml_obj.browse(line_ids)
             line_rs.reconcile(
                 writeoff_acc_id=writeoff_account_id,
-                writeoff_journal_id=self.journal_id.id
+                writeoff_journal_id=self.journal_id
                 )
             return True, True
         elif allow_partial:
@@ -173,13 +173,13 @@ class MassReconcileBase(models.AbstractModel):
             # it will do a full reconcile instead of a partial reconcile
             # and make a write-off for exchange
             if sum_credit > sum_debit:
-                writeoff_account_id = self.income_exchange_account_id.id
+                writeoff_account_id = self.income_exchange_account_id
             else:
-                writeoff_account_id = self.expense_exchange_account_id.id
+                writeoff_account_id = self.expense_exchange_account_id
             line_rs = ml_obj.browse(line_ids)
             line_rs.reconcile(
                 writeoff_acc_id=writeoff_account_id,
-                writeoff_journal_id=self.journal_id.id
+                writeoff_journal_id=self.journal_id
                 )
             return True, False
         return False, False


### PR DESCRIPTION
Small PR to correct a mistake : in https://github.com/OCA/OCB/blob/9.0/addons/account/models/account_move.py#L874 , the IDs are retrieved from the `reconcile()` method parameters. Now, the RecordSets are passed as parameters as expected.
