### PR TITLE
[12.0][FIX] account_reconcile_reconciliation_date: grouping invoices in payments (greenify repo)

### DIFF
--- a/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
+++ b/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
@@ -126,6 +126,7 @@ class TestAccountReconcileReconciliationDate(AccountingTestCase):
                    'payment_date': time.strftime('%Y') + '-07-15',
                    'journal_id': self.bank_journal_euro.id,
                    'payment_method_id': self.payment_method_manual_in.id,
+                   'group_invoices': True,
                    })
         register_payments.create_payments()
         payment = self.payment_model.search([], order="id desc", limit=1)


### PR DESCRIPTION
It's due to https://github.com/odoo/odoo/commit/9393ea10a9ac50dd3372ea2e1436e00ba049b5e5.

Fast-track.