### PR TITLE
[12.0][IMP] set as reconciled payments related on move line

### DIFF
--- a/account_banking_reconciliation/models/account_banking_reconciliation.py
+++ b/account_banking_reconciliation/models/account_banking_reconciliation.py
@@ -94,7 +94,8 @@ class BankAccRecStatement(models.Model):
         return True
 
     def reconcile_payment(self, line):
-        line.filtered(lambda l: l.cleared_bank_account).mapped("payment_id").write({"state": "reconciled"})
+        cleared = line.filtered(lambda l: l.cleared_bank_account)
+        cleared.mapped("payment_id").write({"state": "reconciled"})
 
     @api.multi
     def action_process(self):

--- a/account_banking_reconciliation/models/account_banking_reconciliation.py
+++ b/account_banking_reconciliation/models/account_banking_reconciliation.py
@@ -93,6 +93,9 @@ class BankAccRecStatement(models.Model):
         self.write({'state': 'to_be_reviewed'})
         return True
 
+    def reconcile_payment(self, line):
+        line.filtered(lambda l: l.cleared_bank_account).mapped("payment_id").write({"state": "reconciled"})
+
     @api.multi
     def action_process(self):
         """Set the account move lines as 'Cleared' and
@@ -114,6 +117,7 @@ class BankAccRecStatement(models.Model):
                 statement_line.move_line_id.write({
                     'cleared_bank_account': cleared_bank_account,
                     'bank_acc_rec_statement_id': statement_id})
+                self.reconcile_payment(statement_line.move_line_id)
 
             statement.write({'state': 'done',
                              'verified_by_user_id': self.env.uid,


### PR DESCRIPTION
Odoo process reconciliation:

payment must set as reconciled once is done.

