### PR TITLE
account_reconcile_switchon is a proposal for solving issue #215

### DIFF
--- a/account_reconcile_switchon/README.rst
+++ b/account_reconcile_switchon/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+Account Switch On Reconcile
+===========================
+
+This module .
+
+
+Configuration
+=============
+
+No configuration
+
+Usage
+=====
+
+Just set reconcile flag to True
+
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-closing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Willem Hulshof <w.hulshof@magnus.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_reconcile_switchon/__init__.py
+++ b/account_reconcile_switchon/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_reconcile_switchon/__manifest__.py
+++ b/account_reconcile_switchon/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# © 2018 Magnus (Willem Hulshof <w.hulshof@magnus.nl>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Account Switch On Reconcile',
+    'version': '10.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'license': 'AGPL-3',
+    'summary': 'Make switching on reconcile for account with lines possible',
+    'author': 'Magnus',
+    'website': 'http://www.magnus.nl',
+    'depends': [
+        'account',
+        ],
+    'data': [
+    ],
+    'images': [
+        ],
+    'installable': True,
+}

--- a/account_reconcile_switchon/__manifest__.py
+++ b/account_reconcile_switchon/__manifest__.py
@@ -9,7 +9,8 @@
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Make switching on reconcile for account with lines possible',
-    'author': 'Magnus',
+    'author': 'Magnus'
+              "Odoo Community Association (OCA)",
     'website': 'http://www.magnus.nl',
     'depends': [
         'account',

--- a/account_reconcile_switchon/__manifest__.py
+++ b/account_reconcile_switchon/__manifest__.py
@@ -9,7 +9,7 @@
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Make switching on reconcile for account with lines possible',
-    'author': 'Magnus'
+    'author': 'Magnus,'
               "Odoo Community Association (OCA)",
     'website': 'http://www.magnus.nl',
     'depends': [

--- a/account_reconcile_switchon/models/__init__.py
+++ b/account_reconcile_switchon/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import account

--- a/account_reconcile_switchon/models/account.py
+++ b/account_reconcile_switchon/models/account.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+
+from odoo.exceptions import UserError, ValidationError
+from odoo import api, fields, models, _
+
+
+#----------------------------------------------------------
+# Accounts
+#----------------------------------------------------------
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+
+
+    @api.multi
+    def write(self, vals):
+        accounts = []
+        aml = self.env['account.move.line']
+        for account in self:
+            # we check if the write tries to set reconcile to true and there are move lines with this account, but not
+            # yet reconciled, because then the computation becomes a lot more difficult. We fill the accounts list and
+            # remove the "reconcile" key from the vals dict so it will not stumble upon the original write.
+            if vals.get('reconcile') \
+                     and not account.reconcile \
+                     and not len(aml.search([('account_id','=', account.id),('reconciled','=', True)], limit=1)) \
+                     and len(aml.search([('account_id','=', account.id)], limit=1)):
+                accounts.append(account.id)
+                vals.pop('reconcile')
+            # in the case, that there are already reconciled lines, a user error is displayed
+            elif vals.get('reconcile') \
+                     and len(aml.search([('account_id', '=', account.id), ('reconciled', '=', True)], limit=1)):
+                raise UserError(_('You cannot switch reconciliation on on this account as it already has reconciled moves'
+                                  'it must have been switched off before. Now you will have to create a new account'))
+            # not sure if this is still necessary. In the original write unsetting was allowed and we take care, that
+            # with reconciled move lines but switched off, it cannot be set again. Maybe we should allow to unset it.
+            elif vals.get('reconcile') == False \
+                     and account.reconcile\
+                     and len(self.env['account.move.line'].search([('account_id', '=', account.id),('reconciled','=', True)], limit=1)):
+                raise UserError(_('You cannot switch reconciliation off on this account as it already has reconciled moves'))
+        if accounts != []:
+            self.set_reconcile_true(accounts)
+        return super(AccountAccount, self).write(vals)
+
+    @api.multi
+    def set_reconcile_true(self, ids):
+        for account in self.env['account.account'].search([('id','in',ids)]):
+            if account.reconcile:
+                raise UserError(_('You are trying to switch on reconciliation on %s %s %s, that already has reconcile True') %
+                                (account.code, account.name, account.company_id.name))
+        str_lst = ','.join([str(item) for item in ids])
+
+        # UPDATE query to compute residual amounts
+        sql_aml = ("""UPDATE account_move_line
+                    SET 
+                    reconciled = false,
+                    amount_residual = debit - credit,
+                    amount_residual_currency = CASE 
+                                                WHEN amount_currency > 0 
+                                                AND currency_id IS NOT NULL 
+                                                THEN amount_currency 
+                                                ELSE 0 
+                                               END
+                    {0};""".format(
+                    "WHERE account_id in (%s)" % str_lst
+                    ))
+        self.env.cr.execute(sql_aml)
+
+        # UPDATE query to set reconcile = true in account_account
+        sql_account = ("""UPDATE account_account
+                    SET 
+                    reconcile = true
+                    {0};""".format(
+                    "WHERE id in (%s)" % str_lst
+                    ))
+        self.env.cr.execute(sql_account)

--- a/account_reconcile_switchon/models/account.py
+++ b/account_reconcile_switchon/models/account.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 
 
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo import api, fields, models, _
 
 
-#----------------------------------------------------------
+# ----------------------------------------------------------
 # Accounts
-#----------------------------------------------------------
+# ----------------------------------------------------------
 
 
 class AccountAccount(models.Model):
     _inherit = "account.account"
-
-
 
     @api.multi
     def write(self, vals):
@@ -24,31 +22,39 @@ class AccountAccount(models.Model):
             # yet reconciled, because then the computation becomes a lot more difficult. We fill the accounts list and
             # remove the "reconcile" key from the vals dict so it will not stumble upon the original write.
             if vals.get('reconcile') \
-                     and not account.reconcile \
-                     and not len(aml.search([('account_id','=', account.id),('reconciled','=', True)], limit=1)) \
-                     and len(aml.search([('account_id','=', account.id)], limit=1)):
-                accounts.append(account.id)
-                vals.pop('reconcile')
+                and not account.reconcile \
+                and not len(aml.search([('account_id', '=', account.id),'|', ('reconciled', '=', True),
+                                        '|',('matched_debit_ids', '!=', []),
+                                        ('matched_credit_ids', '!=', [])], limit=1)) \
+                and len(aml.search([('account_id', '=', account.id)], limit=1)):
+                    accounts.append(account.id)
+                    vals.pop('reconcile')
             # in the case, that there are already reconciled lines, a user error is displayed
             elif vals.get('reconcile') \
-                     and len(aml.search([('account_id', '=', account.id), ('reconciled', '=', True)], limit=1)):
-                raise UserError(_('You cannot switch reconciliation on on this account as it already has reconciled move lines'
-                                  'it must have been switched off before. Now you will have to create a new account'))
+                and len(aml.search([('account_id', '=', account.id),'|', ('reconciled', '=', True),
+                                                               '|',('matched_debit_ids', '!=', []),
+                                                                ('matched_credit_ids', '!=', [])], limit=1)):
+                    raise UserError(_('You cannot switch reconciliation on on this account'
+                                  ' as it already has reconciled move lines it must have been switched off before.'
+                                  ' Now you will have to create a new account'))
             # not sure if this is still necessary. In the original write unsetting was allowed and we take care, that
             # with reconciled move lines but switched off, it cannot be set again. Maybe we should allow to unset it.
-            elif vals.get('reconcile') == False \
-                     and account.reconcile\
-                     and len(self.env['account.move.line'].search([('account_id', '=', account.id),('reconciled','=', True)], limit=1)):
-                raise UserError(_('You cannot switch reconciliation off on this account as it already has reconciled moves'))
-        if accounts != []:
+            elif not vals.get('reconcile') \
+                and account.reconcile\
+                and len(self.env['account.move.line'].search([('account_id', '=', account.id),
+                                                              ('reconciled', '=', True)], limit=1)):
+                    raise UserError(_('You cannot switch reconciliation off on this account '
+                                      'as it already has reconciled moves'))
+        if accounts:
             self.set_reconcile_true(accounts)
         return super(AccountAccount, self).write(vals)
 
     @api.multi
     def set_reconcile_true(self, ids):
-        for account in self.env['account.account'].search([('id','in',ids)]):
+        for account in self.env['account.account'].search([('id', 'in', ids)]):
             if account.reconcile:
-                raise UserError(_('You are trying to switch on reconciliation on %s %s %s, that already has reconcile True') %
+                raise UserError(_('You are trying to switch on reconciliation on %s %s %s, '
+                                  'that already has reconcile True') %
                                 (account.code, account.name, account.company_id.name))
         str_lst = ','.join([str(item) for item in ids])
 
@@ -63,16 +69,14 @@ class AccountAccount(models.Model):
                                                 THEN amount_currency 
                                                 ELSE 0 
                                                END
-                    {0};""".format(
-                    "WHERE account_id in (%s)" % str_lst
-                    ))
-        self.env.cr.execute(sql_aml)
+                    WHERE account_id in (%s);""")
+
+        self.env.cr.execute(sql_aml, str_lst)
 
         # UPDATE query to set reconcile = true in account_account
         sql_account = ("""UPDATE account_account
                     SET 
                     reconcile = true
-                    {0};""".format(
-                    "WHERE id in (%s)" % str_lst
-                    ))
-        self.env.cr.execute(sql_account)
+                    WHERE id in (%s);""")
+
+        self.env.cr.execute(sql_account, str_lst)

--- a/account_reconcile_switchon/models/account.py
+++ b/account_reconcile_switchon/models/account.py
@@ -32,7 +32,7 @@ class AccountAccount(models.Model):
             # in the case, that there are already reconciled lines, a user error is displayed
             elif vals.get('reconcile') \
                      and len(aml.search([('account_id', '=', account.id), ('reconciled', '=', True)], limit=1)):
-                raise UserError(_('You cannot switch reconciliation on on this account as it already has reconciled moves'
+                raise UserError(_('You cannot switch reconciliation on on this account as it already has reconciled move lines'
                                   'it must have been switched off before. Now you will have to create a new account'))
             # not sure if this is still necessary. In the original write unsetting was allowed and we take care, that
             # with reconciled move lines but switched off, it cannot be set again. Maybe we should allow to unset it.


### PR DESCRIPTION
In standard Odoo, one can not set the reconcile flag in an account if there are already move lines with the account, because the computation of residual_amounts would be too expensive.
If the account was never set to reconcile, the computation is quite simple and the update can be done with sql very fast. If it was set to reconcile before and was unset after that, we show a User error. But assuming finance users do not make a habit of toggling reconcile on and off, this should be an improvement for the finance department.
Have a look.

(first did this PR in account-financial-tools, which obviously is not the best choice.)