### PR TITLE
[10.0] Add module account_mass_reconcile_scheduled

### DIFF
--- a/acccount_mass_reconcile_scheduled/README.rst
+++ b/acccount_mass_reconcile_scheduled/README.rst
@@ -1,0 +1,1 @@
+To be overwritten

--- a/acccount_mass_reconcile_scheduled/__init__.py
+++ b/acccount_mass_reconcile_scheduled/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/acccount_mass_reconcile_scheduled/__manifest__.py
+++ b/acccount_mass_reconcile_scheduled/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Account Mass Reconcile Scheduled",
     "summary": "Schedule only selected mass reconcile records",
-    "version": "11.0.1.0.0",
+    "version": "10.0.1.0.0",
     "category": "Accounting",
     "website": "https://github.com/OCA/account-reconcile",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/acccount_mass_reconcile_scheduled/__manifest__.py
+++ b/acccount_mass_reconcile_scheduled/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Account Mass Reconcile Scheduled",
+    "summary": "Schedule only selected mass reconcile records",
+    "version": "11.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-reconcile",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "account_mass_reconcile",
+    ],
+    "data": [
+        "data/ir_cron.xml",
+        "views/account_mass_reconcile.xml",
+    ],
+    "application": False,
+    "installable": True,
+}

--- a/acccount_mass_reconcile_scheduled/data/ir_cron.xml
+++ b/acccount_mass_reconcile_scheduled/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="ir_cron_scheduled_mass_reconcile" model="ir.cron">
+        <field name="name">Run scheduled mass reconcile</field>
+        <field name="active" eval="False" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False"/>
+        <field name="model" eval="'account.mass.reconcile'"/>
+        <field name="function" eval="'_cron_run_scheduled_mass_reconcile'"/>
+        <field name="args" eval="'()'" />
+    </record>
+</odoo>

--- a/acccount_mass_reconcile_scheduled/models/__init__.py
+++ b/acccount_mass_reconcile_scheduled/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_mass_reconcile

--- a/acccount_mass_reconcile_scheduled/models/account_mass_reconcile.py
+++ b/acccount_mass_reconcile_scheduled/models/account_mass_reconcile.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields, api
+
+
+class AccountMassReconcile(models.Model):
+
+    _inherit = 'account.mass.reconcile'
+
+    scheduled_run = fields.Boolean(
+        string='Run by scheduled task',
+        help='Check this box to make this mass reconcile selected by the '
+             'scheduled task "Run scheduled mass reconcile".'
+    )
+
+    @api.model
+    def _cron_run_scheduled_mass_reconcile(self):
+        mass_reconciles = self.search([('scheduled_run', '=', True)])
+        for mass_reconcile in mass_reconciles:
+            mass_reconcile.run_reconcile()

--- a/acccount_mass_reconcile_scheduled/readme/CONFIGURE.rst
+++ b/acccount_mass_reconcile_scheduled/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+To use this module you need to activate the scheduled task
+"Run scheduled mass reconcile" and deactivate the scheduled task
+"Do Automatic Reconciliations".
+

--- a/acccount_mass_reconcile_scheduled/readme/CONTRIBUTORS.rst
+++ b/acccount_mass_reconcile_scheduled/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/acccount_mass_reconcile_scheduled/readme/DESCRIPTION.rst
+++ b/acccount_mass_reconcile_scheduled/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module extends account_mass_reconcile to add a checkbox allowing only
+selected mass reconcile to be run automatically after each other (using
+multiple calls) by a scheduled task, instead of the existing scheduled task
+running either everything or only the oldest mass reconcile that was run,
+in a single call.

--- a/acccount_mass_reconcile_scheduled/readme/ROADMAP.rst
+++ b/acccount_mass_reconcile_scheduled/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+* Merge this module with account_mass_reconcile to replace the existing dubious
+  scheduled task.
+* Create a cron automatically from the account.mass.reconcile form view

--- a/acccount_mass_reconcile_scheduled/views/account_mass_reconcile.xml
+++ b/acccount_mass_reconcile_scheduled/views/account_mass_reconcile.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="account_mass_reconcile_form_inherit" model="ir.ui.view">
+        <field name="name">account.mass.reconcile.form.inherit</field>
+        <field name="model">account.mass.reconcile</field>
+        <field name="inherit_id" ref="account_mass_reconcile.account_mass_reconcile_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page name="scheduling" string="Scheduling">
+                    <field name="scheduled_run" />
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module extends account_mass_reconcile to add a checkbox allowing only
selected mass reconcile to be run automatically after each other (using
multiple calls) by a scheduled task, instead of the existing scheduled task
running either everything or only the oldest mass reconcile that was run,
in a single call.
