### PR TITLE
[FIX] account_reconcile_reconciliation_date: Reconciliation Date Not Showing

### DIFF
--- a/account_reconcile_reconciliation_date/views/account_invoice.xml
+++ b/account_reconcile_reconciliation_date/views/account_invoice.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <field name="date_due" position="after">
-                <field name="reconciliation_date" invisible="[('reconciliation_date', '=', False)]"/>
+                <field name="reconciliation_date" attrs="{'invisible': [('reconciliation_date', '=', False)]}"/>
             </field>
         </field>
     </record>

--- a/account_reconcile_reconciliation_date/views/account_payment.xml
+++ b/account_reconcile_reconciliation_date/views/account_payment.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
             <field name="payment_date" position="after">
-                <field name="reconciliation_date" invisible="[('reconciliation_date', '=', False)]"/>
+                <field name="reconciliation_date" attrs="{'invisible': [('reconciliation_date', '=', False)]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The reconciliation_date field is being set properly however the field is not showing even though it should be. This solution fixes that bug.