### PR TITLE
Remove now non-existing "Display partial" button

### DIFF
--- a/account_mass_reconcile/views/mass_reconcile.xml
+++ b/account_mass_reconcile/views/mass_reconcile.xml
@@ -88,9 +88,6 @@ The lines should have the partner, the credit entry ref. is matched vs the debit
                     string="Start Auto Reconcilation" type="object"/>
                 <button icon="STOCK_JUMP_TO" name="last_history_reconcile" colspan="2"
                     string="Display items reconciled on the last run" type="object"/>
-                <button icon="STOCK_JUMP_TO" name="last_history_partial" colspan="2"
-                    string="Display items partially reconciled on the last run"
-                    type="object"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Small part I missed when migrating the modules : the "Display partial" button should not exist anymore.
