### PR TITLE
[10.0] [IMP] base_transaction_id: Add transaction_id on account.payment

### DIFF
--- a/base_transaction_id/__manifest__.py
+++ b/base_transaction_id/__manifest__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*
+# -*- coding: utf-8 -*-
 # © 2012 Yannick Vaucher, Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Base transaction id for financial institutes',
@@ -8,9 +8,11 @@
  'category': 'Hidden/Dependency',
  'depends': [
      'sale',
+     'account',
  ],
  'website': 'https://www.odoo-community.org/',
  'data': [
+     'views/account_payment.xml',
      'views/invoice.xml',
      'views/sale.xml',
      'views/account_move_line.xml',

--- a/base_transaction_id/models/__init__.py
+++ b/base_transaction_id/models/__init__.py
@@ -5,3 +5,4 @@ from . import invoice
 from . import sale
 from . import account_move
 from . import account_bank_statement_line
+from . import account_payment

--- a/base_transaction_id/models/account_payment.py
+++ b/base_transaction_id/models/account_payment.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountPayment(models.Model):
+
+    _inherit = 'account.payment'
+
+    transaction_id = fields.Char(
+        'Transaction ID',
+        required=False,
+        copy=False,
+        help="Transaction id from the financial institute"
+    )
+
+    @api.multi
+    def _get_liquidity_move_line_vals(self, amount):
+        self.ensure_one()
+        vals = super(AccountPayment, self)._get_liquidity_move_line_vals(
+            amount)
+        if self.transaction_id:
+            vals['name'] = self.transaction_id
+        return vals

--- a/base_transaction_id/models/account_payment.py
+++ b/base_transaction_id/models/account_payment.py
@@ -16,6 +16,8 @@ class AccountPayment(models.Model):
         help="Transaction id from the financial institute"
     )
 
+    invoice_ids = fields.Many2many(inverse='_inverse_invoice_ids')
+
     @api.multi
     def _get_liquidity_move_line_vals(self, amount):
         self.ensure_one()
@@ -23,4 +25,13 @@ class AccountPayment(models.Model):
             amount)
         if self.transaction_id:
             vals['name'] = self.transaction_id
+            vals['transaction_ref'] = self.transaction_id
         return vals
+
+    @api.multi
+    def _inverse_invoice_ids(self):
+        for rec in self:
+            invoices = rec.invoice_ids.filtered(lambda x: x.transaction_id)
+            if not rec.transaction_id and invoices:
+                rec.transaction_id = ", ".join(invoices.mapped(
+                    'transaction_id'))

--- a/base_transaction_id/static/src/js/account_widgets.js
+++ b/base_transaction_id/static/src/js/account_widgets.js
@@ -8,7 +8,7 @@ odoo.define('base_transaction_id.base_transaction_id', function (require) {
             if (line.transaction_ref) {
                 line.q_label += ' (' + line.transaction_ref + ')';
             }
-        },
+        }
     });
 
 });

--- a/base_transaction_id/tests/__init__.py
+++ b/base_transaction_id/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_account_payment

--- a/base_transaction_id/tests/test_account_payment.py
+++ b/base_transaction_id/tests/test_account_payment.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+
+
+class TestAccountPayment(common.TransactionCase):
+
+    def test_transaction_id_on_move_line(self):
+        account_payment = self.env['account.payment'].new({
+            'name': 'payment_name'
+        })
+        vals = account_payment._get_liquidity_move_line_vals(10)
+        self.assertEqual(
+            vals.get('name'),
+            'payment_name',
+            'The name of the move line is the name of the payment if no '
+            'transaction_id is specified on the payment')
+        account_payment.transaction_id = 'transaction id'
+        vals = account_payment._get_liquidity_move_line_vals(10)
+        self.assertEqual(
+            vals.get('name'),
+            'transaction id',
+            'The name of the move line is the transaction if of the payment '
+            'if specified on the payment')

--- a/base_transaction_id/tests/test_account_payment.py
+++ b/base_transaction_id/tests/test_account_payment.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import odoo.tests.common as common
+from odoo import fields
 
 
 class TestAccountPayment(common.TransactionCase):
@@ -24,3 +25,66 @@ class TestAccountPayment(common.TransactionCase):
             'transaction id',
             'The name of the move line is the transaction if of the payment '
             'if specified on the payment')
+        self.assertEqual(
+            vals.get('transaction_ref'),
+            'transaction id',
+            'The transaction reference of the move line is the transaction if '
+            'of the payment '
+            'if specified on the payment')
+
+    def test_transaction_id_from_invoice(self):
+        transaction_ref = '1234568787'
+        tax = self.env['account.tax'].create({
+            'name': 'Tax 10.0',
+            'amount': 10.0,
+            'amount_type': 'fixed',
+        })
+
+        # Should be changed by automatic on_change later
+        invoice_account = self.env['account.account'].search(
+            [('user_type_id', '=',
+              self.env.ref('account.data_account_type_receivable').id)],
+            limit=1).id
+        invoice_line_account = self.env['account.account'].search(
+            [('user_type_id', '=',
+              self.env.ref('account.data_account_type_expenses').id)],
+            limit=1).id
+
+        invoice = self.env['account.invoice'].create(
+            {'partner_id': self.env.ref('base.res_partner_2').id,
+             'account_id': invoice_account,
+             'type': 'out_invoice',
+             'transaction_id': transaction_ref})
+
+        self.env['account.invoice.line'].create(
+            {'product_id': self.env.ref('product.product_product_4').id,
+             'quantity': 1.0,
+             'price_unit': 100.0,
+             'invoice_id': invoice.id,
+             'name': 'product that cost 100',
+             'account_id': invoice_line_account,
+             'invoice_line_tax_ids': [(6, 0, [tax.id])]})
+
+        # change the state of invoice to open by clicking Validate button
+        invoice.action_invoice_open()
+
+        journal = self.env['account.journal'].search([('type', '=', 'bank')],
+                                                     limit=1)
+        payment = self.env['account.payment'].create({
+            'invoice_ids': [(6, 0, invoice.ids)],
+            'amount': invoice.residual,
+            'payment_date': fields.Date.today(),
+            'communication': invoice.reference or invoice.number,
+            'partner_id': invoice.partner_id.id,
+            'partner_type': 'customer',
+            'journal_id': journal.id,
+            'payment_method_id': self.env.ref(
+                'account.account_payment_method_manual_in').id,
+            'payment_type': 'inbound'})
+        payment.post()
+
+        self.assertEqual(invoice.state, 'paid')
+
+        move_line = invoice.payment_ids.move_line_ids.filtered(
+            lambda x: x.account_id.internal_type == 'liquidity')
+        self.assertEqual(move_line.transaction_ref, transaction_ref)

--- a/base_transaction_id/views/account_payment.xml
+++ b/base_transaction_id/views/account_payment.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="account_payment_form_view">
+        <field name="name">account.payment.form (in base_transaction_id)</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+            <field name="payment_date" position="after">
+                <field name="transaction_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="account_payment_tree_view">
+        <field name="name">account.payment.tree (in base_transaction_id)</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_supplier_payment_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="transaction_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="account_payment_search_view">
+        <field name="name">account.payment.search (in base_transaction_id)</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_search"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="transaction_id"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This change is required to ease the reconciliation of the account.move
created from the account.payment.
- [ ] required by https://github.com/OCA/sale-workflow/pull/526