### PR TITLE
[9.0] Use correct order if cron only does one reconcile at a time

### DIFF
--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -301,7 +301,7 @@ class AccountMassReconcile(models.Model):
         if run_all:
             reconciles.run_reconcile()
             return True
-        reconciles.sorted(key=_get_date)
-        older = reconciles[0]
+        ordered_reconciles = reconciles.sorted(key=_get_date)
+        older = ordered_reconciles[:1]
         older.run_reconcile()
         return True


### PR DESCRIPTION
Pretty much a straight-forward PR: `sorted` was used on a set to get the oldest reconcile method in `run_scheduler`, but since it's not assigned, the set remained in the same order and only 1 method was ever used in the cron job.