### PR TITLE
[11.0] [ADD] account_reconcile_payment_order: Inbound and outbound payment's support

### DIFF
--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -15,11 +15,12 @@ class AccountBankStatementLine(models.Model):
         return self.env['account.payment.order'].search([
             ('total_company_currency', '=', self.amount),
             ('state', 'in', ['done', 'uploaded']),
-			('payment_type', '=', ['inbound']),
-		]), self.env['account.payment.order'].search([
+            ('payment_type', '=', ['inbound']),
+        ]),
+        self.env['account.payment.order'].search([
             ('total_company_currency', '=', -self.amount),
             ('state', 'in', ['done', 'uploaded']),
-			('payment_type', '=', ['outbound']),
+            ('payment_type', '=', ['outbound']),
         ])
 
     def prepare_proposition_from_orders(self, orders, excluded_ids=None):

--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -13,8 +13,13 @@ class AccountBankStatementLine(models.Model):
         line.
         """
         return self.env['account.payment.order'].search([
+            ('total_company_currency', '=', self.amount),
+            ('state', 'in', ['done', 'uploaded']),
+			('payment_type', '=', ['inbound']),
+		]), self.env['account.payment.order'].search([
             ('total_company_currency', '=', -self.amount),
             ('state', 'in', ['done', 'uploaded']),
+			('payment_type', '=', ['outbound']),
         ])
 
     def prepare_proposition_from_orders(self, orders, excluded_ids=None):

--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -13,7 +13,7 @@ class AccountBankStatementLine(models.Model):
         line.
         """
         return self.env['account.payment.order'].search([
-            ('total_company_currency', '=', self.amount),
+            ('total_company_currency', '=', -self.amount),
             ('state', 'in', ['done', 'uploaded']),
         ])
 

--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -15,12 +15,12 @@ class AccountBankStatementLine(models.Model):
         return self.env['account.payment.order'].search([
             ('total_company_currency', '=', self.amount),
             ('state', 'in', ['done', 'uploaded']),
-            ('payment_type', '=', ['inbound']),
+            ('payment_type', '=', 'inbound'),
         ]),
         self.env['account.payment.order'].search([
             ('total_company_currency', '=', -self.amount),
             ('state', 'in', ['done', 'uploaded']),
-            ('payment_type', '=', ['outbound']),
+            ('payment_type', '=', 'outbound'),
         ])
 
     def prepare_proposition_from_orders(self, orders, excluded_ids=None):

--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -12,7 +12,7 @@ class AccountBankStatementLine(models.Model):
         """Find orders that might be candidates for matching a statement
         line.
         """
-        return self.env['account.payment.order'].search([
+        return [self.env['account.payment.order'].search([
             ('total_company_currency', '=', self.amount),
             ('state', 'in', ['done', 'uploaded']),
             ('payment_type', '=', 'inbound'),
@@ -21,7 +21,7 @@ class AccountBankStatementLine(models.Model):
             ('total_company_currency', '=', -self.amount),
             ('state', 'in', ['done', 'uploaded']),
             ('payment_type', '=', 'outbound'),
-        ])
+        ])]
 
     def prepare_proposition_from_orders(self, orders, excluded_ids=None):
         """Fill with the expected format the reconciliation proposition

--- a/account_reconcile_payment_order/models/account_bank_statement_line.py
+++ b/account_reconcile_payment_order/models/account_bank_statement_line.py
@@ -12,16 +12,18 @@ class AccountBankStatementLine(models.Model):
         """Find orders that might be candidates for matching a statement
         line.
         """
-        return [self.env['account.payment.order'].search([
-            ('total_company_currency', '=', self.amount),
-            ('state', 'in', ['done', 'uploaded']),
+        inbound_apo = self.env['account.payment.order'].search([
             ('payment_type', '=', 'inbound'),
-        ]),
-        self.env['account.payment.order'].search([
-            ('total_company_currency', '=', -self.amount),
-            ('state', 'in', ['done', 'uploaded']),
+            ('total_company_currency', '=', self.amount),
+            ('state', 'in', ['done', 'uploaded'])
+        ])
+        outbound_apo = self.env['account.payment.order'].search([
             ('payment_type', '=', 'outbound'),
-        ])]
+            ('total_company_currency', '=', -self.amount),
+            ('state', 'in', ['done', 'uploaded'])
+        ])
+        matched_apo = inbound_apo + outbound_apo
+        return matched_apo
 
     def prepare_proposition_from_orders(self, orders, excluded_ids=None):
         """Fill with the expected format the reconciliation proposition


### PR DESCRIPTION
If self.amount is positive, the account payment order which is an outgoing payment will never be proposed on the bank statement line to match.
If self.amount is negative it will be proposed to be reconciled on the bank outgoing payment from the funds of the account.

This is what happens actually, if the proposed value is changed to negative it will be suggested to reconcile properly on the bank statement.

@pedrobaeza  ¿What do you think?

Before changing the value

![CapturaA](https://user-images.githubusercontent.com/15079415/95329560-6f039b00-08a7-11eb-8037-9809addbcb6f.PNG)
![CapturaB](https://user-images.githubusercontent.com/15079415/95329561-6f9c3180-08a7-11eb-89bc-514cfa918998.PNG)
![CapturaC](https://user-images.githubusercontent.com/15079415/95329563-6f9c3180-08a7-11eb-9226-ac9c00f952ab.PNG)


After changing the value

![CapturaD](https://user-images.githubusercontent.com/15079415/95330116-5c3d9600-08a8-11eb-88b5-d50adcb4b56a.PNG)
