### PR TITLE
[10.0] add filter for filtering the uncompleted move line that should be completed manually

### DIFF
--- a/account_move_base_import/views/account_move_view.xml
+++ b/account_move_base_import/views/account_move_view.xml
@@ -64,4 +64,22 @@
 
     <menuitem string="Move Completion Rule" action="action_move_completion_rule_tree"
               id="menu_action_move_completion_rule_tree_menu" parent="account.account_management_menu"/>
+
+    <record id="view_account_move_filter" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_account_move_filter"/>
+        <field name="arch" type="xml">
+            <separator position="after">
+                <filter
+                    string="To Complete"
+                    domain="[
+                        ('state','!=','posted'),
+                        ('journal_id.used_for_completion', '=', True),
+                        ('line_ids.already_completed', '=', False)]"
+                    help="Account move that should be completed manually"/>
+                <separator/>
+            </separator>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
The base module already give the posibiltity to autocomplete automatically the move line.
When you import the move line automatically (stripe, amazon, bank...) the autocompletion can be configurated to be done automatically, but it's hard to see which move are not full completed.

This change add a new filter to see all move that are not full completed

![image](https://user-images.githubusercontent.com/1164578/33843198-fcc6a550-de9c-11e7-94a5-62bbe897f4a9.png)

