### PR TITLE
[9.0][BUG][account_mass_reconcile] Add test using exchange currency account

### DIFF
--- a/account_mass_reconcile/tests/test_scenario_reconcile.py
+++ b/account_mass_reconcile/tests/test_scenario_reconcile.py
@@ -229,3 +229,94 @@ class TestScenarioReconcile(common.TransactionCase):
             'paid',
             invoice.state
         )
+
+    def test_scenario_reconcile_partial_exchange_writeoff_account(self):
+        # Create Payment
+        move_vals = {
+            'journal_id': self.ref('account.bank_journal'),
+            'partner_id': self.ref('base.res_partner_12'),
+            'name': 'Payment Test',
+            'ref': 'Payment Test',
+            'date': fields.Date.today(),
+            'line_ids': [
+                (0, 0, {
+                    'name': 'Payment Test',
+                    'debit': 500,
+                    'credit': 0,
+                    'account_id': self.ref('account.a_sale')}),
+                (0, 0, {
+                    'name': 'Payment Test',
+                    'debit': 0,
+                    'credit': 500,
+                    'account_id': self.ref('account.a_recv')})
+                ]}
+        move = self.env['account.move'].create(move_vals)
+        move.post()
+        line_payment = move.line_ids.filtered(
+            lambda l: l.account_id.id == self.ref('account.a_recv'))
+        self.assertEqual(
+            line_payment.reconciled,
+            False
+        )
+
+        invoice1 = self.invoice_obj.create(
+            {
+                'type': 'out_invoice',
+                'account_id': self.ref('account.a_recv'),
+                'company_id': self.ref('base.main_company'),
+                'journal_id': self.ref('account.sales_journal'),
+                'partner_id': self.ref('base.res_partner_12'),
+                'reference': 'Payment Test',
+                'invoice_line_ids': [
+                    (0, 0, {
+                        'name': '[PCSC234] PC Assemble SC234',
+                        'account_id': self.ref('account.a_sale'),
+                        'price_unit': 45,
+                        'quantity': 1.0,
+                        'product_id': self.ref('product.product_product_3'),
+                    }
+                    )
+                ]
+            }
+        )
+        # validate invoice
+        invoice1.signal_workflow('invoice_open')
+        invoice1_line = invoice1.move_id.line_ids.filtered(
+            lambda l: l.account_id.id == self.ref('account.a_recv'))
+        self.assertEqual(
+            invoice1_line.reconciled,
+            False
+        )
+
+        # Create the mass reconcile record
+        reconcile_method_vals = {
+            'name': 'mass.reconcile.advanced.ref',
+            'write_off': 0.1,
+            'account_lost_id': self.ref('account.income_fx_expense'),
+            'account_profit_id': self.ref('account.income_fx_expense'),
+            'income_exchange_account_id': self.ref(
+                'account.income_fx_expense'),
+            'expense_exchange_account_id': self.ref(
+                'account.income_fx_expense'),
+            'journal_id': self.ref('account.miscellaneous_journal'),
+        }
+        mass_rec = self.mass_rec_obj.create({
+            'name': 'mass_reconcile_1',
+            'account': self.ref('account.a_recv'),
+            'reconcile_method': [
+                (0, 0, reconcile_method_vals)
+            ]
+        })
+        mass_rec.run_reconcile()
+
+        invoice1_line = invoice1.move_id.line_ids.filtered(
+            lambda l: l.account_id.id == self.ref('account.a_recv'))
+
+        self.assertEqual(
+            line_payment.amount_residual,
+            -455.0
+        )
+        self.assertEqual(
+            invoice1_line.reconciled,
+            True
+        )


### PR DESCRIPTION
Here I just added tests to show a bug.
I am not really confortable with the exchange rate reconciliation part, but the test show the bug, maybe someone has an idea to fix the problem.

The case is quite simple, if we configure an advance reconcile method with profit/lost write off account id and also profit/lost exchange account_id, the reconciliation will fail for very simple cases.

The test show this example : 
write off limit : 0.1
1 payment : 500
One invoice : 45

The reconciliation make a write off with amount = 455 !
Of course, we should not have write off journal entry on this case, and we should not have a full reconciliation, as it is the case for now.


For a start, maybe we could allow the user to configure if he does want partial reconciliation or not on the reconciliation method?
If he choose not doing partial reconciliation, at least he avoid all problems...


Any help on this is appreciated. I have no customer using these exchange account on automatic reconciliation, so no problem for now, but I guess other could have this bug...