### PR TITLE
[9.0][imp][account_mass_reconcile] search for unreconciled entries using a search default method, instead of a domain. 

### DIFF
--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -251,7 +251,7 @@ class AccountMassReconcile(models.Model):
         )
 
     @api.model
-    def _open_move_line_list(self, move_line_ids, name):
+    def _open_move_line_list(self, context, name):
         return {
             'name': name,
             'view_mode': 'tree,form',
@@ -261,19 +261,19 @@ class AccountMassReconcile(models.Model):
             'type': 'ir.actions.act_window',
             'nodestroy': True,
             'target': 'current',
-            'domain': unicode([('id', 'in', move_line_ids)]),
+            'context': context,
         }
 
     @api.multi
     def open_unreconcile(self):
         """ Open the view of move line with the unreconciled move lines"""
         self.ensure_one()
-        obj_move_line = self.env['account.move.line']
-        lines = obj_move_line.search(
-            [('account_id', '=', self.account.id),
-             ('reconciled', '=', False)])
+        context = {
+            'search_default_account_id': self.account.id,
+            'search_default_unreconciled': True
+        }
         name = _('Unreconciled items')
-        return self._open_move_line_list(lines.ids or [], name)
+        return self._open_move_line_list(context, name)
 
     @api.multi
     def last_history_reconcile(self):

--- a/account_mass_reconcile/tests/test_reconcile.py
+++ b/account_mass_reconcile/tests/test_reconcile.py
@@ -15,6 +15,7 @@ class TestReconcile(common.TransactionCase):
                            get_module_resource('account', 'test',
                                                'account_minimal_test.xml'),
                            {}, 'init', False, 'test')
+        self.reconcile_account_id = self.ref('account.a_salary_expense')
         self.rec_history_obj = self.env['mass.reconcile.history']
         self.mass_rec_obj = self.env['account.mass.reconcile']
         self.mass_rec_method_obj = (
@@ -23,7 +24,7 @@ class TestReconcile(common.TransactionCase):
         self.mass_rec = self.mass_rec_obj.create(
             {
                 'name': 'AER2',
-                'account': self.ref('account.a_salary_expense'),
+                'account': self.reconcile_account_id,
             }
             )
         self.mass_rec_method = self.mass_rec_method_obj.create(
@@ -61,7 +62,11 @@ class TestReconcile(common.TransactionCase):
 
     def test_open_unreconcile(self):
         res = self.mass_rec.open_unreconcile()
-        self.assertEqual(unicode([('id', 'in', [])]), res.get('domain', []))
+        context = {
+            'search_default_account_id': self.reconcile_account_id,
+            'search_default_unreconciled': True
+        }
+        self.assertEqual(context, res.get('context', {}))
 
     def test_prepare_run_transient(self):
         res = self.mass_rec._prepare_run_transient(self.mass_rec_method)


### PR DESCRIPTION
When the user presses the button 'Go to unreconciled items'

![image](https://user-images.githubusercontent.com/7683926/47560326-2ea7ee00-d918-11e8-9cdf-9e9e39d5d913.png)

A method would generate a domain that contained the move lines pending to reconcile for the account being reconciled. 

We found that when the number of items to reconcile was large (e.g. more than 6000 items), the resulting tree view was causing problems, when applying groupings to the resulting list.

I find it much more solid to apply search default filters based on account and unreconciled journal items.

![image](https://user-images.githubusercontent.com/7683926/47560446-80507880-d918-11e8-901c-9ebb44c69179.png)

This is anyway how you'd search for unreconciled entries for a given account in the journal items menu.

