### PR TITLE
[11.0][FIX] base_transaction_id (fix migration)

### DIFF
--- a/base_transaction_id/models/account_move.py
+++ b/base_transaction_id/models/account_move.py
@@ -33,12 +33,11 @@ class AccountMoveLine(models.Model):
         return prepared_lines
 
     @api.model
-    def domain_move_lines_for_reconciliation(self, excluded_ids=None,
-                                             str=False):
+    def domain_move_lines_for_reconciliation(self, str=False):
         """Add transaction_ref in search of move lines."""
         _super = super(AccountMoveLine, self)
         _get_domain = _super.domain_move_lines_for_reconciliation
-        domain = _get_domain(excluded_ids=excluded_ids, str=str)
+        domain = _get_domain(str=str)
         if not str and str != '/':
             return domain
         domain_trans_ref = [('transaction_ref', 'ilike', str)]


### PR DESCRIPTION
On the code core Odoo, the argument `excluded_ids` have been deleted in the function `domain_move_lines_for_reconciliation`:
https://github.com/odoo/odoo/blob/11.0/addons/account/models/account_move.py#L696

The migration to V11 have let the argument in the module `base_transaction_id`.

That PR fix this problem.