### PR TITLE
[14.0] account_reconciliation_widget: Use payment_ref for the statement line label

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1033,6 +1033,7 @@ class AccountReconciliation(models.AbstractModel):
             # FIXME: where to fill?
             # 'note': st_line.note or "",
             "name": st_line.name,
+            "payment_ref": st_line.payment_ref,
             "date": format_date(self.env, st_line.date),
             "amount": amount,
             "amount_str": amount_str,  # Amount in the statement line currency

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1030,8 +1030,7 @@ class AccountReconciliation(models.AbstractModel):
         data = {
             "id": st_line.id,
             "ref": st_line.ref,
-            # FIXME: where to fill?
-            # 'note': st_line.note or "",
+            "narration": st_line.narration or "",
             "name": st_line.name,
             "payment_ref": st_line.payment_ref,
             "date": format_date(self.env, st_line.date),

--- a/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
+++ b/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
@@ -569,8 +569,8 @@
         <tr><td>Account</td><td><t t-esc="state.st_line.account_code" /> <t
                         t-esc="state.st_line.account_name"
                     /></td></tr>
-        <tr t-if="state.st_line.note"><td>Note</td><td style="white-space: pre;"><t
-                        t-esc="state.st_line.note"
+        <tr t-if="state.st_line.narration"><td>Note</td><td style="white-space: pre;"><t
+                        t-esc="state.st_line.narration"
                     /></td></tr>
     </table>
 </t>

--- a/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
+++ b/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
@@ -149,8 +149,8 @@
                             /></td>
                     <td class="cell_due_date"><t t-esc="state.st_line.date" /></td>
                     <td class="cell_label"><t
-                                t-if="state.st_line.name"
-                                t-esc="state.st_line.name"
+                                t-if="state.st_line.payment_ref"
+                                t-esc="state.st_line.payment_ref"
                             /> <t t-if="state.st_line.amount_currency_str"> (<t
                                     t-esc="state.st_line.amount_currency_str"
                                 />)</t></td>
@@ -562,7 +562,7 @@
         <tr t-if="state.st_line.ref"><td>Transaction</td><td><t
                         t-esc="state.st_line.ref"
                     /></td></tr>
-        <tr><td>Description</td><td><t t-esc="state.st_line.name" /></td></tr>
+        <tr><td>Description</td><td><t t-esc="state.st_line.payment_ref" /></td></tr>
         <tr><td>Amount</td><td><t t-raw="state.st_line.amount_str" /><t
                         t-if="state.st_line.amount_currency_str"
                     > (<t t-esc="state.st_line.amount_currency_str" />)</t></td></tr>


### PR DESCRIPTION
This fixes a problem following the merge of PR #359 : in the reconcile interface of the bank statement, the move name was displayed instead of the label for the bank statement line. 
This is because the label of the bank statement line was renamed from 'name' to 'payment_ref' between odoo v13 and v14.