### PR TITLE
[12.0] IMP account_move_transactionid_import

### DIFF
--- a/account_move_transactionid_import/data/completion_rule_data.xml
+++ b/account_move_transactionid_import/data/completion_rule_data.xml
@@ -3,14 +3,14 @@
 
     <record id="bank_statement_completion_rule_4" model="account.move.completion.rule">
          <field name="name">Match from Sales Order using transaction ID</field>
-         <field name="sequence">30</field>
+         <field name="sequence">40</field>
          <field name="function_to_call">get_from_transaction_id_and_so</field>
      </record>
 
      <record id="bank_statement_completion_rule_trans_id_invoice" model="account.move.completion.rule">
          <field name="name">Match from Invoice using transaction ID</field>
-         <field name="sequence">40</field>
+         <field name="sequence">30</field>
          <field name="function_to_call">get_from_transaction_id_and_invoice</field>
      </record>
-    
+
 </odoo>


### PR DESCRIPTION
switch the priority of the 2 autocompletion rules

we want the match on invoice to have a higher priority because it will provide the
correct account when autocompleting