### PR TITLE
[12.0][FIX] account_skip_bank_reconciliation: correctly skip matching only when exclude_bank_reconcile is True

### DIFF
--- a/account_skip_bank_reconciliation/models/account_reconcile_model.py
+++ b/account_skip_bank_reconciliation/models/account_reconcile_model.py
@@ -11,5 +11,5 @@ class AccountReconcileModel(models.Model):
     def _apply_conditions(self, query, params):
         query, params = super(
             AccountReconcileModel, self)._apply_conditions(query, params)
-        query += ' AND account.exclude_bank_reconcile = False'
+        query += ' AND account.exclude_bank_reconcile IS NOT TRUE'
         return query, params


### PR DESCRIPTION
Fixes https://github.com/OCA/account-reconcile/issues/304

Fast-track.