### PR TITLE
[12.0][FIX] set correct value when extracting empty row

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -152,7 +152,7 @@ class AccountJournal(models.Model):
         global_commission_amount = 0
         for row in parser.result_row_list:
             global_commission_amount += float(
-                row.get("commission_amount", "0.0")
+                row.get("commission_amount") or 0.0
             )
         partner_id = self.partner_id.id
         # Commission line


### PR DESCRIPTION
an empty string is not correctly replaced 