### PR TITLE
[12.0] Create module account_reconcile_blue_lines_restriction

### DIFF
--- a/account_reconcile_blue_lines_restriction/__init__.py
+++ b/account_reconcile_blue_lines_restriction/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_reconcile_blue_lines_restriction/__manifest__.py
+++ b/account_reconcile_blue_lines_restriction/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Account Reconciliation Blue Lines Restriction",
+    "summary": "Restrict appearance of blue lines to reconciliable accounts",
+    "version": "12.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-reconcile",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [
+    ],
+}

--- a/account_reconcile_blue_lines_restriction/models/__init__.py
+++ b/account_reconcile_blue_lines_restriction/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_reconcile_model
+from . import account_reconciliation_widget

--- a/account_reconcile_blue_lines_restriction/models/account_reconcile_model.py
+++ b/account_reconcile_blue_lines_restriction/models/account_reconcile_model.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models
+
+
+class AccountReconcileModel(models.Model):
+
+    _inherit = 'account.reconcile.model'
+
+    @api.multi
+    def _apply_conditions(self, query, params):
+        """Remove AMLs with account not allowed for reconciliation from
+           blue lines appearance conditions"""
+        new_query, new_params = super()._apply_conditions(query, params)
+        if self.rule_type == 'invoice_matching':
+            new_query += '''
+                AND (
+                    -- modified blue lines appearance conditions
+                    aml.account_id IN (
+                        journal.default_credit_account_id,
+                        journal.default_debit_account_id
+                    )
+                    AND aml.statement_id IS NULL
+                    AND (
+                        company.account_bank_reconciliation_start IS NULL
+                        OR
+                        aml.date > company.account_bank_reconciliation_start
+                    )
+                    -- This line restricts propositions to lines on
+                    -- accounts allowing reconciliation
+                    AND account.reconcile IS TRUE
+                    OR (
+                        -- black lines appearance conditions
+                        account.reconcile IS TRUE
+                        AND aml.reconciled IS FALSE
+                    )
+                )
+            '''
+        return new_query, new_params

--- a/account_reconcile_blue_lines_restriction/models/account_reconciliation_widget.py
+++ b/account_reconcile_blue_lines_restriction/models/account_reconciliation_widget.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models
+from odoo.osv import expression
+
+
+class AccountReconciliationWidget(models.AbstractModel):
+
+    _inherit = "account.reconciliation.widget"
+
+    @api.model
+    def _domain_move_lines_for_reconciliation(
+        self, st_line, aml_accounts, partner_id, excluded_ids=None, search_str=False
+    ):
+        domain = super()._domain_move_lines_for_reconciliation(
+            st_line, aml_accounts, partner_id, excluded_ids=excluded_ids, search_str=search_str
+        )
+        domain = expression.AND([domain, [('account_id.reconcile', '=', True)]])
+        return domain

--- a/account_reconcile_blue_lines_restriction/readme/CONTRIBUTORS.rst
+++ b/account_reconcile_blue_lines_restriction/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/account_reconcile_blue_lines_restriction/readme/DESCRIPTION.rst
+++ b/account_reconcile_blue_lines_restriction/readme/DESCRIPTION.rst
@@ -1,0 +1,10 @@
+This module extends the reconciliation feature of Odoo in order to change
+the blue lines appearance conditions in the reconciliation propositions.
+
+When opening the reconciliation widget, Odoo can propose account move lines
+linked to an account that is not marked to "Allow Reconciliation", if said
+account is defined as "Default Debit Account" or "Default Credit Account" on
+the journal from the bank statement line.
+
+This module restricts those proposition to move lines linked to an account
+that is marked as "Allow Reconciliation".


### PR DESCRIPTION
This module extends the reconciliation feature of Odoo in order to change
the blue lines appearance conditions in the reconciliation propositions.

When opening the reconciliation widget, Odoo can propose account move lines
linked to an account that is not marked to "Allow Reconciliation", if said
account is defined as "Default Debit Account" or "Default Credit Account" on
the journal from the bank statement line.

This module restricts those proposition to move lines linked to an account
that is marked as "Allow Reconciliation".

