### PR TITLE
[FIX] fix default order for simple reconciliation

### DIFF
--- a/account_mass_reconcile/models/simple_reconciliation.py
+++ b/account_mass_reconcile/models/simple_reconciliation.py
@@ -48,7 +48,9 @@ class MassReconcileSimple(models.AbstractModel):
 
     @api.multi
     def _simple_order(self, *args, **kwargs):
-        return "ORDER BY account_move_line.%s" % self._key_field
+        return (
+            "ORDER BY account_move_line.%s, "
+            "account_move_line.date asc") % self._key_field
 
     @api.multi
     def _action_rec(self):


### PR DESCRIPTION
Hi, this is a small fix that improve the result of automatic reconciliation.

Indeed in case you have a lot of existing move line unreconciled with the same amount, and you reconcile based on "amount and partner" the system can reconcile old invoice with new payment.
With that fix this problem is really reduce as the reconcilliation will be done on ordered line on the date.

@guewen 