### PR TITLE
[10.0] FIX missing date field, it's a related field and should be added automatically with the same value of the move date

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -233,6 +233,7 @@ class AccountJournal(models.Model):
         values['company_currency_id'] = self.company_id.currency_id.id
         values['journal_id'] = self.id
         values['move_id'] = move.id
+        values['date'] = move.date
         if not values.get('account_id', False):
             values['account_id'] = self.receivable_account_id.id
         values = move_line_obj._add_missing_default_values(values)


### PR DESCRIPTION
When importing with the base module the date on the account_move_line are empty by default.
As the field date is a related to the move.date it should be filled with the same value

edit: I have also added other extra field that were missing tooo