### PR TITLE
[9.0] correcty use temporary cursor in reconcile method

### DIFF
--- a/account_mass_reconcile/models/base_advanced_reconciliation.py
+++ b/account_mass_reconcile/models/base_advanced_reconciliation.py
@@ -262,7 +262,7 @@ class MassReconcileAdvanced(models.AbstractModel):
             if reconciled and full:
                 reconciled_ids += reconcile_group_ids
 
-            if (self.env.context['commit_every'] and
+            if (self.env.context.get('commit_every') and
                     group_count % self.env.context['commit_every'] == 0):
                 self.env.cr.commit()
                 _logger.info("Commit the reconciliations after %d groups",

--- a/account_mass_reconcile/models/base_advanced_reconciliation.py
+++ b/account_mass_reconcile/models/base_advanced_reconciliation.py
@@ -223,54 +223,49 @@ class MassReconcileAdvanced(models.AbstractModel):
     def _rec_auto_lines_advanced(self, credit_lines, debit_lines):
         """ Advanced reconciliation main loop """
         reconciled_ids = []
-        for rec in self:
-            reconcile_groups = []
-            ctx = self.env.context.copy()
-            ctx['commit_every'] = (
-                rec.account_id.company_id.reconciliation_commit_every
-            )
-            _logger.info("%d credit lines to reconcile", len(credit_lines))
-            for idx, credit_line in enumerate(credit_lines, start=1):
-                if idx % 50 == 0:
-                    _logger.info("... %d/%d credit lines inspected ...", idx,
-                                 len(credit_lines))
-                if self._skip_line(credit_line):
-                    continue
-                opposite_lines = self._search_opposites(credit_line,
-                                                        debit_lines)
-                if not opposite_lines:
-                    continue
-                opposite_ids = [l['id'] for l in opposite_lines]
-                line_ids = opposite_ids + [credit_line['id']]
-                for group in reconcile_groups:
-                    if any([lid in group for lid in opposite_ids]):
-                        _logger.debug("New lines %s matched with an existing "
-                                      "group %s", line_ids, group)
-                        group.update(line_ids)
-                        break
-                else:
-                    _logger.debug("New group of lines matched %s", line_ids)
-                    reconcile_groups.append(set(line_ids))
-            lines_by_id = dict([(l['id'], l)
-                                for l in credit_lines + debit_lines])
-            _logger.info("Found %d groups to reconcile",
-                         len(reconcile_groups))
-            for group_count, reconcile_group_ids \
-                    in enumerate(reconcile_groups, start=1):
-                _logger.debug("Reconciling group %d/%d with ids %s",
-                              group_count, len(reconcile_groups),
-                              reconcile_group_ids)
-                group_lines = [lines_by_id[lid]
-                               for lid in reconcile_group_ids]
-                reconciled, full = self._reconcile_lines(group_lines,
-                                                         allow_partial=True)
-                if reconciled and full:
-                    reconciled_ids += reconcile_group_ids
+        reconcile_groups = []
+        _logger.info("%d credit lines to reconcile", len(credit_lines))
+        for idx, credit_line in enumerate(credit_lines, start=1):
+            if idx % 50 == 0:
+                _logger.info("... %d/%d credit lines inspected ...", idx,
+                             len(credit_lines))
+            if self._skip_line(credit_line):
+                continue
+            opposite_lines = self._search_opposites(credit_line,
+                                                    debit_lines)
+            if not opposite_lines:
+                continue
+            opposite_ids = [l['id'] for l in opposite_lines]
+            line_ids = opposite_ids + [credit_line['id']]
+            for group in reconcile_groups:
+                if any([lid in group for lid in opposite_ids]):
+                    _logger.debug("New lines %s matched with an existing "
+                                  "group %s", line_ids, group)
+                    group.update(line_ids)
+                    break
+            else:
+                _logger.debug("New group of lines matched %s", line_ids)
+                reconcile_groups.append(set(line_ids))
+        lines_by_id = dict([(l['id'], l)
+                            for l in credit_lines + debit_lines])
+        _logger.info("Found %d groups to reconcile",
+                     len(reconcile_groups))
+        for group_count, reconcile_group_ids \
+                in enumerate(reconcile_groups, start=1):
+            _logger.debug("Reconciling group %d/%d with ids %s",
+                          group_count, len(reconcile_groups),
+                          reconcile_group_ids)
+            group_lines = [lines_by_id[lid]
+                           for lid in reconcile_group_ids]
+            reconciled, full = self._reconcile_lines(group_lines,
+                                                     allow_partial=True)
+            if reconciled and full:
+                reconciled_ids += reconcile_group_ids
 
-                if (ctx['commit_every'] and
-                        group_count % ctx['commit_every'] == 0):
-                    self.env.cr.commit()
-                    _logger.info("Commit the reconciliations after %d groups",
-                                 group_count)
-            _logger.info("Reconciliation is over")
+            if (self.env.context['commit_every'] and
+                    group_count % self.env.context['commit_every'] == 0):
+                self.env.cr.commit()
+                _logger.info("Commit the reconciliations after %d groups",
+                             group_count)
+        _logger.info("Reconciliation is over")
         return reconciled_ids

--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -4,11 +4,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime
-from openerp import models, api, fields, _
+from openerp import models, api, fields, exceptions, _
 from openerp.exceptions import Warning as UserError
 from openerp import sql_db
 
+import psycopg2
 import logging
+
 _logger = logging.getLogger(__name__)
 
 
@@ -174,25 +176,37 @@ class AccountMassReconcile(models.Model):
         # often. We have to create it here and not later to avoid problems
         # where the new cursor sees the lines as reconciles but the old one
         # does not.
-
         for rec in self:
+            # SELECT FOR UPDATE the mass reconcile row ; this is done in order
+            # to avoid 2 processes on the same mass reconcile method.
+            try:
+                self.env.cr.execute('SELECT id FROM account_mass_reconcile'
+                                    ' WHERE id = %s'
+                                    ' FOR UPDATE NOWAIT', (rec.id,))
+            except psycopg2.OperationalError:
+                raise exceptions.UserError(
+                    'A mass reconcile is already ongoing for this account, '
+                    'please try again later.')
+
             ctx = self.env.context.copy()
             ctx['commit_every'] = (
                 rec.account.company_id.reconciliation_commit_every
             )
             if ctx['commit_every']:
                 new_cr = sql_db.db_connect(self.env.cr.dbname).cursor()
+                new_env = api.Environment(new_cr, self.env.uid, ctx)
             else:
                 new_cr = self.env.cr
+                new_env = self.env
 
             try:
                 all_ml_rec_ids = []
 
                 for method in rec.reconcile_method:
-                    rec_model = self.env[method.name]
+                    rec_model = self.with_env(new_env).env[method.name]
                     auto_rec_id = rec_model.create(
                         self._prepare_run_transient(method)
-                        )
+                    )
 
                     ml_rec_ids = auto_rec_id.automatic_reconcile()
 


### PR DESCRIPTION
We had some concurrency issues with mass reconcile. After checking, here are my fixes:
* if a temporary new cursor is created, use it (with the context) for reconciliation (this way, we avoid releasing the lock on the cron),
* remove `ctx['commit_every']` from `_rec_auto_lines_advanced` (since it's defined in `run_reconcile`),
* add a `SELECT FOR UPDATE` to lock the current mass reconcile (useful to avoid processing the same account in 2 concurrent processes)