### PR TITLE
[FIX][10.0] account_move_base_import currency handling

### DIFF
--- a/account_move_base_import/README.rst
+++ b/account_move_base_import/README.rst
@@ -83,6 +83,7 @@ Contributors
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Sébastien Beau <sebastien.beau@akretion.com>
 * Matthieu Dietrich <matthieu.dietrich@camptocamp.com>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 
 Maintainer
 ----------

--- a/account_move_base_import/__manifest__.py
+++ b/account_move_base_import/__manifest__.py
@@ -6,7 +6,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 {
     'name': "Journal Entry base import",
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'author': "Akretion,Camptocamp,Odoo Community Association (OCA)",
     'category': 'Finance',
     'depends': ['account'],


### PR DESCRIPTION
When importing a batch for a journal which has a currency different from the
company currency, the values in the batch files are in the currency of the journal.
The previous code was creating move lines as if the amounts in the batch file were in
the company currency.

We fix this by checking for the case, and converting the amounts the company currency at
the rate of the date of the transaction to fill in the credit / debit columns, and setting the
value of amount_currency to the value in the batch file.