### PR TITLE
[IMP] account_move_base_import: don't break without xlrd, add it to dependencies

### DIFF
--- a/account_move_base_import/__manifest__.py
+++ b/account_move_base_import/__manifest__.py
@@ -26,6 +26,9 @@
         'test/refund.yml',
         'test/completion_test.yml'
     ],
+    'external_dependencies': {
+        'python' : ['xlrd'],
+    },
     'installable': True,
     'license': 'AGPL-3',
 }

--- a/account_move_base_import/parser/file_parser.py
+++ b/account_move_base_import/parser/file_parser.py
@@ -12,7 +12,7 @@ from .parser import AccountMoveImportParser, UnicodeDictReader
 try:
     import xlrd
 except:
-    raise Exception(_('Please install python lib xlrd'))
+    xlrd = False
 
 
 def float_or_zero(val):

--- a/account_move_base_import/parser/file_parser.py
+++ b/account_move_base_import/parser/file_parser.py
@@ -8,10 +8,15 @@ from openerp.tools.translate import _
 from openerp.exceptions import UserError
 import tempfile
 import datetime
+import logging
 from .parser import AccountMoveImportParser, UnicodeDictReader
+
+_logger = logging.getLogger(__name__)
+
 try:
     import xlrd
-except:
+except (ImportError, IOError) as err:
+    _logger.debug(err)
     xlrd = False
 
 


### PR DESCRIPTION
otherwise, this breaks when Odoo loads assets (we have a static folder by now) and the library isn't available