### PR TITLE
[12.0][ADD] account_bank_statement_postprocess: postprocess lines on import

### DIFF
--- a/account_bank_statement_postprocess/__init__.py
+++ b/account_bank_statement_postprocess/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/account_bank_statement_postprocess/__manifest__.py
+++ b/account_bank_statement_postprocess/__manifest__.py
@@ -1,0 +1,24 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Accounting: Bank Statement Post-processing",
+    "summary": "Process imported bank statements to enrich records.",
+    "version": "12.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-reconcile",
+    "author": "CorporateHub, Odoo Community Association (OCA)",
+    "maintainers": ["alexey-pelykh"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "security/account_bank_statement_postprocess.xml",
+        "security/ir.model.access.csv",
+        "views/account_bank_statement_line.xml",
+        "views/account_bank_statement_postprocess_model.xml",
+        "views/account_bank_statement.xml",
+    ],
+}

--- a/account_bank_statement_postprocess/models/__init__.py
+++ b/account_bank_statement_postprocess/models/__init__.py
@@ -1,0 +1,5 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import account_bank_statement_line
+from . import account_bank_statement_postprocess_model
+from . import account_bank_statement

--- a/account_bank_statement_postprocess/models/account_bank_statement.py
+++ b/account_bank_statement_postprocess/models/account_bank_statement.py
@@ -1,0 +1,12 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountBankStatement(models.Model):
+    _inherit = "account.bank.statement"
+
+    @api.multi
+    def action_apply_postprocessing(self):
+        self.mapped('line_ids').action_apply_postprocessing()

--- a/account_bank_statement_postprocess/models/account_bank_statement_line.py
+++ b/account_bank_statement_postprocess/models/account_bank_statement_line.py
@@ -1,0 +1,28 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    @api.model
+    def create(self, vals):
+        line = super().create(vals)
+        if not self.env.context.get('skip_postprocess'):
+            line \
+                .with_context(postprocess_on_import=True) \
+                .action_apply_postprocessing()
+        return line
+
+    @api.multi
+    def action_apply_postprocessing(self):
+        postprocess_on_import = self.env.context.get('postprocess_on_import')
+        models = self.env["account.bank.statement.postprocess.model"].search(
+            [('apply_on_import', '=', True)] if postprocess_on_import else []
+        )
+        for line in self:
+            if line.journal_entry_ids.ids:
+                continue
+            models.apply(line)

--- a/account_bank_statement_postprocess/models/account_bank_statement_postprocess_model.py
+++ b/account_bank_statement_postprocess/models/account_bank_statement_postprocess_model.py
@@ -1,0 +1,541 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+from decimal import Decimal, ROUND_HALF_UP
+import re
+
+
+class AccountBankStatementPostprocessModel(models.Model):
+    _name = "account.bank.statement.postprocess.model"
+    _description = "Account Bank Statement Postprocess Model"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(
+        required=True,
+        default=10,
+    )
+    active = fields.Boolean(
+        default=True,
+    )
+    company_id = fields.Many2one(
+        string="Company",
+        comodel_name="res.company",
+        required=True,
+        default=lambda self: self.env.user.company_id,
+    )
+    name = fields.Char(
+        string="Name",
+        required=True,
+    )
+    postprocess_type = fields.Selection(
+        string="Type",
+        selection=lambda self: self._selection_postprocess_type(),
+        required=True,
+        default=lambda self: self._selection_postprocess_type()[0][0],
+        help="Type of the postprocess model",
+    )
+    match_journal_ids = fields.Many2many(
+        string="Journals",
+        comodel_name="account.journal",
+        domain=[("type", "in", ("bank", "cash"))],
+        help=(
+            "The postprocess model will only be applicable to records from the "
+            "selected journals, if specified."
+        ),
+    )
+    match_transaction_type = fields.Selection(
+        string="Transaction Type",
+        selection=[
+            ("debit", _("Debit")),
+            ("credit", _("Credit")),
+            ("any", _("Any")),
+        ],
+        default="any",
+        required=True,
+        help="Type of the transaction to apply postprocess matching to.",
+    )
+    match_field = fields.Selection(
+        string="Field",
+        selection=lambda self: self._selection_match_field(),
+        required=True,
+        help="Field of the transaction record to be used for postprocess matching.",
+    )
+    match_regexp = fields.Char(
+        string="Expression",
+        required=True,
+        help=(
+            "Regular expression used to extract information from the field of "
+            "the transaction record. See help for details."
+        ),
+    )
+    match_help = fields.Html(
+        string="Help",
+        compute="_compute_match_help",
+    )
+    apply_on_import = fields.Boolean(
+        string="Apply on Import",
+        help=(
+            "If enabled, the model will be applied automatically on statement "
+            "import."
+        ),
+    )
+    allow_recursion = fields.Boolean(
+        string="Allow Recursion",
+        help=(
+            "For models that create new statement lines: if enabled, new lines"
+            "are going to be post-processed as well."
+        ),
+    )
+    is_other_field_supported = fields.Boolean(
+        string="Is \"Other Field\" supported",
+        compute="_compute_is_other_field_supported",
+    )
+    other_field = fields.Selection(
+        string="Other Field",
+        selection=lambda self: self._selection_other_field(),
+        help="See postprocess model help.",
+    )
+    is_other_value_supported = fields.Boolean(
+        string="Is \"Other Value\" supported",
+        compute="_compute_is_other_value_supported",
+    )
+    other_value = fields.Char(
+        string="Other Value",
+    )
+
+    @api.model
+    def _selection_postprocess_type(self):
+        return [
+            ("extract_fee", _("Extract fee")),
+            ("multi_currency", _("Multi-currency")),
+            ("multi_currency_with_fee", _("Multi-currency (fee included)")),
+            ("trim_field", _("Trim field")),
+            ("append_field", _("Append field")),
+            ("merge_per_statement", _("Merge per statement")),
+            ("delete", _("Delete")),
+        ]
+
+    @api.model
+    def _selection_match_field(self):
+        fields = self.env["account.bank.statement.line"].fields_get().items()
+        return [
+            (field, definition.get("string"))
+            for field, definition in fields
+            if self._is_match_field_supported(field, definition)
+        ]
+
+    @api.model
+    def _is_match_field_supported(self, field, definition):
+        return definition["type"] in ["char", "text"]
+
+    @api.model
+    def _selection_other_field(self):
+        fields = self.env["account.bank.statement.line"].fields_get().items()
+        return [
+            (field, definition.get("string"))
+            for field, definition in fields
+            if self._is_other_field_valid(field, definition)
+        ]
+
+    @api.model
+    def _is_other_field_valid(self, field, definition):
+        return definition["type"] in ["char", "text"]
+
+    @api.multi
+    @api.depends("postprocess_type")
+    def _compute_match_help(self):
+        for model in self:
+            model.match_help = model._get_match_help()
+
+    @api.multi
+    def _get_match_help(self):
+        self.ensure_one()
+        if self.postprocess_type == "extract_fee":
+            return _(
+                "\"Extract Fee\" model looks for the fee amount in the "
+                "specified field of the transaction record. In order to "
+                "extract the fee amount value, use <code>FEE</code> or "
+                "<code>FEE_PERCENT</code> named group in the regular "
+                "expression. Value of \"Other Value\" is formatted using "
+                "named groups i.e <code>%%()s</code> for full match or "
+                "<code>%%(GROUP_NAME)s</code> for a specific group value "
+                "is used as a new transaction record description."
+            )
+        elif self.postprocess_type == "multi_currency":
+            return _(
+                "\"Multi-Currency\" model looks for the transaction amount "
+                "expressed in the other currency in case of a multi-currency "
+                "transaction record. The other currency and the amount are "
+                "saved into corresponding fields of the transaction record. "
+                "In order to extract the other currency code use "
+                "<code>CURRENCY</code> named group and "
+                "<code>AMOUNT_CURRENCY</code> for extracting the amount "
+                "expressed in that currency. <code>EXCHANGE_RATE</code> can "
+                "be specified to double-check amount computation."
+            )
+        elif self.postprocess_type == "multi_currency_with_fee":
+            return _(
+                "\"Multi-Currency (Fee Included)\" model looks for the "
+                "transaction amount expressed in the other currency in case "
+                "of a multi-currency transaction record. The other currency "
+                "and the amount are saved into corresponding fields of the "
+                "transaction record. This model writes off into transaction "
+                "fee the remainder of the transaction. In order to extract "
+                "the other currency code use <code>CURRENCY</code> named "
+                "group and <code>AMOUNT_CURRENCY</code> for extracting the "
+                "amount expressed in that currency. "
+                "<code>EXCHANGE_RATE</code> is used to compute remainder of "
+                "the transaction. Value of \"Other Value\" is formatted using "
+                "named groups i.e <code>%%()s</code> for full match or "
+                "<code>%%(GROUP_NAME)s</code> for a specific group value "
+                "is used as a new transaction record description."
+            )
+        elif self.postprocess_type == "trim_field":
+            return _(
+                "\"Trim Field\" model matches transactions by the value of "
+                "the specified field of the transaction record and removes "
+                "match from the field value using capturing groups."
+            )
+        elif self.postprocess_type == "append_field":
+            return _(
+                "\"Append Field\" model matches transactions by the value of "
+                "the specified field of the transaction record and appends "
+                "match using the value of the other field."
+            )
+        elif self.postprocess_type == "merge_per_statement":
+            return _(
+                "\"Merge per Statement\" model matches transactions by the "
+                "value of the specified field of the transaction record and "
+                "merges records that matched into a new transaction record "
+                "created per statement. Value of \"Other Value\" is formatted "
+                "using named groups (i.e <code>%%(GROUP_NAME)s</code>) is "
+                "used as a new transaction record description."
+            )
+        elif self.postprocess_type == "delete":
+            return _(
+                "\"Delete\" model matches transactions by the value of "
+                "the specified field of the transaction record and deletes "
+                "records that matched."
+            )
+
+    @api.multi
+    @api.depends("postprocess_type")
+    def _compute_is_other_field_supported(self):
+        for model in self:
+            model.is_other_field_supported = model._is_other_field_supported()
+
+    @api.multi
+    def _is_other_field_supported(self):
+        self.ensure_one()
+        return self.postprocess_type in [
+            "append_field",
+        ]
+
+    @api.multi
+    @api.depends("postprocess_type")
+    def _compute_is_other_value_supported(self):
+        for model in self:
+            model.is_other_value_supported = model._is_other_value_supported()
+
+    @api.multi
+    def _is_other_value_supported(self):
+        self.ensure_one()
+        return self.postprocess_type in [
+            "extract_fee",
+            "multi_currency_with_fee",
+            "merge_per_statement",
+        ]
+
+    @api.multi
+    def apply(self, lines):
+        for model in self:
+            regexp = re.compile(model.match_regexp, re.DOTALL | re.MULTILINE)
+            for line in lines.exists():
+                if model._is_applicable(line):
+                    model._try_to_apply(regexp, line)
+
+    @api.multi
+    def _is_applicable(self, line):
+        self.ensure_one()
+        if self.match_journal_ids \
+                and line.journal_id not in self.match_journal_ids:
+            return False
+        if self.match_transaction_type == "debit" and line.amount >= 0.0:
+            return False
+        if self.match_transaction_type == "credit" and line.amount <= 0.0:
+            return False
+        return True
+
+    @api.multi
+    def _try_to_apply(self, regexp, line):
+        self.ensure_one()
+        value = str(line[self.match_field])
+        match = regexp.search(value)
+        if match is not None:
+            self._apply(line, value, match)
+
+    @api.multi
+    def _apply(self, line, value, match):
+        self.ensure_one()
+        if self.postprocess_type == "extract_fee":
+            self._apply_extract_fee(line, value, match)
+        elif self.postprocess_type == "multi_currency":
+            self._apply_multi_currency(line, value, match)
+        elif self.postprocess_type == "multi_currency_with_fee":
+            self._apply_multi_currency_with_fee(line, value, match)
+        elif self.postprocess_type == "trim_field":
+            self._apply_trim_field(line, value, match)
+        elif self.postprocess_type == "append_field":
+            self._apply_append_field(line, value, match)
+        elif self.postprocess_type == "merge_per_statement":
+            self._apply_merge_per_statement(line, value, match)
+        elif self.postprocess_type == "delete":
+            self._apply_delete(line, value, match)
+
+    @api.multi
+    def _create_new_statement_line(self, vals):
+        self.ensure_one()
+        AccountBankStatementLine = self.env["account.bank.statement.line"]
+        if not self.allow_recursion:
+            AccountBankStatementLine = AccountBankStatementLine.with_context(
+                skip_postprocess=True,
+            )
+        return AccountBankStatementLine.create(vals)
+
+    @api.multi
+    def _apply_extract_fee(self, line, value, match):
+        self.ensure_one()
+        match_groups = match.groupdict()
+        if "FEE" not in match_groups and "FEE_PERCENT" not in match_groups:
+            raise UserError(_(
+                "\"%s\" expression is incorrect for \"Extract Fee\" model:"
+                " please specify FEE or FEE_PERCENT named group."
+            ))
+        fee_value = match_groups.get("FEE")
+        fee_percent_value = match_groups.get("FEE_PERCENT")
+        if fee_value and fee_percent_value:
+            raise UserError(_(
+                "\"%s\" expression is incorrect for \"Extract Fee\" model:"
+                " please specify only one named group: FEE or FEE_PERCENT."
+            ))
+        currency = line.statement_id.currency_id
+        fee_amount = self._parse_decimal(
+            fee_value or fee_percent_value,
+            currency=currency if fee_value else None,
+        )
+        line_amount = Decimal(str(line.amount))
+        if fee_percent_value:
+            fee_amount = fee_amount * Decimal("0.01")
+            fee_amount = self._round_decimal(
+                line_amount * fee_amount,
+                currency
+            )
+        fee_amount = fee_amount.copy_sign(line_amount)
+
+        fee_line = self._create_new_statement_line({
+            "name": (self.other_value or _("Extracted Fee: %()s")) % {
+                **match_groups,
+                "": line.name,
+            },
+            "date": line.date,
+            "amount": str(fee_amount),
+            "statement_id": line.statement_id.id,
+            "sequence": line.sequence,
+        })
+        line.amount = line.amount - fee_line.amount
+
+    @api.multi
+    def _apply_multi_currency(self, line, value, match):
+        self.ensure_one()
+        match_groups = match.groupdict()
+        if "CURRENCY" not in match_groups \
+                or "AMOUNT_CURRENCY" not in match_groups:
+            raise UserError(_(
+                "\"%s\" expression is incorrect for \"Multi-Currency\" "
+                "model: please specify CURRENCY and AMOUNT_CURRENCY named "
+                "groups. Optionally, use EXCHANGE_RATE."
+            ))
+        currency_code = match_groups.get("CURRENCY")
+        amount_currency_value = match_groups.get("AMOUNT_CURRENCY")
+
+        currency = self.env["res.currency"].search(
+            [("name", "=ilike", currency_code)]
+        )
+        if not currency:
+            raise UserError(_(
+                "Currency with code \"%s\" does not exist or inactive"
+            ) % (
+                currency_code,
+            ))
+
+        line_amount = Decimal(str(line.amount))
+        amount_currency = self._parse_decimal(
+            amount_currency_value,
+            currency=currency,
+        )
+        amount_currency = amount_currency.copy_sign(line_amount)
+
+        exchange_rate_value = match_groups.get("EXCHANGE_RATE")
+        if exchange_rate_value:
+            exchange_rate = self._parse_decimal(
+                exchange_rate_value
+            )
+            computed_amount_currency = self._round_decimal(
+                line_amount / exchange_rate,
+                currency
+            )
+            if computed_amount_currency != amount_currency:
+                raise UserError(_(
+                    "Amount computed using reference exchange rate (%s) "
+                    "differs from the amount parsed from the field (%s)."
+                ) % (
+                    computed_amount_currency,
+                    amount_currency,
+                ))
+        line.write({
+            "amount_currency": str(amount_currency),
+            "currency_id": currency.id,
+        })
+
+    @api.multi
+    def _apply_multi_currency_with_fee(self, line, value, match):
+        self.ensure_one()
+        match_groups = match.groupdict()
+        if "CURRENCY" not in match_groups \
+                or "AMOUNT_CURRENCY" not in match_groups \
+                or "EXCHANGE_RATE" not in match_groups:
+            raise UserError(_(
+                "\"%s\" expression is incorrect for \"Multi-Currency (Fee "
+                "Included)\" model: please specify CURRENCY, "
+                "AMOUNT_CURRENCY, and EXCHANGE_RATE named groups."
+            ))
+        currency_code = match_groups.get("CURRENCY")
+        amount_currency_value = match_groups.get("AMOUNT_CURRENCY")
+        exchange_rate_value = match_groups.get("EXCHANGE_RATE")
+
+        currency = self.env["res.currency"].search(
+            [("name", "=ilike", currency_code)]
+        )
+        if not currency:
+            raise UserError(_(
+                "Currency with code \"%s\" does not exist or inactive"
+            ) % (
+                currency_code,
+            ))
+
+        total_amount = Decimal(str(line.amount))
+        exchange_rate = self._parse_decimal(exchange_rate_value)
+
+        amount_currency = self._parse_decimal(
+            amount_currency_value,
+            currency=currency,
+        )
+        amount_currency = amount_currency.copy_sign(total_amount)
+        line_amount = self._round_decimal(
+            amount_currency * exchange_rate,
+            line.statement_id.currency_id
+        )
+        fee_amount = total_amount - line_amount
+
+        self._create_new_statement_line({
+            "name": (self.other_value or _("Extracted Fee: %()s")) % {
+                **match_groups,
+                "": line.name,
+            },
+            "date": line.date,
+            "amount": str(fee_amount),
+            "statement_id": line.statement_id.id,
+            "sequence": line.sequence,
+        })
+        line.write({
+            "amount": str(line_amount),
+            "amount_currency": str(amount_currency),
+            "currency_id": currency.id,
+        })
+
+    @api.multi
+    def _apply_trim_field(self, line, value, match):
+        self.ensure_one()
+        if match.groups():
+            for group in match.groups():
+                value = value.replace(group, "")
+        else:
+            value = value.replace(match.group(), "")
+        line.write({
+            self.match_field: value,
+        })
+
+    @api.multi
+    def _apply_append_field(self, line, value, match):
+        self.ensure_one()
+        other_value = str(line[self.other_field])
+        if not other_value:
+            return
+        end_of_match = match.end()
+        value = "; ".join(part for part in [
+            value[:end_of_match],
+            str(line[self.other_field]),
+            value[end_of_match:],
+        ] if part)
+        line.write({
+            self.match_field: value,
+        })
+
+    @api.multi
+    def _apply_merge_per_statement(self, line, value, match):
+        self.ensure_one()
+        match_groups = match.groupdict()
+        merged_line_name = (self.other_value or _("Merged Transaction")) % {
+            **match_groups,
+        }
+        merged_line = self.env["account.bank.statement.line"].search(
+            [
+                ("name", "=", merged_line_name),
+                ("date", "=", line.statement_id.date),
+                ("statement_id", "=", line.statement_id.id),
+            ],
+            limit=1,
+        )
+        if not merged_line:
+            merged_line = self._create_new_statement_line({
+                "name": merged_line_name,
+                "date": line.statement_id.date,
+                "statement_id": line.statement_id.id,
+            })
+        merged_line.amount += line.amount
+        line.unlink()
+
+    @api.multi
+    def _apply_delete(self, line, value, match):
+        self.ensure_one()
+        line.unlink()
+
+    @api.multi
+    def _parse_decimal(self, value, currency=None):
+        self.ensure_one()
+        value_decimal_part = value[
+            -(currency.decimal_places + 1 if currency else len(value)):
+        ]
+        comma_index = value_decimal_part.rfind(",")
+        dot_index = value_decimal_part.rfind(".")
+        if comma_index > dot_index:
+            decimal_separator = ","
+            thousands_separator = "."
+        else:
+            decimal_separator = "."
+            thousands_separator = ","
+        value = value.replace(thousands_separator, "")
+        if decimal_separator != ".":
+            value = value.replace(decimal_separator, ".")
+        return Decimal(value)
+
+    @api.multi
+    def _round_decimal(self, value, currency):
+        self.ensure_one()
+        return value.quantize(
+            Decimal(10) ** -currency.decimal_places,
+            rounding=ROUND_HALF_UP
+        )

--- a/account_bank_statement_postprocess/readme/CONTRIBUTORS.rst
+++ b/account_bank_statement_postprocess/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/account_bank_statement_postprocess/readme/DESCRIPTION.rst
+++ b/account_bank_statement_postprocess/readme/DESCRIPTION.rst
@@ -1,0 +1,17 @@
+This module extends the functionality of Bank Statements to support various
+post-processing models that are applied to the records.
+
+Supported models:
+
+ * "Extract fee" creates an extra record on the statement with fee and
+   subtracts that from the original record.
+ * "Multi-currency" adjusts the record to reflect multi-currency
+   transaction values.
+ * "Multi-currency (fee included)" adjusts the record to reflect multi-currency
+   transaction values (with fee included).
+ * "Trim field" adjusts the record by trimming part of the value.
+ * "Append field" adjusts the record by appending part of the value using the
+   value of the other field.
+ * "Merge per statement" merged matching records into a new one within the
+   same statement, e.g. merge fees for faster reconcile.
+ * "Delete" removes matching records from the statement.

--- a/account_bank_statement_postprocess/readme/USAGE.rst
+++ b/account_bank_statement_postprocess/readme/USAGE.rst
@@ -1,0 +1,8 @@
+To ignore or un-ignore transaction currency on bank statement line:
+
+#. Go to Statement
+#. Click on blue *Ignore Currency* or gray *Un-Ignore* icon on statement line
+
+To ignore or un-ignore transaction currency during reconciliation:
+
+#. Click on blue *Ignore Currency* or gray *Un-Ignore* icon on statement line

--- a/account_bank_statement_postprocess/security/account_bank_statement_postprocess.xml
+++ b/account_bank_statement_postprocess/security/account_bank_statement_postprocess.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+    <record id="account_bank_statement_postprocess_model_multicompany" model="ir.rule">
+        <field name="name">Account Bank Statement Postprocess Model multi-company</field>
+        <field name="model_id" ref="model_account_bank_statement_postprocess_model"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_postprocess/security/ir.model.access.csv
+++ b/account_bank_statement_postprocess/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_bank_statement_postprocess_model,account.bank.statement.postprocess.model,model_account_bank_statement_postprocess_model,account.group_account_user,1,1,1,1

--- a/account_bank_statement_postprocess/tests/__init__.py
+++ b/account_bank_statement_postprocess/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_account_bank_statement_postprocess_model

--- a/account_bank_statement_postprocess/tests/test_account_bank_statement_postprocess_model.py
+++ b/account_bank_statement_postprocess/tests/test_account_bank_statement_postprocess_model.py
@@ -1,0 +1,615 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountBankStatementPostprocessModel(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_eur = self.env.ref("base.EUR")
+        self.AccountJournal = self.env["account.journal"]
+        self.AccountBankStatement = self.env["account.bank.statement"]
+        self.AccountBankStatementLine = self.env["account.bank.statement.line"]
+        self.AccountBankStatementPostprocessModel = self.env[
+            "account.bank.statement.postprocess.model"
+        ]
+
+    def test_extract_fee_percent(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (+ 1.00%)",
+            "amount": "100.0",
+            "amount_currency": "85.0",
+            "currency_id": self.currency_eur.id,
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "extract_fee",
+            "match_field": "name",
+            "match_regexp": r"\(\+\s+(?P<FEE_PERCENT>[\d.,]+)%\)",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        self.assertEqual(line.amount, 99.0)
+
+        fee_line = statement.line_ids - line
+        self.assertEqual(fee_line.amount, 1.00)
+        self.assertEqual(fee_line.name, "Extracted Fee: TRANSACTION (+ 1.00%)")
+
+    def test_extract_fee(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (+ 1.00)",
+            "amount": "100.0",
+            "amount_currency": "85.0",
+            "currency_id": self.currency_eur.id,
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "extract_fee",
+            "match_field": "name",
+            "match_regexp": r"\(\+\s+(?P<FEE>[\d.,]+)\)",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        self.assertEqual(line.amount, 99.0)
+
+        fee_line = statement.line_ids - line
+        self.assertEqual(fee_line.amount, 1.00)
+        self.assertEqual(fee_line.name, "Extracted Fee: TRANSACTION (+ 1.00)")
+
+    def test_extract_fee_custom_description(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (+ 1.00)",
+            "amount": "100.0",
+            "amount_currency": "85.0",
+            "currency_id": self.currency_eur.id,
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "extract_fee",
+            "match_field": "name",
+            "match_regexp": r"\(\+\s+(?P<FEE>[\d.,]+)\)",
+            "other_value": "Custom: %()s",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+
+        fee_line = statement.line_ids - line
+        self.assertEqual(fee_line.name, "Custom: TRANSACTION (+ 1.00)")
+
+    def test_multi_currency(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (85.00 EUR)",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "multi_currency",
+            "match_field": "name",
+            "match_regexp": (
+                r"\((?P<AMOUNT_CURRENCY>[\d.,]+)\s+(?P<CURRENCY>[A-Z]{3})\)"
+            ),
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 1)
+        self.assertEqual(line.amount, 100.0)
+        self.assertEqual(line.amount_currency, 85.0)
+        self.assertEqual(line.currency_id, self.currency_eur)
+
+    def test_multi_currency_with_fee(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_eur.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (56.00 USD + 0.56, 0.8830357)",
+            "amount": "-49.94",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Multi-Currency (Fee Included)",
+            "postprocess_type": "multi_currency_with_fee",
+            "match_field": "name",
+            "match_regexp": (
+                r"\s*\((?P<AMOUNT_CURRENCY>[\d.,]+)\s+(?P<CURRENCY>[A-Z]{3})"
+                r"\s+\+\s+(?P<FEE>[\d.,]+),\s+"
+                r"(?P<EXCHANGE_RATE>[\d.,]+)\)"
+            ),
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        fee_line = statement.line_ids - line
+
+        self.assertEqual(line.amount, -49.45)
+        self.assertEqual(line.amount_currency, -56.0)
+        self.assertEqual(line.currency_id, self.currency_usd)
+
+        self.assertEqual(fee_line.amount, -0.49)
+        self.assertEqual(fee_line.amount_currency, 0.0)
+        self.assertFalse(fee_line.currency_id)
+        self.assertEqual(
+            fee_line.name,
+            "Extracted Fee: TRANSACTION (56.00 USD + 0.56, 0.8830357)"
+        )
+
+    def test_multi_currency_with_fee_percent(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_eur.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (56.00 USD, 0.8830357)",
+            "amount": "-49.94",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Multi-Currency (Fee Included)",
+            "postprocess_type": "multi_currency_with_fee",
+            "match_field": "name",
+            "match_regexp": (
+                r"\s*\((?P<AMOUNT_CURRENCY>[\d.,]+)\s+(?P<CURRENCY>[A-Z]{3}),"
+                r"\s+(?P<EXCHANGE_RATE>[\d.,]+)\)"
+            ),
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        fee_line = statement.line_ids - line
+
+        self.assertEqual(line.amount, -49.45)
+        self.assertEqual(line.amount_currency, -56.0)
+        self.assertEqual(line.currency_id, self.currency_usd)
+
+        self.assertEqual(fee_line.amount, -0.49)
+        self.assertEqual(fee_line.amount_currency, 0.0)
+        self.assertFalse(fee_line.currency_id)
+        self.assertEqual(
+            fee_line.name,
+            "Extracted Fee: TRANSACTION (56.00 USD, 0.8830357)"
+        )
+
+    def test_multi_currency_with_fee_custom_description(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_eur.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (56.00 USD, 0.8830357)",
+            "amount": "-49.94",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Multi-Currency (Fee Included)",
+            "postprocess_type": "multi_currency_with_fee",
+            "match_field": "name",
+            "match_regexp": (
+                r"\s*\((?P<AMOUNT_CURRENCY>[\d.,]+)\s+(?P<CURRENCY>[A-Z]{3}),"
+                r"\s+(?P<EXCHANGE_RATE>[\d.,]+)\)"
+            ),
+            "other_value": "Custom: %()s",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        fee_line = statement.line_ids - line
+
+        self.assertEqual(line.amount, -49.45)
+        self.assertEqual(line.amount_currency, -56.0)
+        self.assertEqual(line.currency_id, self.currency_usd)
+
+        self.assertEqual(fee_line.amount, -0.49)
+        self.assertEqual(fee_line.amount_currency, 0.0)
+        self.assertFalse(fee_line.currency_id)
+        self.assertEqual(
+            fee_line.name,
+            "Custom: TRANSACTION (56.00 USD, 0.8830357)"
+        )
+
+    def test_trim_field(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (JUNK)",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "trim_field",
+            "match_field": "name",
+            "match_regexp": r"\s+\(JUNK\)",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(line.name, "TRANSACTION")
+
+    def test_trim_field_groups(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (JUNK)",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "trim_field",
+            "match_field": "name",
+            "match_regexp": r"(?:TRANSACTION)( \(JUNK\))",
+        })
+
+        model.apply(line)
+
+        self.assertEqual(line.name, "TRANSACTION")
+
+    def test_append_field(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "append_field",
+            "match_field": "name",
+            "match_regexp": r".*",
+            "other_field": "note"
+        })
+
+        model.apply(line)
+
+        self.assertEqual(line.name, "TRANSACTION; NOTE")
+
+    def test_merge_per_statement(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION1",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION1-ID",
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION2",
+            "amount": "200.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION2-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "merge_per_statement",
+            "match_field": "name",
+            "match_regexp": "TRANSACTION",
+        })
+
+        model.apply(statement.line_ids)
+
+        self.assertEqual(len(statement.line_ids), 1)
+        self.assertEqual(statement.line_ids.name, "Merged Transaction")
+        self.assertEqual(statement.line_ids.amount, 300.0)
+
+    def test_merge_per_statement_custom_description(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "EXCHANGE1",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "EXCHANGE1-ID",
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "FEE1",
+            "amount": "1.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "FEE1-ID",
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "EXCHANGE2",
+            "amount": "50.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "EXCHANGE2-ID",
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "FEE2",
+            "amount": "0.5",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "FEE2-ID",
+        })
+        model_1 = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model 1",
+            "postprocess_type": "merge_per_statement",
+            "match_field": "name",
+            "match_regexp": "FEE",
+            "other_value": "Merged Fee",
+        })
+        model_2 = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model 2",
+            "postprocess_type": "merge_per_statement",
+            "match_field": "name",
+            "match_regexp": "EXCHANGE",
+            "other_value": "Merged Exchange",
+        })
+
+        (model_1 | model_2).apply(statement.line_ids)
+
+        self.assertEqual(len(statement.line_ids), 2)
+
+    def test_delete(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION2",
+            "amount": "200.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION2-ID",
+        })
+        model = self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "delete",
+            "match_field": "name",
+            "match_regexp": "TRANSACTION2",
+        })
+
+        model.apply(statement.line_ids)
+
+        self.assertEqual(statement.line_ids, line)
+
+    def test_apply_on_import(self):
+        self.AccountBankStatementPostprocessModel.create({
+            "name": "Postprocess Model",
+            "postprocess_type": "trim_field",
+            "match_field": "name",
+            "match_regexp": r"(?:TRANSACTION)( \(JUNK\))",
+            "apply_on_import": True,
+        })
+
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_usd.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (JUNK)",
+            "amount": "100.0",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+
+        self.assertEqual(line.name, "TRANSACTION")
+
+    def test_combined_models(self):
+        journal = self.AccountJournal.create({
+            "name": "Bank",
+            "type": "bank",
+            "code": "BANK",
+            "currency_id": self.currency_eur.id,
+        })
+        statement = self.AccountBankStatement.create({
+            "name": "Statement",
+            "journal_id": journal.id,
+        })
+        line = self.AccountBankStatementLine.create({
+            "statement_id": statement.id,
+            "name": "TRANSACTION (56.00 USD + 1.0%, 0.8830357)",
+            "amount": "-49.94",
+            "date": "2020-09-01",
+            "note": "NOTE",
+            "unique_import_id": "TRANSACTION-ID",
+        })
+        multi_currency = self.AccountBankStatementPostprocessModel.create({
+            "name": "Multi-Currency",
+            "postprocess_type": "multi_currency",
+            "match_field": "name",
+            "match_regexp": (
+                r"\s*\((?P<AMOUNT_CURRENCY>[\d.,]+)\s+(?P<CURRENCY>[A-Z]{3})\s+"
+                r"\+\s+(?:[\d.,]+)%,\s+(?:[\d.,]+)\)"
+            ),
+        })
+        extract_fee = self.AccountBankStatementPostprocessModel.create({
+            "name": "Extract Fee",
+            "postprocess_type": "extract_fee",
+            "match_field": "name",
+            "match_regexp": (
+                r"\s*\((?:[\d.,]+)\s+(?:[A-Z]{3})\s+\+\s+"
+                r"(?P<FEE_PERCENT>[\d.,]+)%,\s+(?:[\d.,]+)\)"
+            ),
+        })
+
+        (multi_currency | extract_fee).apply(line)
+
+        self.assertEqual(len(statement.line_ids), 2)
+        fee_line = statement.line_ids - line
+
+        self.assertEqual(line.amount, -49.44)
+        self.assertEqual(line.amount_currency, -56.0)
+        self.assertEqual(line.currency_id, self.currency_usd)
+
+        self.assertEqual(fee_line.amount, -0.50)
+        self.assertEqual(fee_line.amount_currency, 0.0)
+        self.assertFalse(fee_line.currency_id)

--- a/account_bank_statement_postprocess/views/account_bank_statement.xml
+++ b/account_bank_statement_postprocess/views/account_bank_statement.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="action_account_bank_statement_postprocess" model="ir.actions.server">
+        <field name="name">Apply Post-Processing</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="account.model_account_bank_statement"/>
+        <field name="binding_model_id" ref="account.model_account_bank_statement"/>
+        <field name="code">
+            if records:
+                records.action_apply_postprocessing()
+        </field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_postprocess/views/account_bank_statement_line.xml
+++ b/account_bank_statement_postprocess/views/account_bank_statement_line.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="action_account_bank_statement_line_postprocess" model="ir.actions.server">
+        <field name="name">Apply Post-Processing</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="account.model_account_bank_statement_line"/>
+        <field name="binding_model_id" ref="account.model_account_bank_statement_line"/>
+        <field name="code">
+            if records:
+                records.action_apply_postprocessing()
+        </field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_postprocess/views/account_bank_statement_postprocess_model.xml
+++ b/account_bank_statement_postprocess/views/account_bank_statement_postprocess_model.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="account_bank_statement_postprocess_model_form" model="ir.ui.view">
+        <field name="name">account.bank.statement.postprocess.model.form</field>
+        <field name="model">account.bank.statement.postprocess.model</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
+                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1>
+                            <field name="name" placeholder="e.g. Extract Fees"/>
+                        </h1>
+                    </div>
+                    <field name="is_other_field_supported" invisible="1"/>
+                    <field name="is_other_value_supported" invisible="1"/>
+                    <group groups="base.group_multi_company">
+                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                    </group>
+                    <group>
+                        <group>
+                            <field name="postprocess_type" widget="radio"/>
+                        </group>
+                        <group>
+                            <field name="match_help" nolabel="1"/>
+                        </group>
+                        <group>
+                            <field name="match_field"/>
+                        </group>
+                        <group>
+                            <field name="match_regexp"/>
+                        </group>
+                        <group>
+                            <field name="apply_on_import"/>
+                        </group>
+                        <group>
+                            <field name="allow_recursion"/>
+                        </group>
+                        <group attrs="{'invisible': [('is_other_field_supported', '!=', True)]}">
+                            <field name="other_field"/>
+                        </group>
+                        <group attrs="{'invisible': [('is_other_value_supported', '!=', True)]}">
+                            <field name="other_value"/>
+                        </group>
+                    </group>
+                    <group string="Conditions">
+                        <group>
+                            <field name="match_journal_ids" options="{'no_create': True}" widget="many2many_tags"/>
+                        </group>
+                        <group>
+                            <field name="match_transaction_type" widget="radio"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="account_bank_statement_postprocess_model_tree" model="ir.ui.view">
+        <field name="name">account.bank.statement.postprocess.model.tree</field>
+        <field name="model">account.bank.statement.postprocess.model</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="account_bank_statement_postprocess_model_search" model="ir.ui.view">
+        <field name="name">account.bank.statement.postprocess.model.search</field>
+        <field name="model">account.bank.statement.postprocess.model</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter name="active" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_bank_statement_postprocess_model" model="ir.actions.act_window">
+        <field name="name">Bank Statement Post-Process Models</field>
+        <field name="res_model">account.bank.statement.postprocess.model</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new bank statement post-process model
+            </p>
+            <p>
+                Those can be used to post-process existing bank statement records.
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_bank_statement_postprocess_model" parent="account.account_account_menu" action="action_bank_statement_postprocess_model" sequence="101" />
+
+</odoo>


### PR DESCRIPTION
This module extends the functionality of Bank Statements to support various
post-processing models that are applied to the records.

Supported models:

 * "Extract fee" creates an extra record on the statement with fee and
   subtracts that from the original record.
 * "Multi-currency" adjusts the record to reflect multi-currency
   transaction values.
 * "Multi-currency (fee included)" adjusts the record to reflect multi-currency
   transaction values (with fee included).
 * "Trim field" adjusts the record by trimming part of the value.
 * "Append field" adjusts the record by appending part of the value using the
   value of the other field.
 * "Merge per statement" merged matching records into a new one within the
   same statement, e.g. merge fees for faster reconcile.
 * "Delete" removes matching records from the statement.
