### PR TITLE
[11.0][fix] base_transaction_id - extending reconciliation proposition to search transaction_ref in account_bank_statement_line.ref

### DIFF
--- a/base_transaction_id/models/account_bank_statement_line.py
+++ b/base_transaction_id/models/account_bank_statement_line.py
@@ -21,5 +21,11 @@ class AccountBankStatementLine(models.Model):
                 overlook_partner=overlook_partner)
             if match_recs and len(match_recs) == 1:
                 return match_recs
+        if self.ref:
+            domain = [('transaction_ref', 'ilike', self.ref)]
+            match_recs = self.get_move_lines_for_reconciliation(
+                excluded_ids=excluded_ids, limit=2, additional_domain=domain)
+            if match_recs and len(match_recs) == 1:
+                return match_recs
         _super = super(AccountBankStatementLine, self)
         return _super.get_reconciliation_proposition(excluded_ids=excluded_ids)


### PR DESCRIPTION
The reconciliation proposition in accounting dashboard/bank is not matching move lines with transaction reference. Transaction Reference is ignored because it is saved in account_bank_statement_line.ref and the account_move_line.transaction_ref is compared only with account_bank_statement_line.name.

In .camt files the transaction reference comes in "CdtrRefInf" and by parsing the .camt file this information will be saved in account_bank_statement_line.ref field. But there is no reconciliation proposition using this field.

I extended the method get_reconciliation_proposition, so if no match with transaction reference s found using account_bank_statement_line.name the match will be searched using account_bank_statement_line.ref.