### PR TITLE
[14.0][FIX] account_reconciliation_widget: progressbar width

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
@@ -244,11 +244,12 @@ odoo.define("account.ReconciliationClientAction", function (require) {
                     $pager: this.$pager,
                 };
                 this.renderer.$progress = this.$pager;
-                $(this.renderer.$progress)
-                    .parent()
-                    .css("width", "100%")
-                    .css("padding-left", "0");
             }
+        },
+
+        on_attach_callback: function () {
+            this._super.apply(this, arguments);
+            $(this.$pager).parent().css("width", "100%").css("padding-left", "0");
         },
 
         // --------------------------------------------------------------------------


### PR DESCRIPTION
Some changes in Odoo 14.0 JS execution flow makes setting progresbar width in do_show not working properly