### PR TITLE
[12.0][FIX]  account_reconcile_restrict_partner_mismatch (greenify repo)

### DIFF
--- a/account_reconcile_restrict_partner_mismatch/report/report_reconciled_lines.py
+++ b/account_reconcile_restrict_partner_mismatch/report/report_reconciled_lines.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, tools
 
 class AccountReconcilePartnerMismatchReport(models.Model):
     _name = 'account.reconcile.partner.mismatch.report'
+    _description = 'Account Reconcile Partner Mismatch Report'
     _auto = False
 
     partial_reconcile_id = fields.Many2one(


### PR DESCRIPTION
Add a missing `_description`.