### PR TITLE
[10.0] Port base modules to v10

### DIFF
--- a/account_move_base_import/README.rst
+++ b/account_move_base_import/README.rst
@@ -52,10 +52,7 @@ both.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
-
-.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
-.. branch is "8.0" for example
+   :target: https://runbot.odoo-community.org/runbot/98/10.0
 
 Known issues / Roadmap
 ======================

--- a/account_move_base_import/__init__.py
+++ b/account_move_base_import/__init__.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
-# © 2011-2016 Camptocamp SA
-# © 2013 Savoir-faire Linux
-# © 2014 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
 from . import parser
 from . import wizard
 from . import models

--- a/account_move_base_import/__manifest__.py
+++ b/account_move_base_import/__manifest__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 {
     'name': "Journal Entry base import",
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'author': "Akretion,Camptocamp,Odoo Community Association (OCA)",
     'category': 'Finance',
     'depends': ['account'],
@@ -26,7 +26,6 @@
         'test/refund.yml',
         'test/completion_test.yml'
     ],
-    'installable': False,
-    'auto_install': False,
+    'installable': True,
     'license': 'AGPL-3',
 }

--- a/account_move_base_import/i18n/bg.po
+++ b/account_move_base_import/i18n/bg.po
@@ -3,20 +3,19 @@
 # * account_move_base_import
 # 
 # Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
-# Andrea Cometa <a.cometa@apuliasoftware.it>, 2016
+# Kaloyan Naumov <kaloyan@lumnus.net>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-28 11:33+0000\n"
 "PO-Revision-Date: 2016-09-28 11:33+0000\n"
-"Last-Translator: Andrea Cometa <a.cometa@apuliasoftware.it>, 2016\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"Last-Translator: Kaloyan Naumov <kaloyan@lumnus.net>, 2016\n"
+"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
+"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_move_base_import
@@ -77,7 +76,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.ui.view,arch_db:account_move_base_import.move_importer_view
 msgid "Cancel"
-msgstr "Annulla"
+msgstr "Откажи"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_account_journal_receivable_account_id
@@ -136,13 +135,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_uid
 msgid "Created by"
-msgstr "Creato da"
+msgstr "Създадено от"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_date
 msgid "Created on"
-msgstr "Creato il"
+msgstr "Създадено на"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_partner_id
@@ -181,7 +180,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_display_name
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_display_name
 msgid "Display Name"
-msgstr "Nome da visualizzare"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_res_partner_bank_statement_label
@@ -336,7 +335,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_journal
 msgid "Journal"
-msgstr "Sezionale"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_move_line
@@ -369,19 +368,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule___last_update
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import___last_update
 msgid "Last Modified on"
-msgstr "Ultima modifica il"
+msgstr "Последно обновено на"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_uid
 msgid "Last Updated by"
-msgstr "Ultimo aggiornamento di"
+msgstr "Последно обновено от"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_date
 msgid "Last Updated on"
-msgstr "Ultimo aggiornamento il"
+msgstr "Последно обновено на"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_journal_launch_import_completion
@@ -472,7 +471,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_name
 msgid "Name"
-msgstr ""
+msgstr "Име"
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/parser/parser.py:148
@@ -520,7 +519,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_res_partner
 msgid "Partner"
-msgstr "Partner"
+msgstr "Партньор"
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/parser/file_parser.py:15

--- a/account_move_base_import/i18n/es.po
+++ b/account_move_base_import/i18n/es.po
@@ -4,13 +4,14 @@
 # 
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-12 11:12+0000\n"
-"PO-Revision-Date: 2016-09-12 11:12+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"POT-Creation-Date: 2016-09-28 11:33+0000\n"
+"PO-Revision-Date: 2016-09-28 11:33+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2016\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -135,7 +136,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_date
@@ -263,7 +264,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_id
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_account_journal_message_unread
@@ -374,7 +375,7 @@ msgstr "Última modificación en"
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización por"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_date
@@ -519,7 +520,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_res_partner
 msgid "Partner"
-msgstr ""
+msgstr "Empresa"
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/parser/file_parser.py:15

--- a/account_move_base_import/i18n/hr.po
+++ b/account_move_base_import/i18n/hr.po
@@ -3,21 +3,20 @@
 # * account_move_base_import
 # 
 # Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
-# Andrea Cometa <a.cometa@apuliasoftware.it>, 2016
+# Bole <bole@dajmi5.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-28 11:33+0000\n"
 "PO-Revision-Date: 2016-09-28 11:33+0000\n"
-"Last-Translator: Andrea Cometa <a.cometa@apuliasoftware.it>, 2016\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2016\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/models/account_move.py:351
@@ -77,7 +76,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.ui.view,arch_db:account_move_base_import.move_importer_view
 msgid "Cancel"
-msgstr "Annulla"
+msgstr "Odustani"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_account_journal_receivable_account_id
@@ -136,13 +135,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_uid
 msgid "Created by"
-msgstr "Creato da"
+msgstr "Kreirao"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_date
 msgid "Created on"
-msgstr "Creato il"
+msgstr "Kreirano"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_partner_id
@@ -181,7 +180,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_display_name
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_display_name
 msgid "Display Name"
-msgstr "Nome da visualizzare"
+msgstr "Naziv "
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_res_partner_bank_statement_label
@@ -336,7 +335,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_journal
 msgid "Journal"
-msgstr "Sezionale"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_move_line
@@ -369,19 +368,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule___last_update
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import___last_update
 msgid "Last Modified on"
-msgstr "Ultima modifica il"
+msgstr "Zadnje modificirano"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_uid
 msgid "Last Updated by"
-msgstr "Ultimo aggiornamento di"
+msgstr "Zadnji ažurirao"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_date
 msgid "Last Updated on"
-msgstr "Ultimo aggiornamento il"
+msgstr "Zadnje ažuriranje"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_journal_launch_import_completion

--- a/account_move_base_import/i18n/hr_HR.po
+++ b/account_move_base_import/i18n/hr_HR.po
@@ -3,13 +3,14 @@
 # * account_move_base_import
 # 
 # Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
 # Bole <bole@dajmi5.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-08 02:45+0000\n"
-"PO-Revision-Date: 2016-07-08 02:45+0000\n"
+"POT-Creation-Date: 2016-09-28 11:33+0000\n"
+"PO-Revision-Date: 2016-09-28 11:33+0000\n"
 "Last-Translator: Bole <bole@dajmi5.com>, 2016\n"
 "Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
 "MIME-Version: 1.0\n"
@@ -323,7 +324,7 @@ msgstr ""
 #: code:addons/account_move_base_import/models/account_move.py:78
 #: code:addons/account_move_base_import/models/account_move.py:96
 #, python-format
-msgid "Invalid invoice type for completion: %"
+msgid "Invalid invoice type for completion: %s"
 msgstr ""
 
 #. module: account_move_base_import
@@ -374,13 +375,13 @@ msgstr "Zadnja izmjena"
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Zadnji ažurirao"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Zadnje ažurirano"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_journal_launch_import_completion
@@ -510,10 +511,10 @@ msgid "Number of unread messages"
 msgstr ""
 
 #. module: account_move_base_import
-#: code:addons/account_move_base_import/models/account_move.py:305
-#: code:addons/account_move_base_import/models/account_move.py:321
+#: code:addons/account_move_base_import/models/account_move.py:306
+#: code:addons/account_move_base_import/models/account_move.py:322
 #, python-format
-msgid "ORM bypass error"
+msgid "ORM bypass error: %s"
 msgstr ""
 
 #. module: account_move_base_import
@@ -580,7 +581,7 @@ msgstr ""
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/models/account_journal.py:332
 #, python-format
-msgid "Statement import errorThe statement cannot be created: %s"
+msgid "Statement import error The statement cannot be created: %s"
 msgstr ""
 
 #. module: account_move_base_import

--- a/account_move_base_import/i18n/zh_CN.po
+++ b/account_move_base_import/i18n/zh_CN.po
@@ -4,20 +4,19 @@
 # 
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
-# Andrea Cometa <a.cometa@apuliasoftware.it>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-28 11:33+0000\n"
 "PO-Revision-Date: 2016-09-28 11:33+0000\n"
-"Last-Translator: Andrea Cometa <a.cometa@apuliasoftware.it>, 2016\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/models/account_move.py:351
@@ -77,7 +76,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.ui.view,arch_db:account_move_base_import.move_importer_view
 msgid "Cancel"
-msgstr "Annulla"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_account_journal_receivable_account_id
@@ -136,13 +135,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_uid
 msgid "Created by"
-msgstr "Creato da"
+msgstr "创建者"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_create_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_create_date
 msgid "Created on"
-msgstr "Creato il"
+msgstr "创建时间"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_partner_id
@@ -181,7 +180,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_display_name
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_display_name
 msgid "Display Name"
-msgstr "Nome da visualizzare"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model.fields,help:account_move_base_import.field_res_partner_bank_statement_label
@@ -336,7 +335,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_journal
 msgid "Journal"
-msgstr "Sezionale"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_account_move_line
@@ -369,19 +368,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule___last_update
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import___last_update
 msgid "Last Modified on"
-msgstr "Ultima modifica il"
+msgstr ""
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_uid
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_uid
 msgid "Last Updated by"
-msgstr "Ultimo aggiornamento di"
+msgstr "最后更新者"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_move_completion_rule_write_date
 #: model:ir.model.fields,field_description:account_move_base_import.field_credit_statement_import_write_date
 msgid "Last Updated on"
-msgstr "Ultimo aggiornamento il"
+msgstr "上次更新日期"
 
 #. module: account_move_base_import
 #: model:ir.model.fields,field_description:account_move_base_import.field_account_journal_launch_import_completion
@@ -520,7 +519,7 @@ msgstr ""
 #. module: account_move_base_import
 #: model:ir.model,name:account_move_base_import.model_res_partner
 msgid "Partner"
-msgstr "Partner"
+msgstr ""
 
 #. module: account_move_base_import
 #: code:addons/account_move_base_import/parser/file_parser.py:15

--- a/account_move_base_import/models/__init__.py
+++ b/account_move_base_import/models/__init__.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
-# © 2011-2016 Camptocamp SA
-# © 2013 Savoir-faire Linux
-# © 2014 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
 from . import account_journal
 from . import account_move
 from . import partner

--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
@@ -7,9 +7,9 @@
 import sys
 import traceback
 import os
-from openerp import _, api, fields, models
+from odoo import _, api, fields, models
 from ..parser.parser import new_move_parser
-from openerp.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError
 from operator import attrgetter
 
 
@@ -289,10 +289,11 @@ class AccountJournal(models.Model):
                               "The file is empty"))
         parsed_cols = parser.get_move_line_vals(result_row_list[0]).keys()
         for col in parsed_cols:
-            if col not in move_line_obj._columns:
+            print dir(move_line_obj)
+            if col not in move_line_obj._fields:
                 raise UserError(
                     _("Missing column! Column %s you try to import is not "
-                      "present in the bank statement line!") % col)
+                      "present in the move line!") % col)
         move_vals = self.prepare_move_vals(result_row_list, parser)
         move = move_obj.create(move_vals)
         try:

--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -289,7 +289,6 @@ class AccountJournal(models.Model):
                               "The file is empty"))
         parsed_cols = parser.get_move_line_vals(result_row_list[0]).keys()
         for col in parsed_cols:
-            print dir(move_line_obj)
             if col not in move_line_obj._fields:
                 raise UserError(
                     _("Missing column! Column %s you try to import is not "

--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -243,7 +243,8 @@ class AccountJournal(models.Model):
         the profile.
         """
         vals = {'journal_id': self.id,
-                'currency_id': self.currency_id.id}
+                'currency_id': self.currency_id.id,
+                'import_partner_id': self.partner_id.id}
         vals.update(parser.get_move_vals())
         return vals
 

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -266,7 +266,6 @@ class AccountMoveLine(models.Model):
         ]
         keys = [k for k in move_store[0].keys() if k in avail]
         keys.sort()
-        print "keys==================", keys
         return keys
 
     def _prepare_insert(self, move, cols):
@@ -276,9 +275,7 @@ class AccountMoveLine(models.Model):
         move_copy = move
         for k, col in move_copy.iteritems():
             if k in cols:
-                print "DIR self._fields[k]=", dir(self._fields[k])
-                move_copy[k] = self._fields[k]._symbol_set[1](col)
-                print "move_copy[k]==========", move_copy[k]
+                move_copy[k] = self._fields[k].convert_to_column(col, None)
         return move_copy
 
     def _prepare_manyinsert(self, move_store, cols):

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
@@ -10,8 +10,8 @@ import logging
 
 import psycopg2
 
-from openerp import _, api, fields, models
-from openerp.exceptions import ValidationError
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 _logger = logging.getLogger(__name__)
@@ -260,12 +260,13 @@ class AccountMoveLine(models.Model):
 
     def _get_available_columns(self, move_store):
         """Return writeable by SQL columns"""
-        model_cols = self._columns
+        model_cols = self._fields
         avail = [
             k for k, col in model_cols.iteritems() if not hasattr(col, '_fnct')
         ]
         keys = [k for k in move_store[0].keys() if k in avail]
         keys.sort()
+        print "keys==================", keys
         return keys
 
     def _prepare_insert(self, move, cols):
@@ -275,7 +276,9 @@ class AccountMoveLine(models.Model):
         move_copy = move
         for k, col in move_copy.iteritems():
             if k in cols:
-                move_copy[k] = self._columns[k]._symbol_set[1](col)
+                print "DIR self._fields[k]=", dir(self._fields[k])
+                move_copy[k] = self._fields[k]._symbol_set[1](col)
+                print "move_copy[k]==========", move_copy[k]
         return move_copy
 
     def _prepare_manyinsert(self, move_store, cols):
@@ -333,17 +336,19 @@ class AccountMove(models.Model):
         related='journal_id.used_for_completion',
         readonly=True)
     completion_logs = fields.Text(string='Completion Log', readonly=True)
+    # partner_id is a native field of the account module
+    # (related='line_ids.partner_id', store=True, readonly=True)
     partner_id = fields.Many2one(related=False, compute='_compute_partner_id')
     import_partner_id = fields.Many2one('res.partner',
                                         string="Partner from import")
 
+    @api.one
     @api.depends('line_ids.partner_id', 'import_partner_id')
     def _compute_partner_id(self):
-        for move in self:
-            if move.import_partner_id:
-                move.partner_id = move.import_partner_id
-            elif move.line_ids:
-                move.partner_id = move.line_ids[0].partner_id
+        if self.import_partner_id:
+            self.partner_id = self.import_partner_id
+        elif self.line_ids:
+            self.partner_id = self.line_ids[0].partner_id
 
     def write_completion_log(self, error_msg, number_imported):
         """Write the log in the completion_logs field of the bank statement to

--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -333,6 +333,17 @@ class AccountMove(models.Model):
         related='journal_id.used_for_completion',
         readonly=True)
     completion_logs = fields.Text(string='Completion Log', readonly=True)
+    partner_id = fields.Many2one(related=False, compute='_compute_partner_id')
+    import_partner_id = fields.Many2one('res.partner',
+                                        string="Partner from import")
+
+    @api.depends('line_ids.partner_id', 'import_partner_id')
+    def _compute_partner_id(self):
+        for move in self:
+            if move.import_partner_id:
+                move.partner_id = move.import_partner_id
+            elif move.line_ids:
+                move.partner_id = move.line_ids[0].partner_id
 
     def write_completion_log(self, error_msg, number_imported):
         """Write the log in the completion_logs field of the bank statement to

--- a/account_move_base_import/models/partner.py
+++ b/account_move_base_import/models/partner.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-from openerp import fields, models
+from odoo import fields, models
 
 
 class ResPartner(models.Model):

--- a/account_move_base_import/test/completion_test.yml
+++ b/account_move_base_import/test/completion_test.yml
@@ -66,20 +66,16 @@
 -
   !python {model: account.move.line}: |
     import datetime as dt
-    context['check_move_validity'] = False
-    model.write({'name': dt.date.today().strftime('TBNK/%Y/0001'),
-                 'credit': 210.0})
-    model.write({'name': 'T2S12345',
-                 'debit': 65.0})
-    model.write({'name': dt.date.today().strftime('RTEXJ/%Y/0001'),
-                 'debit': 210.0})
-    model.write({'credit': 600.0})
-    model.write({'debit': 932.4})
+    model.browse(ref('move_line_ci')).with_context(check_move_validity=False).write({'name': dt.date.today().strftime('TBNK/%Y/0001'),'credit': 210.0})
+    model.browse(ref('move_line_si')).with_context(check_move_validity=False).write({'name': 'T2S12345','debit': 65.0})
+    model.browse(ref('move_line_cr')).with_context(check_move_validity=False).write({'name': dt.date.today().strftime('RTEXJ/%Y/0001'),'debit': 210.0})
+    model.browse(ref('move_line_partner_name')).with_context(check_move_validity=False).write({'credit': 600.0})
+    model.browse(ref('move_line_partner_label')).with_context(check_move_validity=False).write({'debit': 932.4})
 -
   I run the auto complete
 -
-  !python {model: account.move}: |
-    result = self.button_auto_completion()
+  !python {model: account.move, ref: move_test1}: |
+    result = model.browse(ref('move_test1')).button_auto_completion()
 -
   Now I can check that all is nice and shiny, line 1. I expect the Customer
   Invoice Number to be recognised.

--- a/account_move_base_import/test/completion_test.yml
+++ b/account_move_base_import/test/completion_test.yml
@@ -67,29 +67,19 @@
   !python {model: account.move.line}: |
     import datetime as dt
     context['check_move_validity'] = False
-    model.write(cr, uid, [ref('move_line_ci')],
-                {'name': dt.date.today().strftime('TBNK/%Y/0001'),
-                 'credit': 210.0},
-                context)
-    model.write(cr, uid, [ref('move_line_si')],
-                {'name': 'T2S12345',
-                 'debit': 65.0},
-                context)
-    model.write(cr, uid, [ref('move_line_cr')],
-                {'name': dt.date.today().strftime('RTEXJ/%Y/0001'),
-                 'debit': 210.0},
-                context)
-    model.write(cr, uid, [ref('move_line_partner_name')],
-                {'credit': 600.0},
-                context)
-    model.write(cr, uid, [ref('move_line_partner_label')],
-                {'debit': 932.4},
-                context)
+    model.write({'name': dt.date.today().strftime('TBNK/%Y/0001'),
+                 'credit': 210.0})
+    model.write({'name': 'T2S12345',
+                 'debit': 65.0})
+    model.write({'name': dt.date.today().strftime('RTEXJ/%Y/0001'),
+                 'debit': 210.0})
+    model.write({'credit': 600.0})
+    model.write({'debit': 932.4})
 -
   I run the auto complete
 -
   !python {model: account.move}: |
-    result = self.button_auto_completion(cr, uid, [ref("move_test1")])
+    result = self.button_auto_completion()
 -
   Now I can check that all is nice and shiny, line 1. I expect the Customer
   Invoice Number to be recognised.

--- a/account_move_base_import/test/invoice.yml
+++ b/account_move_base_import/test/invoice.yml
@@ -27,7 +27,8 @@
 -
   I confirm the Invoice
 -
-  !workflow {model: account.invoice, action: invoice_open, ref: invoice_for_completion_1}
+  !python {model: account.invoice, id: invoice_for_completion_1}:
+    self.action_invoice_open()
 -
   I check that the invoice state is "Open"
 -
@@ -38,5 +39,5 @@
 -
   !python {model: account.invoice}: |
     import datetime as dt
-    invoice = model.browse(cr, uid, ref('invoice_for_completion_1'), context)
+    invoice = model.browse(ref('invoice_for_completion_1'))
     assert invoice.number == dt.date.today().strftime('TBNK/%Y/0001')

--- a/account_move_base_import/test/refund.yml
+++ b/account_move_base_import/test/refund.yml
@@ -27,7 +27,8 @@
 -
   I confirm the refund
 -
-  !workflow {model: account.invoice, action: invoice_open, ref: refund_for_completion_1}
+  !python {model: account.invoice, id: invoice_for_completion_1}:
+    self.action_invoice_open()
 -
   I check that the refund state is "Open"
 -
@@ -38,5 +39,5 @@
 -
   !python {model: account.invoice}: |
     import datetime as dt
-    invoice = model.browse(cr, uid, ref('refund_for_completion_1'), context)
+    invoice = model.browse(ref('refund_for_completion_1'))
     assert invoice.number == dt.date.today().strftime('RTEXJ/%Y/0001')

--- a/account_move_base_import/test/refund.yml
+++ b/account_move_base_import/test/refund.yml
@@ -27,8 +27,8 @@
 -
   I confirm the refund
 -
-  !python {model: account.invoice, id: invoice_for_completion_1}:
-    self.action_invoice_open()
+  !python {model: account.invoice, ref: invoice_for_completion_1}: |
+    model.browse(ref('refund_for_completion_1')).action_invoice_open()
 -
   I check that the refund state is "Open"
 -

--- a/account_move_base_import/test/supplier_invoice.yml
+++ b/account_move_base_import/test/supplier_invoice.yml
@@ -17,10 +17,8 @@
 -
   I add a reference to an existing supplier invoce
 -
-  !python {model: account.invoice}: |
-    self.write({
-      'reference': 'T2S12345'
-    })
+  !python {model: account.invoice, id: account.demo_invoice_0}: |
+    self.write({'reference': 'T2S12345'})
 -
   I check a second time that my invoice is still a supplier invoice
 -
@@ -29,7 +27,7 @@
 -
   Now I confirm it
 -
-  !python {model: account.invoice, id: account.demo_invoice_0}:
+  !python {model: account.invoice, ref: account.demo_invoice_0}: |
     self.action_invoice_open()
 -
   I check that the supplier number is there

--- a/account_move_base_import/test/supplier_invoice.yml
+++ b/account_move_base_import/test/supplier_invoice.yml
@@ -18,7 +18,7 @@
   I add a reference to an existing supplier invoce
 -
   !python {model: account.invoice}: |
-    self.write(cr, uid, ref('account.demo_invoice_0'), {
+    self.write({
       'reference': 'T2S12345'
     })
 -
@@ -29,7 +29,8 @@
 -
   Now I confirm it
 -
-  !workflow {model: account.invoice, action: invoice_open, ref: account.demo_invoice_0}
+  !python {model: account.invoice, id: account.demo_invoice_0}:
+    self.action_invoice_open()
 -
   I check that the supplier number is there
 -

--- a/account_move_base_import/tests/test_base_completion.py
+++ b/account_move_base_import/tests/test_base_completion.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-from openerp import fields, tools
-from openerp.modules import get_module_resource
-from openerp.tests import common
+from odoo import fields, tools
+from odoo.modules import get_module_resource
+from odoo.tests import common
 from collections import namedtuple
 
 name_completion_case = namedtuple(

--- a/account_move_base_import/tests/test_base_import.py
+++ b/account_move_base_import/tests/test_base_import.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
+# © 2011-2016 Akretion
 # © 2011-2016 Camptocamp SA
 # © 2013 Savoir-faire Linux
 # © 2014 ACSONE SA/NV
@@ -8,9 +8,9 @@ import base64
 import inspect
 import os
 from operator import attrgetter
-from openerp.tests import common
-from openerp import tools
-from openerp.modules import get_module_resource
+from odoo.tests import common
+from odoo import tools
+from odoo.modules import get_module_resource
 
 
 class TestCodaImport(common.TransactionCase):

--- a/account_move_base_import/views/account_move_view.xml
+++ b/account_move_base_import/views/account_move_view.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="view_move_importer_form" model="ir.ui.view">
         <field name="name">account.move.view</field>
@@ -56,9 +57,8 @@
     </record>
 
     <record id="action_move_completion_rule_tree" model="ir.actions.act_window">
-        <field name="name">Move Completion Rule</field>
+        <field name="name">Move Completion Rules</field>
         <field name="res_model">account.move.completion.rule</field>
-        <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
     </record>
 

--- a/account_move_base_import/views/journal_view.xml
+++ b/account_move_base_import/views/journal_view.xml
@@ -28,14 +28,13 @@
                     <group>
                         <button name="%(account_move_base_import.move_importer_action)d"
                                 string="Import batch file"
-                                type="action" icon="gtk-ok"
+                                type="action"
                                 colspan = "2"/>
                     </group>
                 </page>
                 <page string="Auto-Completion related infos" attrs="{'invisible': [('used_for_completion', '=', False)]}">
-                    <group>
-                        <separator colspan="4" string="Auto-Completion Rules"/>
-                        <field name="rule_ids" colspan="4" nolabel="1"/>
+                    <group string="Auto-Completion Rules" name="completion_rules">
+                        <field name="rule_ids" colspan="2" nolabel="1"/>
                     </group>
                 </page>
             </notebook>

--- a/account_move_base_import/views/partner_view.xml
+++ b/account_move_base_import/views/partner_view.xml
@@ -1,9 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
     <record id="bk_view_partner_form" model="ir.ui.view">
         <field name="name">account_bank_statement_import.view.partner.form</field>
         <field name="model">res.partner</field>
-        <field name="priority">20</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <field name="property_account_payable_id" position="after">

--- a/account_move_base_import/wizard/__init__.py
+++ b/account_move_base_import/wizard/__init__.py
@@ -1,7 +1,3 @@
 # -*- coding: utf-8 -*-
-# © 2011 Akretion
-# © 2011-2016 Camptocamp SA
-# © 2013 Savoir-faire Linux
-# © 2014 ACSONE SA/NV
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
 from . import import_statement

--- a/account_move_base_import/wizard/import_statement_view.xml
+++ b/account_move_base_import/wizard/import_statement_view.xml
@@ -5,18 +5,19 @@
         <field name="model">credit.statement.import</field>
         <field name="arch" type="xml">
             <form string="Import move">
-                <group colspan="4" >
-                    <field name="journal_id" on_change="onchange_journal_id(journal_id)" domain="[('used_for_import', '=', True)]"/>
-                    <field name="input_statement" filename="file_name" colspan="2"/>
-                    <field name="file_name" colspan="2" invisible="1"/>
-                    <separator string="Import Parameters Summary" colspan="4"/>
-                    <field name="partner_id" readonly="1"/>
-                    <field name="receivable_account_id" readonly="1"/>
-                    <field name="commission_account_id" readonly="1"/>
+                <group name="main">
+                    <field name="journal_id" domain="[('used_for_import', '=', True)]"/>
+                    <field name="input_statement" filename="file_name"/>
+                    <field name="file_name" invisible="1"/>
+                </group>
+                <group string="Import Parameters Summary" name="params">
+                    <field name="partner_id"/>
+                    <field name="receivable_account_id"/>
+                    <field name="commission_account_id"/>
                 </group>
                 <footer>
-                    <button  icon="gtk-ok" name="import_statement" string="Import file" type="object" class="oe_highlight"/>
-                    <button  icon="gtk-cancel" special="cancel" string="Cancel"/>
+                    <button name="import_statement" string="Import file" type="object" class="oe_highlight"/>
+                    <button special="cancel" string="Cancel" class="oe_link"/>
                 </footer>
             </form>
         </field>
@@ -25,9 +26,7 @@
     <record id="move_importer_action" model="ir.actions.act_window">
         <field name="name">Import Batch File</field>
         <field name="res_model">credit.statement.import</field>
-        <field name="view_type">form</field>
-        <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="move_importer_view"/>
+        <field name="view_mode">form</field>
         <field name="target">new</field>
     </record>
 

--- a/account_move_transactionid_import/i18n/it.po
+++ b/account_move_transactionid_import/i18n/it.po
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_move_transactionid_import
+# 
+# Translators:
+# Andrea Cometa <a.cometa@apuliasoftware.it>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-28 11:33+0000\n"
+"PO-Revision-Date: 2016-09-28 11:33+0000\n"
+"Last-Translator: Andrea Cometa <a.cometa@apuliasoftware.it>, 2016\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_move_transactionid_import
+#: model:ir.model,name:account_move_transactionid_import.model_account_journal
+msgid "Journal"
+msgstr "Sezionale"
+
+#. module: account_move_transactionid_import
+#: code:addons/account_move_transactionid_import/models/account_move.py:41
+#: code:addons/account_move_transactionid_import/models/account_move.py:69
+#, python-format
+msgid "Line named \"%s\" was matched by more than one partner."
+msgstr ""
+
+#. module: account_move_transactionid_import
+#: model:ir.model,name:account_move_transactionid_import.model_account_move_completion_rule
+msgid "account.move.completion.rule"
+msgstr ""

--- a/account_move_transactionid_import/parser/transactionid_file_parser.py
+++ b/account_move_transactionid_import/parser/transactionid_file_parser.py
@@ -66,6 +66,6 @@ class TransactionIDFileParser(FileParser):
             'name': line.get('label', '/'),
             'date_maturity': line.get('date', datetime.datetime.now().date()),
             'credit': amount > 0.0 and amount or 0.0,
-            'debit': amount < 0.0 and amount or 0.0,
+            'debit': amount < 0.0 and -amount or 0.0,
             'transaction_ref': line.get('transaction_id', '/'),
         }

--- a/base_transaction_id/__init__.py
+++ b/base_transaction_id/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*# -*- coding: utf-8 -*-
-# © 2012-2015 Yannick Vaucher (Camptocamp)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# -*- coding: utf-8 -*-
+
 from . import models

--- a/base_transaction_id/__manifest__.py
+++ b/base_transaction_id/__manifest__.py
@@ -1,27 +1,21 @@
-# -*- coding: utf-8 -*# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*
 # © 2012 Yannick Vaucher (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Base transaction id for financial institutes',
- 'version': '9.0.1.0.0',
+ 'version': '10.0.1.0.0',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'Hidden/Dependency',
- 'complexity': 'easy',
  'depends': [
-     'account',
-     'stock_account',
-     'sale_stock',
+     'sale',
  ],
- 'website': 'http://www.openerp.com',
+ 'website': 'https://www.odoo-community.org/',
  'data': [
      'views/invoice.xml',
      'views/sale.xml',
      'views/account_move_line.xml',
      'views/base_transaction_id.xml',
  ],
- 'test': [],
- 'installable': False,
- 'images': [],
- 'auto_install': False,
+ 'installable': True,
  'license': 'AGPL-3',
  }

--- a/base_transaction_id/__manifest__.py
+++ b/base_transaction_id/__manifest__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-# © 2012 Yannick Vaucher (Camptocamp)
+# © 2012 Yannick Vaucher, Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Base transaction id for financial institutes',
  'version': '10.0.1.0.0',

--- a/base_transaction_id/i18n/ar.po
+++ b/base_transaction_id/i18n/ar.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Arabic (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "فاتورة"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/bg.po
+++ b/base_transaction_id/i18n/bg.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/bg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Фактура"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/bs.po
+++ b/base_transaction_id/i18n/bs.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Bosnian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/bs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: bs\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/ca.po
+++ b/base_transaction_id/i18n/ca.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Catalan (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/cs.po
+++ b/base_transaction_id/i18n/cs.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Czech (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/el_GR.po
+++ b/base_transaction_id/i18n/el_GR.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-03 10:40+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/el_GR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: el_GR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Τιμολόγιο"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/en_GB.po
+++ b/base_transaction_id/i18n/en_GB.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Invoice"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/es_CR.po
+++ b/base_transaction_id/i18n/es_CR.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_CR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/es_EC.po
+++ b/base_transaction_id/i18n/es_EC.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (Ecuador) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es_EC/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_EC\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/es_ES.po
+++ b/base_transaction_id/i18n/es_ES.po
@@ -8,24 +8,24 @@ msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-28 11:33+0000\n"
-"PO-Revision-Date: 2016-10-01 07:04+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Italian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/it/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (Spain) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
+"Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
 msgid "Bank Statement Line"
-msgstr "Linea estratto conto"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Fattura"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
@@ -35,7 +35,7 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Ordini di Vendita"
+msgstr "Pedido de venta"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id

--- a/base_transaction_id/i18n/es_MX.po
+++ b/base_transaction_id/i18n/es_MX.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-26 03:55+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (Mexico) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: es_MX\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/et.po
+++ b/base_transaction_id/i18n/et.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Estonian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Arve"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/fi.po
+++ b/base_transaction_id/i18n/fi.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Finnish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Lasku"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr "Myyntitilaus"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/fr.po
+++ b/base_transaction_id/i18n/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-30 02:44+0000\n"
-"PO-Revision-Date: 2016-06-29 06:38+0000\n"
+"POT-Creation-Date: 2016-11-03 10:40+0000\n"
+"PO-Revision-Date: 2016-11-18 10:00+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: French (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -30,7 +30,7 @@ msgstr "Facture"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr ""
+msgstr "Écriture comptable"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order

--- a/base_transaction_id/i18n/fr_CH.po
+++ b/base_transaction_id/i18n/fr_CH.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: French (Switzerland) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/fr_CH/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fr_CH\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Facture"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/gl.po
+++ b/base_transaction_id/i18n/gl.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Galician (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/hr.po
+++ b/base_transaction_id/i18n/hr.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-26 03:55+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Croatian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Račun"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr "Prodajni nalog"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/hu.po
+++ b/base_transaction_id/i18n/hu.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Hungarian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Számla"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr "Vevői megrendelés"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/id.po
+++ b/base_transaction_id/i18n/id.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Indonesian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: id\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktur"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/ja.po
+++ b/base_transaction_id/i18n/ja.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Japanese (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "請求書"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/lt.po
+++ b/base_transaction_id/i18n/lt.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/lt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: lt\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Sąskaita faktūra"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/mk.po
+++ b/base_transaction_id/i18n/mk.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Macedonian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/mk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: mk\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Фактура"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/mn.po
+++ b/base_transaction_id/i18n/mn.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Mongolian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/mn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: mn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Нэхэмжлэл"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/nb_NO.po
+++ b/base_transaction_id/i18n/nb_NO.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Norwegian Bokmål (Norway) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/nb_NO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nb_NO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Innmelding"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/nl.po
+++ b/base_transaction_id/i18n/nl.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-26 03:55+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Dutch (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Factuur"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr "Verkooporder"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/nl_BE.po
+++ b/base_transaction_id/i18n/nl_BE.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Dutch (Belgium) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/nl_BE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: nl_BE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Factuur"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/pl.po
+++ b/base_transaction_id/i18n/pl.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Polish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/pt.po
+++ b/base_transaction_id/i18n/pt.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Portuguese (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Fatura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/pt_PT.po
+++ b/base_transaction_id/i18n/pt_PT.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-12-10 01:07+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: pt_PT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Fatura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/ro.po
+++ b/base_transaction_id/i18n/ro.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Romanian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -31,12 +30,12 @@ msgstr "Factura"
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/ru.po
+++ b/base_transaction_id/i18n/ru.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Russian (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Счет"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/sk_SK.po
+++ b/base_transaction_id/i18n/sk_SK.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Slovak (Slovakia) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/sk_SK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sk_SK\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktúra"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/sv.po
+++ b/base_transaction_id/i18n/sv.po
@@ -3,19 +3,18 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Swedish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: base_transaction_id
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Faktura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/th.po
+++ b/base_transaction_id/i18n/th.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Thai (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/th/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: th\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "ใบแจ้งหนี้"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/tr.po
+++ b/base_transaction_id/i18n/tr.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Turkish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "Fatura"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/zh_CN.po
+++ b/base_transaction_id/i18n/zh_CN.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-26 03:55+0000\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "发票"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr "销售订单"
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/i18n/zh_TW.po
+++ b/base_transaction_id/i18n/zh_TW.po
@@ -3,20 +3,19 @@
 # * base_transaction_id
 # 
 # Translators:
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-reconcile (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:39+0000\n"
-"PO-Revision-Date: 2016-12-27 12:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/es/)\n"
+"PO-Revision-Date: 2016-04-26 13:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/oca/OCA-bank-statement-reconcile-9-0/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_bank_statement_line
@@ -26,17 +25,17 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_invoice
 msgid "Invoice"
-msgstr "Factura"
+msgstr "發票"
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_account_move_line
 msgid "Journal Item"
-msgstr "Apunte contable"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model,name:base_transaction_id.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: base_transaction_id
 #: model:ir.model.fields,field_description:base_transaction_id.field_account_invoice_transaction_id
@@ -57,4 +56,4 @@ msgstr ""
 #. module: base_transaction_id
 #: model:ir.model.fields,help:base_transaction_id.field_sale_order_transaction_id
 msgid "Transaction id from the financial institute"
-msgstr "Id de la transacción de la institución financiera"
+msgstr ""

--- a/base_transaction_id/models/account_bank_statement_line.py
+++ b/base_transaction_id/models/account_bank_statement_line.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2016 Yannick Vaucher (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from openerp import api, models
+from odoo import api, models
 
 
 class AccountBankStatementLine(models.Model):

--- a/base_transaction_id/models/account_bank_statement_line.py
+++ b/base_transaction_id/models/account_bank_statement_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Yannick Vaucher (Camptocamp)
+# © 2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, models
 

--- a/base_transaction_id/models/account_move.py
+++ b/base_transaction_id/models/account_move.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # © 2014 Guewen Baconnier (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from openerp import models, fields, api
-from openerp.osv import expression
+from odoo import models, fields, api
+from odoo.osv import expression
 
 
 class AccountMoveLine(models.Model):

--- a/base_transaction_id/models/invoice.py
+++ b/base_transaction_id/models/invoice.py
@@ -2,7 +2,7 @@
 # © 2011-2012 Nicolas Bessi (Camptocamp)
 # © 2012-2015 Yannick Vaucher (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from openerp import models, fields, api
+from odoo import models, fields, api
 
 
 class AccountInvoice(models.Model):

--- a/base_transaction_id/models/sale.py
+++ b/base_transaction_id/models/sale.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2011-2012 Nicolas Bessi (Camptocamp)
 # © 2012-2015 Yannick Vaucher (Camptocamp)
-from openerp import models, fields, api
+from odoo import models, fields, api
 
 
 class SaleOrder(models.Model):

--- a/base_transaction_id/views/account_move_line.xml
+++ b/base_transaction_id/views/account_move_line.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-  <data noupdate="0">
-    <record id="view_move_line_form" model="ir.ui.view">
-      <field name="name">account.move.line.form</field>
-      <field name="model">account.move.line</field>
-      <field name="inherit_id" ref="account.view_move_line_form"/>
-      <field name="arch" type="xml">
-        <xpath expr="//field[@name='reconciled']/.." position="after">
-          <field name="transaction_ref"/>
-        </xpath>
-      </field>
-    </record>
-  </data>
-</openerp>
+<odoo>
+  <record id="view_move_line_form" model="ir.ui.view">
+    <field name="name">account.move.line.form</field>
+    <field name="model">account.move.line</field>
+    <field name="inherit_id" ref="account.view_move_line_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='reconciled']/.." position="after">
+        <field name="transaction_ref"/>
+      </xpath>
+    </field>
+  </record>
+</odoo>

--- a/base_transaction_id/views/base_transaction_id.xml
+++ b/base_transaction_id/views/base_transaction_id.xml
@@ -6,4 +6,3 @@
     </xpath>
   </template>
 </odoo>
-

--- a/base_transaction_id/views/base_transaction_id.xml
+++ b/base_transaction_id/views/base_transaction_id.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-  <data>
-    <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
-      <xpath expr="." position="inside">
-        <script type="text/javascript" src="/base_transaction_id/static/src/js/account_widgets.js"></script>
-      </xpath>
-    </template>
-  </data>
-</openerp>
+<odoo>
+  <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
+    <xpath expr="." position="inside">
+      <script type="text/javascript" src="/base_transaction_id/static/src/js/account_widgets.js"></script>
+    </xpath>
+  </template>
+</odoo>
 

--- a/base_transaction_id/views/invoice.xml
+++ b/base_transaction_id/views/invoice.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-  <record model="ir.ui.view" id="invoice_form">
-    <field name="name">base_transaction_id.customer.invoice.form</field>
+  <record model="ir.ui.view" id="invoice_view_custom">
+    <field name="name">customer.invoice.transaction.inherit</field>
     <field name="model">account.invoice</field>
     <field name="inherit_id" ref="account.invoice_form"/>
     <field name="arch" type="xml">
-      <field name="origin" position="after">
+      <xpath expr="//page[@name='other_info']/group/group/field[@name='origin']" position="after">
           <field name="transaction_id"/>
-      </field>
+      </xpath>
     </field>
   </record>
 
-  <record model="ir.ui.view" id="invoice_tree">
-    <field name="name">base_transaction_id.customer.account.invoice.tree</field>
+  <record model="ir.ui.view" id="invoice_tree_custom">
+    <field name="name">account.invoice.tree_inherit</field>
     <field name="model">account.invoice</field>
     <field name="inherit_id" ref="account.invoice_tree"/>
     <field name="arch" type="xml">

--- a/base_transaction_id/views/invoice.xml
+++ b/base_transaction_id/views/invoice.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-  <data>
-    <record model="ir.ui.view" id="invoice_view_custom">
-      <field name="name">customer.invoice.transaction.inherit</field>
-      <field name="model">account.invoice</field>
-      <field name="inherit_id" ref="account.invoice_form"/>
-      <field name="arch" type="xml">
-        <field name="origin" position="after">
-            <field name="transaction_id"/>
-        </field>
-      </field>
-    </record>
+<odoo>
 
-    <record model="ir.ui.view" id="invoice_tree_custom">
-      <field name="name">account.invoice.tree.inherit</field>
-      <field name="model">account.invoice</field>
-      <field name="inherit_id" ref="account.invoice_tree"/>
-      <field name="arch" type="xml">
-        <field name="origin" position="after">
+  <record model="ir.ui.view" id="invoice_form">
+    <field name="name">base_transaction_id.customer.invoice.form</field>
+    <field name="model">account.invoice</field>
+    <field name="inherit_id" ref="account.invoice_form"/>
+    <field name="arch" type="xml">
+      <field name="origin" position="after">
           <field name="transaction_id"/>
-        </field>
       </field>
-    </record>
-  </data>
-</openerp>
+    </field>
+  </record>
+
+  <record model="ir.ui.view" id="invoice_tree">
+    <field name="name">base_transaction_id.customer.account.invoice.tree</field>
+    <field name="model">account.invoice</field>
+    <field name="inherit_id" ref="account.invoice_tree"/>
+    <field name="arch" type="xml">
+      <field name="origin" position="after">
+        <field name="transaction_id"/>
+      </field>
+    </field>
+  </record>
+
+</odoo>

--- a/base_transaction_id/views/sale.xml
+++ b/base_transaction_id/views/sale.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-  <data>
-    <record id="view_order_form_transaction" model="ir.ui.view">
-      <field name="name">sale.order.form.transaction</field>
-      <field name="model">sale.order</field>
-      <field name="inherit_id" ref="sale.view_order_form"/>
-      <field name="arch" type="xml">
-        <group name="sale_pay" position="inside">
-          <field name="transaction_id"/>
-        </group>
-      </field>
-    </record>
-  </data>
-</openerp>
+<odoo>
+
+  <record id="view_order_form" model="ir.ui.view">
+    <field name="name">base_transaction_id.sale.order.form</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form"/>
+    <field name="arch" type="xml">
+      <group name="sale_pay" position="inside">
+        <field name="transaction_id"/>
+      </group>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
This is a work in progress... it doesn't work yet, because I don't know how to port "self._fields[k]._symbol_set" to v10, cf file account_move_base_import/models/account_move.py method _prepare_insert()