### PR TITLE
[10.0] Rollback reconcile operations when automatic reconcile fails.

### DIFF
--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -214,6 +214,7 @@ class AccountMassReconcile(models.Model):
                 # In case of error, we log it in the mail thread, log the
                 # stack trace and create an empty history line; otherwise,
                 # the cron will just loop on this reconcile task.
+                new_cr.rollback()
                 _logger.exception(
                     "The reconcile task %s had an exception: %s",
                     rec.name, e.message


### PR DESCRIPTION
Not sure about this one, review would be good. But in our case we have issues when automatic reconcile jobs are failing. Some invoices are left as paid because it was reconciling its move entries during the process. However, because the job didn't finish, the move lines are not full reconciled and we can reconcile again which looks wrong. With this added rollback, the things go in previous state and we don't end up with partial reconciles and having to manually correct it (unreconcile / reconcile properly).