### PR TITLE
[IMP] account_mass_reconcile advanced.label

### DIFF
--- a/account_mass_reconcile/models/advanced_reconciliation.py
+++ b/account_mass_reconcile/models/advanced_reconciliation.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2016 Camptocamp SA
+# Copyright 2012-2020 Camptocamp SA
 # Copyright 2010 Sébastien Beau
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -94,11 +94,32 @@ class MassReconcileAdvancedRef(models.TransientModel):
         yield ('ref', (move_line['ref'], move_line['name'])
 
         An OR is used between the values for the same key.
-        An AND is used between the differents keys.
+        An AND is used between the different keys.
 
         :param dict move_line: values of the move_line
         :yield: matchers as tuple ('matcher key', value(s))
         """
         yield ('partner_id', move_line['partner_id'])
-        yield ('ref', ((move_line['ref'] or '').lower().strip(),
-                       move_line['name'].lower().strip()))
+        yield ('ref', ((move_line['name'] or '').lower().strip(),
+                       (move_line['ref'] or '').lower().strip()))
+
+
+class MassReconcileAdvancedLabel(models.TransientModel):
+
+    _name = 'mass.reconcile.advanced.label'
+    _inherit = 'mass.reconcile.advanced'
+
+    @staticmethod
+    def _skip_line(move_line):
+        return not (move_line.get('name') and move_line.get('partner_id'))
+
+    @staticmethod
+    def _matchers(move_line):
+        return (('partner_id', move_line['partner_id']),
+                ('name', move_line['name'].lower().strip()))
+
+    @staticmethod
+    def _opposite_matchers(move_line):
+        yield ('partner_id', move_line['partner_id'])
+        yield ('name', ((move_line['ref'] or '').lower().strip(),
+                        move_line['name'].lower().strip()))

--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -80,6 +80,8 @@ class AccountMassReconcileMethod(models.Model):
              'Simple. Amount and Reference'),
             ('mass.reconcile.advanced.ref',
              'Advanced. Partner and Ref.'),
+            ('mass.reconcile.advanced.label',
+             'Advanced. Partner and Label.'),
         ]
 
     def _selection_name(self):

--- a/account_mass_reconcile/readme/DESCRIPTION.rst
+++ b/account_mass_reconcile/readme/DESCRIPTION.rst
@@ -16,3 +16,7 @@ in this module, the simple reconciliations works
 on 2 lines (1 debit / 1 credit) and do not allow
 partial reconciliation, they also match on 1 key,
 partner or Journal item name.
+
+2 advanced reconciliation methods are also available, which can make full
+reconcilations, based on the account move lines' Label and Reference, for moves
+with the same partner.

--- a/account_mass_reconcile/views/mass_reconcile.xml
+++ b/account_mass_reconcile/views/mass_reconcile.xml
@@ -58,7 +58,12 @@ The lines should have the same amount (with the write-off) and the same referenc
                           <group colspan="2" col="2">
                               <separator colspan="4" string="Advanced. Partner and Ref"/>
                               <label for="reconcile_method" string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
-The lines should have the same partner, and the credit entry ref. is matched with the debit entry ref. or name." colspan="4"/>
+The lines should have the same partner, and the credit entry Reference (ref) is matched with the debit entry Label (name) or Reference (ref)." colspan="4"/>
+                          </group>
+                          <group colspan="2" col="2">
+                              <separator colspan="4" string="Advanced. Partner and Label"/>
+                              <label for="reconcile_method" string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
+The lines should have the same partner, and the credit entry Label (name) is matched with the debit entry Reference (ref) or Label (name)." colspan="4"/>
                           </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
Added the 'mass.reconcile.advanced.label' model to at least be able to
reconcile payments as Odoo would. In Odoo the customer invoice has the
payment reference in the account move ref field, and the payment
typically has this in the move line name field. Since the invoice
account move line that we want to reconcile for customer invoices is a
debit line, and the payment we want to find is a credit line, we need to
invert the current implementation of the reconciliation

'mass.reconcile.advanced.ref' should be used to reconcile refunds.