### PR TITLE
[11.0][imp][account_mass_reconcile] search for unreconciled entries using a search default method, instead of a domain. Fixes memory errors.

### DIFF
--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -275,7 +275,7 @@ class AccountMassReconcile(models.Model):
         )
 
     @staticmethod
-    def _open_move_line_list(move_line_ids, name):
+    def _open_move_line_list(context, name):
         return {
             'name': name,
             'view_mode': 'tree,form',
@@ -285,19 +285,19 @@ class AccountMassReconcile(models.Model):
             'type': 'ir.actions.act_window',
             'nodestroy': True,
             'target': 'current',
-            'domain': [('id', 'in', move_line_ids)],
+            'context': context,
         }
 
     @api.multi
     def open_unreconcile(self):
         """ Open the view of move line with the unreconciled move lines"""
         self.ensure_one()
-        obj_move_line = self.env['account.move.line']
-        lines = obj_move_line.search(
-            [('account_id', '=', self.account.id),
-             ('reconciled', '=', False)])
+        context = {
+            'search_default_account_id': self.account.id,
+            'search_default_unreconciled': True
+        }
         name = _('Unreconciled items')
-        return self._open_move_line_list(lines.ids or [], name)
+        return self._open_move_line_list(context, name)
 
     def last_history_reconcile(self):
         """ Get the last history record for this reconciliation profile

--- a/account_mass_reconcile/tests/test_reconcile.py
+++ b/account_mass_reconcile/tests/test_reconcile.py
@@ -15,6 +15,7 @@ class TestReconcile(common.SavepointCase):
                            get_module_resource('account', 'test',
                                                'account_minimal_test.xml'),
                            {}, 'init', False, 'test')
+        cls.reconcile_account_id = cls.env.ref('account.a_salary_expense').id
         cls.rec_history_obj = cls.env['mass.reconcile.history']
         cls.mass_rec_obj = cls.env['account.mass.reconcile']
         cls.mass_rec_method_obj = (
@@ -52,7 +53,11 @@ class TestReconcile(common.SavepointCase):
 
     def test_open_unreconcile(self):
         res = self.mass_rec.open_unreconcile()
-        self.assertEqual([('id', 'in', [])], res.get('domain', []))
+        context = {
+            'search_default_account_id': self.reconcile_account_id,
+            'search_default_unreconciled': True
+        }
+        self.assertEqual(context, res.get('context', {}))
 
     def test_prepare_run_transient(self):
         res = self.mass_rec._prepare_run_transient(self.mass_rec_method)


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-reconcile/pull/224

cc @pedrobaeza @yvaucher 