### PR TITLE
[12.0][ADD] account_bank_statement_currency_ignore: ignore currency on lines

### DIFF
--- a/account_bank_statement_currency_ignore/__init__.py
+++ b/account_bank_statement_currency_ignore/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models
+from .hooks import pre_init_hook, post_init_hook

--- a/account_bank_statement_currency_ignore/__manifest__.py
+++ b/account_bank_statement_currency_ignore/__manifest__.py
@@ -1,0 +1,27 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Accounting: Ignore Bank Statement Currency",
+    "summary": "Ignore amount in transaction currency on operations.",
+    "version": "12.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-reconcile",
+    "author": "CorporateHub, Odoo Community Association (OCA)",
+    "maintainers": ["alexey-pelykh"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "templates/assets.xml",
+        "views/account_bank_statement_line.xml",
+        "views/account_bank_statement.xml",
+    ],
+    "qweb": [
+        "static/src/xml/account_reconciliation.xml",
+    ],
+}

--- a/account_bank_statement_currency_ignore/hooks.py
+++ b/account_bank_statement_currency_ignore/hooks.py
@@ -1,0 +1,33 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, SUPERUSER_ID
+
+
+def pre_init_hook(cr):
+    cr.execute("""
+        ALTER TABLE account_bank_statement_line
+            ADD original_amount_currency numeric;
+        COMMENT
+            ON COLUMN account_bank_statement_line.original_amount_currency
+            IS 'Original Amount Currency';
+        ALTER TABLE account_bank_statement_line
+            ADD original_currency_id integer
+            CONSTRAINT account_bank_statement_line_original_currency_id_fkey
+                REFERENCES res_currency
+                    ON DELETE SET NULL;
+        COMMENT
+            ON COLUMN account_bank_statement_line.original_currency_id
+            IS 'Original Currency';
+        UPDATE account_bank_statement_line
+            SET
+                original_amount_currency = amount_currency,
+                original_currency_id = currency_id;
+    """)
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    statement_lines = env["account.bank.statement.line"].search([])
+    statement_lines._compute_currency_id()
+    statement_lines._compute_amount_currency()

--- a/account_bank_statement_currency_ignore/models/__init__.py
+++ b/account_bank_statement_currency_ignore/models/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import account_bank_statement_line
+from . import account_reconciliation_widget

--- a/account_bank_statement_currency_ignore/models/account_bank_statement_line.py
+++ b/account_bank_statement_currency_ignore/models/account_bank_statement_line.py
@@ -1,0 +1,91 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    amount_currency = fields.Monetary(
+        compute="_compute_amount_currency",
+        inverse="_inverse_amount_currency",
+        store=True,
+    )
+    currency_id = fields.Many2one(
+        compute="_compute_currency_id",
+        inverse="_inverse_currency_id",
+        store=True,
+    )
+    ignore_currency = fields.Boolean(
+        string="Ignore Currency",
+    )
+    original_amount_currency = fields.Monetary(
+        string="Original Amount Currency",
+        currency_field="original_currency_id",
+        help=(
+            "The original amount expressed in an optional other currency if it "
+            "is a multi-currency entry."
+        ),
+    )
+    original_currency_id = fields.Many2one(
+        string="Original Currency",
+        comodel_name="res.currency",
+        help="The optional other currency if it is a multi-currency entry.",
+    )
+
+    @api.multi
+    @api.depends("original_amount_currency", "ignore_currency")
+    def _compute_amount_currency(self):
+        for line in self:
+            if line.ignore_currency:
+                line.amount_currency = 0.0
+            else:
+                line.amount_currency = line.original_amount_currency
+
+    @api.multi
+    def _inverse_amount_currency(self):
+        for line in self:
+            if line.ignore_currency:
+                raise UserError(_(
+                    'Statement line is set to ignore transaction currency, '
+                    'either un-ignore it prior to editing or make changes to '
+                    '"Original Amount Currency" field.'
+                ))
+            line.original_amount_currency = line.amount_currency
+
+    @api.multi
+    @api.depends("original_currency_id", "ignore_currency")
+    def _compute_currency_id(self):
+        for line in self:
+            if line.ignore_currency:
+                line.currency_id = None
+            else:
+                line.currency_id = line.original_currency_id
+
+    @api.multi
+    def _inverse_currency_id(self):
+        for line in self:
+            if line.ignore_currency:
+                raise UserError(_(
+                    'Statement line is set to ignore transaction currency, '
+                    'either un-ignore it prior to editing or make changes to '
+                    '"Original Currency" field.'
+                ))
+            line.original_currency_id = line.currency_id
+
+    @api.multi
+    def action_toggle_ignore_currency(self):
+        for line in self:
+            line.ignore_currency = not line.ignore_currency
+
+    @api.multi
+    def action_ignore_currency(self):
+        for line in self:
+            line.ignore_currency = True
+
+    @api.multi
+    def action_unignore_currency(self):
+        for line in self:
+            line.ignore_currency = False

--- a/account_bank_statement_currency_ignore/models/account_reconciliation_widget.py
+++ b/account_bank_statement_currency_ignore/models/account_reconciliation_widget.py
@@ -1,0 +1,28 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.tools.misc import formatLang
+
+
+class AccountReconciliation(models.AbstractModel):
+    _inherit = "account.reconciliation.widget"
+
+    @api.model
+    def _get_statement_line(self, st_line):
+        res = super()._get_statement_line(st_line)
+
+        res.update({
+            "ignore_currency": st_line.ignore_currency,
+            "original_amount_currency": st_line.original_amount_currency,
+            "original_amount_currency_str": (
+                st_line.original_currency_id and formatLang(
+                    self.env,
+                    abs(st_line.original_amount_currency),
+                    currency_obj=st_line.original_currency_id,
+                ) or ""
+            ),
+            "original_currency_id": st_line.original_currency_id.id,
+        })
+
+        return res

--- a/account_bank_statement_currency_ignore/readme/CONTRIBUTORS.rst
+++ b/account_bank_statement_currency_ignore/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/account_bank_statement_currency_ignore/readme/DESCRIPTION.rst
+++ b/account_bank_statement_currency_ignore/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module extends the functionality of Bank Statements to support ignoring
+transaction currency in case such information is available, yet is not helpful
+during reconciling process of certain operations.

--- a/account_bank_statement_currency_ignore/readme/USAGE.rst
+++ b/account_bank_statement_currency_ignore/readme/USAGE.rst
@@ -1,0 +1,8 @@
+To ignore or un-ignore transaction currency on bank statement line:
+
+#. Go to Statement
+#. Click on blue *Ignore Currency* or gray *Un-Ignore* icon on statement line
+
+To ignore or un-ignore transaction currency during reconciliation:
+
+#. Click on blue *Ignore Currency* or gray *Un-Ignore* icon on statement line

--- a/account_bank_statement_currency_ignore/static/src/js/reconciliation_client_action.js
+++ b/account_bank_statement_currency_ignore/static/src/js/reconciliation_client_action.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 CorporateHub (https://corporatehub.eu)
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+ */
+odoo.define("account_bank_statement_currency_ignore.ReconciliationClientAction", function (require) {
+    "use strict";
+
+    var ReconciliationClientAction = require("account.ReconciliationClientAction");
+
+    ReconciliationClientAction.StatementAction.include({
+        custom_events: _.extend({}, ReconciliationClientAction.StatementAction.prototype.custom_events, {
+            toggle_ignore_currency: "_onToggleIgnoreCurrency",
+        }),
+        _onToggleIgnoreCurrency: function (e) {
+            console.log(e.data);
+            // var self = this;
+            // var handle = event.target.handle;
+            // var line = this.model.getLine(handle);
+            // var amount = this.model.getPartialReconcileAmount(handle, event.data);
+            // self._getWidget(handle).updatePartialAmount(event.data.data, amount);
+
+            // TODO: call and rerender
+
+            // on Model,
+            // /**
+            //  * RPC method to load informations on lines
+            //  *
+            //  * @param {Array} ids ids of bank statement line passed to rpc call
+            //  * @param {Array} excluded_ids list of move_line ids that needs to be excluded from search
+            //  * @returns {Deferred}
+            //  */
+            // loadData: function(ids, excluded_ids) {
+            //     var self = this;
+            //     return self._rpc({
+            //         model: 'account.reconciliation.widget',
+            //         method: 'get_bank_statement_line_data',
+            //         args: [ids, excluded_ids],
+            //         context: self.context,
+            //     })
+            //     .then(function(res){
+            //         return self._formatLine(res['lines']);
+            //     })
+            // },
+
+            // also see on Action:
+            // /**
+            //  *
+            //  */
+            // _loadMore: function(qty) {
+            //     var self = this;
+            //     return this.model.loadMore(qty).then(function () {
+            //         self._renderLines();
+            //     });
+            // },
+        },
+    });
+});

--- a/account_bank_statement_currency_ignore/static/src/js/reconciliation_renderer.js
+++ b/account_bank_statement_currency_ignore/static/src/js/reconciliation_renderer.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 CorporateHub (https://corporatehub.eu)
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+ */
+odoo.define("account_bank_statement_currency_ignore.ReconciliationRenderer", function (require) {
+    "use strict";
+
+    var ReconciliationRenderer = require("account.ReconciliationRenderer");
+
+    ReconciliationRenderer.LineRenderer.include({
+        events: _.extend({}, ReconciliationRenderer.LineRenderer.prototype.events, {
+            "click .accounting_view .toggle_ignore_currency": "_onToggleIgnoreCurrency",
+        }),
+        _onToggleIgnoreCurrency: function (e) {
+            e.stopPropagation();
+            var lineId = $(e.target).closest(".o_reconciliation_line").data("line-id");
+            this.trigger_up("toggle_ignore_currency", {"data": lineId});
+        },
+        //     updatePartialAmount: function(line_id, amount) {
+        //         var $line = this.$(".mv_line[data-line-id="+line_id+"]");
+        //         $line.find(".line_info_edit").addClass("o_hidden");
+        //         $line.find(".edit_amount_input").removeClass("o_hidden");
+        //         $line.find(".edit_amount_input").focus();
+        //         $line.find(".edit_amount_input").val(amount.toFixed(2));
+        //         $line.find(".edit_amount_input").select();
+        //         $line.find(".line_amount").addClass("o_hidden");
+        //     },
+        //     _editAmount: function (event) {
+        //         event.stopPropagation();
+        //         var $line = $(event.target);
+        //         var moveLineId = $line.closest(".mv_line").data("line-id");
+        //         this.trigger_up(
+        //             "partial_reconcile",
+        //             {"data": {mvLineId: moveLineId, "amount": $line.val()}}
+        //         );
+        //     },
+        //     _onInputKeyup: function (event) {
+        //         if(event.keyCode === 13) {
+        //             if ($(event.target).hasClass("edit_amount_input")) {
+        //                 $(event.target).blur();
+        //                 return;
+        //             }
+        //         }
+        //         if ($(event.target).hasClass("edit_amount_input")) {
+        //             if (event.type === "keyup") {
+        //                 return;
+        //             }
+        //             else {
+        //                 return this._editAmount(event);
+        //             }
+        //         }
+        //         return this._super.apply(this, arguments);
+        //     },
+    });
+});

--- a/account_bank_statement_currency_ignore/static/src/xml/account_reconciliation.xml
+++ b/account_bank_statement_currency_ignore/static/src/xml/account_reconciliation.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<templates>
+
+    <t t-extend="reconciliation.line">
+        <t t-jquery=".o_reconciliation_line" t-operation="attributes">
+            <attribute name="t-att-data-line-id">state.st_line.id</attribute>
+        </t>
+        <t t-jquery=".o_reconciliation_line .accounting_view thead td.cell_left > t" t-operation="prepend">
+            <span
+                t-if="state.st_line.original_currency_id"
+                t-attf-class="toggle_currency_ignore fa fa-money text-#{!state.st_line.ignore_currency ? 'info' : 'muted'}"
+            />
+        </t>
+        <t t-jquery=".o_reconciliation_line .accounting_view thead td.cell_right > t" t-operation="prepend">
+            <span
+                t-if="state.st_line.original_currency_id"
+                t-attf-class="toggle_currency_ignore fa fa-money text-#{!state.st_line.ignore_currency ? 'info' : 'muted'}"
+            />
+        </t>
+    </t>
+
+    <t t-extend="reconciliation.line.statement_line.details">
+        <!-- <table class='details'>
+            <tr><td>Date</td><td><t t-esc="state.st_line.date"/></td></tr>
+            <tr t-if="state.st_line.partner_name"><td>Partner</td><td><t t-esc="state.st_line.partner_name"/></td></tr>
+            <tr t-if="state.st_line.ref"><td>Transaction</td><td><t t-esc="state.st_line.ref"/></td></tr>
+            <tr><td>Description</td><td><t t-esc="state.st_line.name"/></td></tr>
+            <tr><td>Amount</td><td><t t-raw="state.st_line.amount_str"/><t t-if="state.st_line.amount_currency_str"> (<t t-esc="state.st_line.amount_currency_str"/>)</t></td></tr>
+            <tr><td>Account</td><td><t t-esc="state.st_line.account_code"/> <t t-esc="state.st_line.account_name"/></td></tr>
+            <tr t-if="state.st_line.note"><td>Note</td><td style="white-space: pre;"><t t-esc="state.st_line.note"/></td></tr>
+        </table> -->
+    </t>
+
+</templates>

--- a/account_bank_statement_currency_ignore/templates/assets.xml
+++ b/account_bank_statement_currency_ignore/templates/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="assets_backend" name="account_bank_statement_currency_ignore assets" inherit_id="account.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/account_bank_statement_currency_ignore/static/src/js/reconciliation_renderer.js"/>
+            <script type="text/javascript" src="/account_bank_statement_currency_ignore/static/src/js/reconciliation_client_action.js"/>
+            <!-- TODO: https://github.com/OCA/account-reconcile/blob/12.0/account_reconciliation_widget_partial/static/src/js/reconciliation_model.js -->
+        </xpath>
+    </template>
+</odoo>

--- a/account_bank_statement_currency_ignore/tests/__init__.py
+++ b/account_bank_statement_currency_ignore/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_account_bank_statement_line

--- a/account_bank_statement_currency_ignore/tests/test_account_bank_statement_line.py
+++ b/account_bank_statement_currency_ignore/tests/test_account_bank_statement_line.py
@@ -1,0 +1,101 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountBankStatementLine(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_eur = self.env.ref("base.EUR")
+        self.currency_chf = self.env.ref("base.CHF")
+        self.AccountJournal = self.env["account.journal"]
+        self.AccountBankStatement = self.env["account.bank.statement"]
+        self.AccountBankStatementLine = self.env["account.bank.statement.line"]
+
+    def test_create(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION",
+            "amount": "100.0",
+            "amount_currency": "85.0",
+            "currency_id": self.currency_eur.id,
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+
+        self.assertEqual(line.amount_currency, 85.0)
+        self.assertEqual(line.currency_id, self.currency_eur)
+        self.assertEqual(line.original_amount_currency, 85.0)
+        self.assertEqual(line.original_currency_id, self.currency_eur)
+
+    def test_create_ignored(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        with self.assertRaises(UserError):
+            self.AccountBankStatementLine.create({
+                "statement_id": statement.id,
+                "name": "TRANSACTION",
+                "amount": "100.0",
+                "amount_currency": "85.0",
+                "currency_id": self.currency_eur.id,
+                "ignore_currency": True,
+                "date": "2020-09-01",
+                "note": "NOTE",
+                "unique_import_id": "TRANSACTION-ID",
+            })
+
+    def test_create_ignored_original(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION",
+            "amount": "100.0",
+            "original_amount_currency": "85.0",
+            "original_currency_id": self.currency_eur.id,
+            "ignore_currency": True,
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        self.assertEqual(line.amount_currency, 0.0)
+        self.assertFalse(line.currency_id)
+        self.assertEqual(line.original_amount_currency, 85.0)
+        self.assertEqual(line.original_currency_id, self.currency_eur)
+
+        line.action_toggle_ignore_currency()
+        self.assertEqual(line.amount_currency, 85.0)
+        self.assertEqual(line.currency_id, self.currency_eur)
+        self.assertEqual(line.original_amount_currency, 85.0)
+        self.assertEqual(line.original_currency_id, self.currency_eur)

--- a/account_bank_statement_currency_ignore/views/account_bank_statement.xml
+++ b/account_bank_statement_currency_ignore/views/account_bank_statement.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_bank_statement_form" model="ir.ui.view">
+        <field name="name">account.bank.statement.form</field>
+        <field name="model">account.bank.statement</field>
+        <field name="inherit_id" ref="account.view_bank_statement_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='line_ids']/tree/field[@name='currency_id']" position="after">
+                <field name="original_amount_currency" invisible="1"/>
+                <field name="original_currency_id" invisible="1"/>
+                <field name="ignore_currency" invisible="1"/>
+                <button
+                    name="action_ignore_currency"
+                    string="Ignore Currency"
+                    type="object"
+                    icon="fa-money text-info"
+                    attrs="{'invisible': ['|', ('ignore_currency', '=', True), ('original_currency_id', '=', False)]}"
+                />
+                <button
+                    name="action_unignore_currency"
+                    string="Un-Ignore Currency"
+                    type="object"
+                    icon="fa-money text-muted"
+                    attrs="{'invisible': ['|', ('ignore_currency', '=', False), ('original_currency_id', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_currency_ignore/views/account_bank_statement_line.xml
+++ b/account_bank_statement_currency_ignore/views/account_bank_statement_line.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_bank_statement_line_form" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.form</field>
+        <field name="model">account.bank.statement.line</field>
+        <field name="inherit_id" ref="account.view_bank_statement_line_form"/>
+        <field name="arch" type="xml">
+            <field name="journal_currency_id" position="after">
+                <label for="original_amount_currency"/>
+                <div class="o_row" name="original_amount_currency">
+                    <field name="original_amount_currency" nolabel="1"/>
+                    <field name="original_currency_id" class="oe_edit_only"/>
+                </div>
+                <field name="ignore_currency" attrs="{'invisible': [('original_currency_id', '=', 'False')]}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_bank_statement_line_tree" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.tree</field>
+        <field name="model">account.bank.statement.line</field>
+        <field name="inherit_id" ref="account.view_bank_statement_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="journal_currency_id" position="after">
+                <field name="original_amount_currency" invisible="1"/>
+                <field name="original_currency_id" invisible="1"/>
+                <field name="ignore_currency" invisible="1"/>
+                <button
+                    name="action_ignore_currency"
+                    string="Ignore Currency"
+                    type="object"
+                    icon="fa-money text-info"
+                    attrs="{'invisible': ['|', ('ignore_currency', '=', True), ('original_currency_id', '=', False)]}"
+                />
+                <button
+                    name="action_unignore_currency"
+                    string="Un-Ignore Currency"
+                    type="object"
+                    icon="fa-money text-muted"
+                    attrs="{'invisible': ['|', ('ignore_currency', '=', False), ('original_currency_id', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="action_account_confirm_payments" model="ir.actions.server">
+        <field name="name">Toggle Ignore Currency</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="account.model_account_bank_statement_line"/>
+        <field name="binding_model_id" ref="account.model_account_bank_statement_line"/>
+        <field name="code">
+            if records:
+                records.action_toggle_ignore_currency()
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module extends the functionality of Bank Statements to support ignoring
transaction currency in case such information is available, yet is not helpful
during reconciling process of certain operations.
