### PR TITLE
[9.0] Allow for different completed refs on imported move lines

### DIFF
--- a/account_move_base_import/models/account_move.py
+++ b/account_move_base_import/models/account_move.py
@@ -236,6 +236,16 @@ class AccountMoveLine(models.Model):
         default=False,
         help="When this checkbox is ticked, the auto-completion "
         "process/button will ignore this line.")
+    ref = fields.Char(related=False, compute='_compute_move_line_ref')
+    completion_ref = fields.Char('Completion Reference', copy=False)
+
+    @api.depends('move_id.ref', 'completion_ref')
+    def _compute_move_line_ref(self):
+        for line in self:
+            if line.completion_ref:
+                line.ref = line.completion_ref
+            elif line.move_id:
+                line.ref = line.move_id.ref
 
     def _get_line_values_from_rules(self, rules):
         """We'll try to find out the values related to the line based on rules

--- a/account_move_transactionid_import/models/account_move.py
+++ b/account_move_transactionid_import/models/account_move.py
@@ -43,6 +43,9 @@ class AccountMoveCompletionRule(models.Model):
         if len(sales) == 1:
             sale = sales[0]
             res['partner_id'] = sale.partner_id.id
+            res['completion_ref'] = sale.name
+            # Since the update is done in SQL, set 'ref' as well
+            res['ref'] = sale.name
         return res
 
     def get_from_transaction_id_and_invoice(self, line):
@@ -72,4 +75,7 @@ class AccountMoveCompletionRule(models.Model):
             invoice = invoices[0]
             res['partner_id'] = invoice.commercial_partner_id.id
             res['account_id'] = invoice.account_id.id
+            res['completion_ref'] = invoice.move_id.ref
+            # Since the update is done in SQL, set 'ref' as well
+            res['ref'] = invoice.move_id.ref
         return res


### PR DESCRIPTION
Small improvement requested by a customer : in 7.0, in imported bank statement lines, the transaction ID auto-completion mechanism filled the sale order's / invoice's reference in the "ref" field, which was then used when the moves/move lines were created (allowing for the user to see if the payment for a specific SO was imported, for example).

During the migration to 9.0, since moves / move lines are imported directly, I did remove the reference (since it was unique on moves), and while technically, the reconciliation worked (since it was based on the transaction ID), but this removes the convenience for the user.

To add back this reference, I did 3 things:
- create a new field "completion_ref", not copied from line to line, which would contain the auto-completed value,
- re-factor the "ref" field on move lines from a related field to a function field (basically, overriding the related if "completion_ref" is defined),
- the transaction ID auto-completion mechanism will fill the completion_ref and the ref (since it's updated by SQL).