### PR TITLE
[10.0] Add account_mass_reconcile_partner

### DIFF
--- a/account_mass_reconcile_partner/__init__.py
+++ b/account_mass_reconcile_partner/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_mass_reconcile_partner/__manifest__.py
+++ b/account_mass_reconcile_partner/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Mass Reconcile Partner",
+    "version": "10.0.1.0.0",
+    "category": "Finance",
+    "website": "https://github.com/OCA/account-reconcile",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "account_mass_reconcile",
+    ],
+    "data": [
+        "views/mass_reconcile.xml",
+    ],
+    "installable": True,
+}

--- a/account_mass_reconcile_partner/models/__init__.py
+++ b/account_mass_reconcile_partner/models/__init__.py
@@ -1,0 +1,2 @@
+from . import advanced_reconciliation
+from . import mass_reconcile

--- a/account_mass_reconcile_partner/models/advanced_reconciliation.py
+++ b/account_mass_reconcile_partner/models/advanced_reconciliation.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, api
+
+
+class MassReconcileAdvancedPartnerChrono(models.TransientModel):
+
+    _name = 'mass.reconcile.advanced.partner'
+    _inherit = 'mass.reconcile.advanced'
+
+    @api.multi
+    def _get_filter(self):
+        """Order move lines by date for chronological processing"""
+        where, params = super(
+            MassReconcileAdvancedPartnerChrono, self)._get_filter()
+        where = "%s ORDER BY date ASC, id ASC" % where
+        return where, params
+
+    @api.multi
+    def _skip_line(self, move_line):
+        """
+        When True is returned on some conditions, the credit move line
+        will be skipped for reconciliation. Can be inherited to
+        skip on some conditions. ie: ref or partner_id is empty.
+        """
+        return not move_line.get('partner_id')
+
+    @api.multi
+    def _matchers(self, move_line):
+        """Match only the partner"""
+        return [('partner_id', move_line['partner_id']), ]
+
+    @api.multi
+    def _opposite_matchers(self, move_line):
+        """Match only the partner"""
+        yield ('partner_id', move_line['partner_id'])

--- a/account_mass_reconcile_partner/models/mass_reconcile.py
+++ b/account_mass_reconcile_partner/models/mass_reconcile.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, api
+
+
+class AccountMassReconcileMethod(models.Model):
+    _inherit = 'account.mass.reconcile.method'
+
+    @api.model
+    def _get_all_rec_method(self):
+        res = super(AccountMassReconcileMethod, self)._get_all_rec_method()
+        res.append((
+            'mass.reconcile.advanced.partner',
+            'Advanced. Partner'
+        ))
+        return res

--- a/account_mass_reconcile_partner/readme/CONTRIBUTORS.rst
+++ b/account_mass_reconcile_partner/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/account_mass_reconcile_partner/readme/DESCRIPTION.rst
+++ b/account_mass_reconcile_partner/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module extends the functionality of account_mass_reconcile and adds a new
+reconciliation method Advanced. Partner.
+With this method credit lines are matched with debit lines in a chronological
+order if the partner is the same.

--- a/account_mass_reconcile_partner/tests/__init__.py
+++ b/account_mass_reconcile_partner/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reconcile_partner

--- a/account_mass_reconcile_partner/tests/test_reconcile_partner.py
+++ b/account_mass_reconcile_partner/tests/test_reconcile_partner.py
@@ -6,12 +6,12 @@ import time
 from odoo.tests import SavepointCase
 
 
-class TestAccountReconcilePartnerChrono(SavepointCase):
+class TestAccountReconcilePartner(SavepointCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestAccountReconcilePartnerChrono, cls).setUpClass()
-
+        super(TestAccountReconcilePartner, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.partner = cls.env.ref('base.res_partner_18')
         cls.account_receivable = cls.env['account.account'].search([
             ('user_type_id', '=',

--- a/account_mass_reconcile_partner/tests/test_reconcile_partner.py
+++ b/account_mass_reconcile_partner/tests/test_reconcile_partner.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import time
+
+from odoo.tests import SavepointCase
+
+
+class TestAccountReconcilePartnerChrono(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAccountReconcilePartnerChrono, cls).setUpClass()
+
+        cls.partner = cls.env.ref('base.res_partner_18')
+        cls.account_receivable = cls.env['account.account'].search([
+            ('user_type_id', '=',
+             cls.env.ref('account.data_account_type_receivable').id)
+        ], limit=1)
+        account_revenue = cls.env['account.account'].search([
+            ('user_type_id', '=',
+             cls.env.ref('account.data_account_type_revenue').id)
+        ], limit=1)
+        sales_journal = cls.env['account.journal'].search([
+            ('type', '=', 'sale')], limit=1)
+        year = time.strftime('%Y')
+        # Create invoice
+        cls.cust_invoice_january = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'date_invoice': '%s-01-15' % year,
+            'account_id': cls.account_receivable.id,
+            'journal_id': sales_journal.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': '[CONS_DEL01] Server',
+                'product_id': cls.env.ref('product.consu_delivery_01').id,
+                'account_id': account_revenue.id,
+                'price_unit': 1500.0,
+                'quantity': 1.0,
+            })],
+            'name': 'test_reconcile_partner'
+        })
+        cls.cust_invoice_january.action_invoice_open()
+
+        cls.cust_invoice_february = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'date_invoice': '%s-02-15' % year,
+            'account_id': cls.account_receivable.id,
+            'journal_id': sales_journal.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': '[CONS_DEL01] Server',
+                'product_id': cls.env.ref('product.consu_delivery_01').id,
+                'account_id': account_revenue.id,
+                'price_unit': 1500.0,
+                'quantity': 1.0,
+            })],
+            'name': 'test_reconcile_partner'
+        })
+        cls.cust_invoice_february.action_invoice_open()
+
+    def test_account_reconcile_partner(self):
+        self.assertEqual(self.cust_invoice_january.state, 'open')
+        bank_journal = self.env['account.journal'].search([
+            ('type', '=', 'bank')], limit=1)
+
+        # Create payment
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner.id,
+            'journal_id': bank_journal.id,
+            'amount': 1000.0,
+            'communication': 'test_reconcile',
+            'payment_method_id': self.env['account.payment.method'].search([
+                ('name', '=', 'Manual')], limit=1).id,
+        })
+        self.assertEqual(payment.state, 'draft')
+        payment.post()
+        self.assertEqual(payment.state, 'posted')
+        reconcile = self.env['account.mass.reconcile'].create({
+            'name': 'Test reconcile partner',
+            'account': self.account_receivable.id,
+            'reconcile_method': [(0, 0, {
+                'name': 'mass.reconcile.advanced.partner',
+                'date_base_on': 'newest',
+            })]
+        })
+        reconcile.run_reconcile()
+
+        self.assertEqual(self.cust_invoice_january.residual, 500)
+        self.assertEqual(self.cust_invoice_february.residual, 1500)
+
+        # Create payment
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner.id,
+            'journal_id': bank_journal.id,
+            'amount': 800.0,
+            'communication': 'test_reconcile',
+            'payment_method_id': self.env['account.payment.method'].search([
+                ('name', '=', 'Manual')], limit=1).id,
+        })
+        self.assertEqual(payment.state, 'draft')
+        payment.post()
+        self.assertEqual(payment.state, 'posted')
+
+        reconcile.run_reconcile()
+        self.assertEqual(self.cust_invoice_january.residual, 0)
+        self.assertEqual(self.cust_invoice_january.state, 'paid')
+        self.assertEqual(self.cust_invoice_february.residual, 1200)
+        self.assertEqual(self.cust_invoice_february.state, 'open')

--- a/account_mass_reconcile_partner/views/mass_reconcile.xml
+++ b/account_mass_reconcile_partner/views/mass_reconcile.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_mass_reconcile_form_inherit" model="ir.ui.view">
+        <field name="name">account.mass.reconcile.form.inherit</field>
+        <field name="model">account.mass.reconcile</field>
+        <field name="inherit_id" ref="account_mass_reconcile.account_mass_reconcile_form"/>
+        <field name="arch" type="xml">
+            <page name="information" position="inside">
+                <group>
+                    <separator colspan="4" string="Advanced. Partner"/>
+                    <label string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
+                            Lines are matched in a chronological order if the partner is the same." colspan="4"/>
+                </group>
+            </page>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module extends the functionality of account_mass_reconcile and adds a new
reconciliation method Advanced. Partner.
With this method credit lines are matched with debit lines in a chronological
order if the partner is the same.
