### PR TITLE
Force import partner on account.move

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -243,7 +243,8 @@ class AccountJournal(models.Model):
         the profile.
         """
         vals = {'journal_id': self.id,
-                'currency_id': self.currency_id.id}
+                'currency_id': self.currency_id.id,
+                'import_partner_id': self.partner_id.id}
         vals.update(parser.get_move_vals())
         return vals
 

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -333,6 +333,16 @@ class AccountMove(models.Model):
         related='journal_id.used_for_completion',
         readonly=True)
     completion_logs = fields.Text(string='Completion Log', readonly=True)
+    partner_id = fields.Many2one(related=False, compute='_compute_partner_id')
+    import_partner_id = fields.Many2one('res.partner', string="Partner from import")
+
+    @api.depends('line_ids.partner_id', 'import_partner_id')
+    def _compute_partner_id(self):
+        for move in self:
+            if move.import_partner_id:
+                move.partner_id = move.import_partner_id
+            elif move.line_ids:
+                move.partner_id = move.line_ids[0].partner_id
 
     def write_completion_log(self, error_msg, number_imported):
         """Write the log in the completion_logs field of the bank statement to

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -334,7 +334,8 @@ class AccountMove(models.Model):
         readonly=True)
     completion_logs = fields.Text(string='Completion Log', readonly=True)
     partner_id = fields.Many2one(related=False, compute='_compute_partner_id')
-    import_partner_id = fields.Many2one('res.partner', string="Partner from import")
+    import_partner_id = fields.Many2one('res.partner',
+                                        string="Partner from import")
 
     @api.depends('line_ids.partner_id', 'import_partner_id')
     def _compute_partner_id(self):


### PR DESCRIPTION
Small PR to fix an issue I encountered with the import : since multiple partners are now in the move, this means that editing one move line from an import will change the move's partner to a random partner present.

With this, the partner defined as the bank's partner will remain the move's partner.
