### PR TITLE
[9.0][account_move_base_import] Make commission line feature generic for all parsers

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -130,17 +130,22 @@ class AccountJournal(models.Model):
         move_line_obj = self.env['account.move.line']
         refund = 0.0
         payment = 0.0
+        commission = 0.0
         transfer_lines = []
         for move_line in move.line_ids:
-            refund -= move_line.debit
-            payment += move_line.credit
+            if move_line.account_id == self.commission_account_id and \
+                    move_line.already_completed:
+                commission -= move_line.debit
+            else:
+                refund -= move_line.debit
+                payment += move_line.credit
         if self.split_counterpart:
             if refund:
                 transfer_lines.append(refund)
             if payment:
-                transfer_lines.append(payment)
+                transfer_lines.append(payment+commission)
         else:
-            total_amount = refund + payment
+            total_amount = refund + payment + commission
             if total_amount:
                 transfer_lines.append(total_amount)
         counterpart_date = parser.get_move_vals().get('date') or \
@@ -173,9 +178,14 @@ class AccountJournal(models.Model):
         """
         move_line_obj = self.env['account.move.line']
         global_commission_amount = 0
-        for row in parser.result_row_list:
-            global_commission_amount += float(
-                row.get('commission_amount', '0.0'))
+        commmission_field = parser.commission_field
+        if commmission_field:
+            for row in parser.result_row_list:
+                global_commission_amount += float(
+                    row.get(commmission_field, '0.0'))
+            # If commission amount is positive in field, inverse the sign
+            if parser.commission_sign == '+':
+                global_commission_amount = -global_commission_amount
         partner_id = self.partner_id.id
         # Commission line
         if global_commission_amount > 0.0:

--- a/account_move_base_import/parser/generic_file_parser.py
+++ b/account_move_base_import/parser/generic_file_parser.py
@@ -31,6 +31,8 @@ class GenericFileParser(FileParser):
             journal, ftype=ftype,
             extra_fields=conversion_dict,
             **kwargs)
+        self.commission_field = 'commission_amount'
+        self.commission_sign = '-'
 
     @classmethod
     def parser_for(cls, parser_name):

--- a/account_move_base_import/parser/parser.py
+++ b/account_move_base_import/parser/parser.py
@@ -49,6 +49,8 @@ class AccountMoveImportParser(object):
         self.move_name = None
         self.move_ref = None
         self.support_multi_moves = None
+        self.commission_field = None
+        self.commission_sign = '+'
 
     @classmethod
     def parser_for(cls, parser_name):

--- a/account_move_transactionid_import/parser/transactionid_file_parser.py
+++ b/account_move_transactionid_import/parser/transactionid_file_parser.py
@@ -33,6 +33,8 @@ class TransactionIDFileParser(FileParser):
         super(TransactionIDFileParser, self).__init__(
             profile, extra_fields=conversion_dict, ftype=ftype, header=header,
             **kwargs)
+        self.commission_field = 'commission_amount'
+        self.commission_sign = '-'
 
     @classmethod
     def parser_for(cls, parser_name):


### PR DESCRIPTION
I noticed that thecommission feature of the module account_move_base_import was only compatible the generec parser (`generic_csvxls_so`) because the name of the column from the file is hardcoded `commission_amount`

Also, I saw that the commission feature is not compatible with the `split_counterpart` counterpart option.
This PR aims to fix these 2 issues