### PR TITLE
[10.0]base_transaction_id: reconciliation process should not be restricted to payable and receivable accounts

### DIFF
--- a/base_transaction_id/models/account_bank_statement_line.py
+++ b/base_transaction_id/models/account_bank_statement_line.py
@@ -12,13 +12,9 @@ class AccountBankStatementLine(models.Model):
     def get_reconciliation_proposition(self, excluded_ids=None):
         """ Look for transaction_ref to give them as proposition move line """
         if self.name:
-            # If the transaction has no partner, look for match in payable and
-            # receivable account anyway
-            overlook_partner = not self.partner_id
             domain = [('transaction_ref', 'ilike', self.name)]
             match_recs = self.get_move_lines_for_reconciliation(
-                excluded_ids=excluded_ids, limit=2, additional_domain=domain,
-                overlook_partner=overlook_partner)
+                excluded_ids=excluded_ids, limit=2, additional_domain=domain)
             if match_recs and len(match_recs) == 1:
                 return match_recs
         _super = super(AccountBankStatementLine, self)


### PR DESCRIPTION
My customer wants to 2 reconcile 2 bank accounts.

- one account to pay the invoice or pos_order
- the other one wen he gets back the money for the payment platform

Whe he imports the bank statement, he would like to reconcile the first one with the second one.
