### PR TITLE
[12.0] Add field to optionally define analytic account on commission line

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -74,6 +74,11 @@ class AccountJournal(models.Model):
         "the refunds and one for the payments",
     )
 
+    commission_analytic_account_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Commission Analytic Account',
+        help="Choose an analytic account to be used on the commission line.")
+
     @api.multi
     def _prepare_counterpart_line(self, move, amount, date):
         if amount > 0.0:
@@ -192,6 +197,11 @@ class AccountJournal(models.Model):
                         comm_values["debit"], company_currency
                     )
                     comm_values["currency_id"] = currency.id
+                if self.commission_analytic_account_id:
+                    comm_values.update({
+                        'analytic_account_id':
+                            self.commission_analytic_account_id.id
+                    })
                 move_line_obj.with_context(check_move_validity=False).create(
                     comm_values
                 )

--- a/account_move_base_import/views/journal_view.xml
+++ b/account_move_base_import/views/journal_view.xml
@@ -20,6 +20,7 @@
                     </group>
                     <group>
                         <field name="commission_account_id"/>
+                        <field name="commission_analytic_account_id"/>
                         <field name="receivable_account_id" attrs="{'required': [('used_for_import', '=', True)]}"/>
                         <field name="partner_id"/>
                         <field name="create_counterpart"/>


### PR DESCRIPTION
this feature was present in 9.0 but had not been migrated to later versions. 