### PR TITLE
[12.0] account_move_transactionid_import fix

### DIFF
--- a/account_move_transactionid_import/models/account_move.py
+++ b/account_move_transactionid_import/models/account_move.py
@@ -34,7 +34,7 @@ class AccountMoveCompletionRule(models.Model):
             """
         res = {}
         so_obj = self.env['sale.order']
-        sales = so_obj.search([('transaction_id', '=', line.ref)])
+        sales = so_obj.search([('transaction_id', '=', line.name)])
         partners = sales.mapped('partner_id')
         if len(partners) > 1:
             raise ErrorTooManyPartner(
@@ -63,7 +63,7 @@ class AccountMoveCompletionRule(models.Model):
         res = {}
         invoice_obj = self.env['account.invoice']
         invoices = invoice_obj.search(
-            [('transaction_id', '=', line.ref)])
+            [('transaction_id', '=', line.name)])
         partners = invoices.mapped('partner_id.commercial_partner_id')
         accounts = invoices.mapped('account_id')
         if len(partners) > 1:


### PR DESCRIPTION
in #347 and #321 we adapt the way the transactionID is propagated on the
account.move / account.move.line: using the move.ref is not efficient in
case of payment remittance import -> we move the transactionID to the
name of the account.move.line (which is how it is handled in
odoo >= 13.0).

This PR follows to adapt the autocompletion based on transactionID.