### PR TITLE
[10.0] account_mass_reconcile: Fix display of partially reconciled items

### DIFF
--- a/account_mass_reconcile/__manifest__.py
+++ b/account_mass_reconcile/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Account Mass Reconcile",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     "depends": ["account"],
     "author": "Akretion,Camptocamp,Odoo Community Association (OCA)",
     "website": "http://www.akretion.com/",

--- a/account_mass_reconcile/models/base_advanced_reconciliation.py
+++ b/account_mass_reconcile/models/base_advanced_reconciliation.py
@@ -264,7 +264,7 @@ class MassReconcileAdvanced(models.AbstractModel):
                                for lid in reconcile_group_ids]
                 reconciled, full = self._reconcile_lines(group_lines,
                                                          allow_partial=True)
-                if reconciled and full:
+                if reconciled:
                     reconciled_ids += reconcile_group_ids
 
                 if (ctx['commit_every'] and

--- a/account_mass_reconcile/tests/__init__.py
+++ b/account_mass_reconcile/tests/__init__.py
@@ -4,5 +4,6 @@
 
 from . import test_onchange_company
 from . import test_reconcile_history
+from . import test_reconcile_history_display_items
 from . import test_reconcile
 from . import test_scenario_reconcile

--- a/account_mass_reconcile/tests/test_reconcile.py
+++ b/account_mass_reconcile/tests/test_reconcile.py
@@ -61,7 +61,7 @@ class TestReconcile(common.TransactionCase):
 
     def test_open_unreconcile(self):
         res = self.mass_rec.open_unreconcile()
-        self.assertEqual(unicode([('id', 'in', [])]), res.get('domain', []))
+        self.assertEqual([('id', 'in', [])], res.get('domain', []))
 
     def test_prepare_run_transient(self):
         res = self.mass_rec._prepare_run_transient(self.mass_rec_method)

--- a/account_mass_reconcile/tests/test_reconcile_history.py
+++ b/account_mass_reconcile/tests/test_reconcile_history.py
@@ -33,10 +33,10 @@ class TestReconcileHistory(common.TransactionCase):
 
     def test_open_full_empty(self):
         res = self.rec_history._open_move_lines()
-        self.assertEqual(unicode([('id', 'in', [])]), res.get(
+        self.assertEqual([('id', 'in', [])], res.get(
             'domain', []))
 
     def test_open_full_empty_from_method(self):
         res = self.rec_history.open_reconcile()
-        self.assertEqual(unicode([('id', 'in', [])]), res.get(
+        self.assertEqual([('id', 'in', [])], res.get(
             'domain', []))

--- a/account_mass_reconcile/tests/test_reconcile_history_display_items.py
+++ b/account_mass_reconcile/tests/test_reconcile_history_display_items.py
@@ -1,0 +1,141 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import time
+
+from odoo.tests import SavepointCase
+
+
+class TestReconcileHistoryDisplayItems(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestReconcileHistoryDisplayItems, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env.ref('base.res_partner_18')
+        cls.partner_2 = cls.partner.copy({'name': 'Test'})
+        cls.account_receivable = cls.env['account.account'].search([
+            ('user_type_id', '=',
+             cls.env.ref('account.data_account_type_receivable').id)
+        ], limit=1)
+        account_revenue = cls.env['account.account'].search([
+            ('user_type_id', '=',
+             cls.env.ref('account.data_account_type_revenue').id)
+        ], limit=1)
+        sales_journal = cls.env['account.journal'].search([
+            ('type', '=', 'sale')], limit=1)
+        year = time.strftime('%Y')
+        # Create invoices for partner (partial reconcile)
+        cls.cust_invoice_january = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'date_invoice': '%s-01-15' % year,
+            'account_id': cls.account_receivable.id,
+            'journal_id': sales_journal.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': '[CONS_DEL01] Server',
+                'product_id': cls.env.ref('product.consu_delivery_01').id,
+                'account_id': account_revenue.id,
+                'price_unit': 1500.0,
+                'quantity': 1.0,
+            })],
+        })
+
+        cls.cust_invoice_january.action_invoice_open()
+        cls.cust_invoice_january.move_id.write({
+            'ref': 'test_reconcile_partial'
+        })
+        cls.cust_invoice_february = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'date_invoice': '%s-02-15' % year,
+            'account_id': cls.account_receivable.id,
+            'journal_id': sales_journal.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': '[CONS_DEL01] Server',
+                'product_id': cls.env.ref('product.consu_delivery_01').id,
+                'account_id': account_revenue.id,
+                'price_unit': 1500.0,
+                'quantity': 1.0,
+            })],
+        })
+        cls.cust_invoice_february.action_invoice_open()
+        cls.cust_invoice_february.move_id.write({
+            'ref': 'test_reconcile_partial'
+        })
+        # Create invoice for partner 2 (full reconcile)
+        cls.cust_invoice_partner_2 = cls.cust_invoice_january.copy({
+            'partner_id': cls.partner_2.id
+        })
+        cls.cust_invoice_partner_2.action_invoice_open()
+        cls.cust_invoice_partner_2.move_id.write({
+            'ref': 'test_reconcile_full'
+        })
+
+    def test_reconcile_history(self):
+        bank_journal = self.env['account.journal'].search([
+            ('type', '=', 'bank')], limit=1)
+
+        # Create payment for partner 1
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner.id,
+            'journal_id': bank_journal.id,
+            'amount': 2000.0,
+            'communication': 'test_reconcile_partial',
+            'payment_method_id': self.env['account.payment.method'].search([
+                ('name', '=', 'Manual')], limit=1).id,
+        })
+        payment.post()
+        # Create payment for partner 2
+        payment_2 = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner_2.id,
+            'journal_id': bank_journal.id,
+            'amount': 1500.0,
+            'communication': 'test_reconcile_full',
+            'payment_method_id': self.env['account.payment.method'].search([
+                ('name', '=', 'Manual')], limit=1).id,
+        })
+        payment_2.post()
+        reconcile = self.env['account.mass.reconcile'].create({
+            'name': 'Test reconcile display',
+            'account': self.account_receivable.id,
+            'reconcile_method': [(0, 0, {
+                'name': 'mass.reconcile.advanced.ref',
+                'date_base_on': 'newest',
+            })]
+        })
+        reconcile.run_reconcile()
+        # Check full reconciliation for partner 2
+        invoice_2_moves = self.cust_invoice_partner_2.move_id.line_ids
+        payment_2_move_lines = self.env['account.move.line'].search([
+            ('payment_id', '=', payment_2.id)
+        ])
+        full_reconciled_moves = invoice_2_moves | payment_2_move_lines
+        full_reconciled_move_ids = full_reconciled_moves.filtered(
+            lambda m: m.account_id == self.account_receivable
+        ).ids
+
+        history_full_action = reconcile.last_history_reconcile()
+        history_full_lines_ids = history_full_action.get('domain')[0][2]
+        self.assertEqual(
+            set(full_reconciled_move_ids), set(history_full_lines_ids)
+        )
+        # Check partial reconciliation for partner 1
+        invoice_january_moves = self.cust_invoice_january.move_id.line_ids
+        invoice_february_moves = self.cust_invoice_february.move_id.line_ids
+        payment_move_lines = self.env['account.move.line'].search([
+            ('payment_id', '=', payment.id)
+        ])
+        reconciled_moves = (
+            invoice_january_moves | invoice_february_moves | payment_move_lines
+        )
+        reconciled_move_ids = reconciled_moves.filtered(
+            lambda m: m.account_id == self.account_receivable
+        ).ids
+        history_partial_action = reconcile.last_history_partial_reconcile()
+        history_partial_lines_ids = history_partial_action.get('domain')[0][2]
+        self.assertEqual(
+            set(reconciled_move_ids), set(history_partial_lines_ids)
+        )

--- a/account_mass_reconcile/views/mass_reconcile.xml
+++ b/account_mass_reconcile/views/mass_reconcile.xml
@@ -11,7 +11,10 @@
                     <button name="run_reconcile" class="oe_highlight"
                         string="Start Auto Reconciliation" type="object"/>
                     <button icon="fa-share" name="last_history_reconcile"
-                        string="Display items reconciled on the last run"
+                        string="Display items fully reconciled on the last run"
+                        type="object"/>
+                    <button icon="fa-share" name="last_history_partial_reconcile"
+                        string="Display items partially reconciled on the last run"
                         type="object"/>
                 </header>
                 <sheet>
@@ -39,7 +42,9 @@
                                 <tree string="Automatic Mass Reconcile History">
                                     <field name="date"/>
                                     <button icon="fa-share" name="open_reconcile"
-                                        string="Go to reconciled items" type="object"/>
+                                        string="Go to fully reconciled items" type="object"/>
+                                    <button icon="fa-share" name="open_partial_reconcile"
+                                        string="Go to partially reconciled items" type="object"/>
                                 </tree>
                             </field>
                         </page>
@@ -84,7 +89,9 @@ The lines should have the same partner, and the credit entry ref. is matched wit
                 <button icon="gtk-ok" name="run_reconcile" colspan="4"
                     string="Start Auto Reconcilation" type="object"/>
                 <button icon="fa-share" name="last_history_reconcile" colspan="2"
-                    string="Display items reconciled on the last run" type="object"/>
+                    string="Display items fully reconciled on the last run" type="object"/>
+                <button icon="fa-share" name="last_history_partial_reconcile" colspan="2"
+                    string="Display items partially reconciled on the last run" type="object"/>
             </tree>
         </field>
     </record>

--- a/account_mass_reconcile/views/mass_reconcile_history_view.xml
+++ b/account_mass_reconcile/views/mass_reconcile_history_view.xml
@@ -47,8 +47,12 @@
                         <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                     <group col="2">
-                        <separator colspan="2" string="Reconciliations"/>
+                        <separator colspan="2" string="Full Reconciliations"/>
                         <field name="reconcile_ids" nolabel="1"/>
+                    </group>
+                    <group col="2">
+                        <separator colspan="2" string="Partial Reconciliations"/>
+                        <field name="partial_reconcile_ids" nolabel="1"/>
                     </group>
                 </sheet>
             </form>
@@ -63,7 +67,9 @@
                 <field name="mass_reconcile_id"/>
                 <field name="date"/>
                 <button icon="fa-share" name="open_reconcile"
-                    string="Go to reconciled items" type="object"/>
+                    string="Go to fully reconciled items" type="object"/>
+                <button icon="fa-share" name="open_reconcile"
+                    string="Go to partially reconciled items" type="object"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Before this commit, only fully reconciled items are stored in the history.

This commit adds a new action to display partially reconciled items and renames the existing action to display fully reconciled items.