### PR TITLE
[14.0] account_reconciliation_widget: remove payment_id <> false

### DIFF
--- a/account_reconciliation_widget/__init__.py
+++ b/account_reconciliation_widget/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/account_reconciliation_widget/__manifest__.py
+++ b/account_reconciliation_widget/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["account"],
     "data": [
         "security/ir.model.access.csv",
+        "wizards/res_config_settings_views.xml",
         "views/assets.xml",
         "views/account_view.xml",
         "views/account_bank_statement_view.xml",

--- a/account_reconciliation_widget/wizards/__init__.py
+++ b/account_reconciliation_widget/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import res_config_settings

--- a/account_reconciliation_widget/wizards/res_config_settings.py
+++ b/account_reconciliation_widget/wizards/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    account_bank_reconciliation_start = fields.Date(
+        related="company_id.account_bank_reconciliation_start",
+        readonly=False)

--- a/account_reconciliation_widget/wizards/res_config_settings.py
+++ b/account_reconciliation_widget/wizards/res_config_settings.py
@@ -6,8 +6,8 @@ from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
-    _inherit = 'res.config.settings'
+    _inherit = "res.config.settings"
 
     account_bank_reconciliation_start = fields.Date(
-        related="company_id.account_bank_reconciliation_start",
-        readonly=False)
+        related="company_id.account_bank_reconciliation_start", readonly=False
+    )

--- a/account_reconciliation_widget/wizards/res_config_settings_views.xml
+++ b/account_reconciliation_widget/wizards/res_config_settings_views.xml
@@ -1,25 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
   Copyright 2022 Akretion France (http://www.akretion.com/)
   @author: Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
-
 <odoo>
 
 <record id="res_config_settings_view_form" model="ir.ui.view">
     <field name="model">res.config.settings</field>
-    <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+    <field name="inherit_id" ref="account.res_config_settings_view_form" />
     <field name="arch" type="xml">
         <xpath expr="//div[@id='bank_cash']" position="inside">
-            <div class="col-xs-12 col-md-6 o_setting_box" id="account_bank_reconciliation_start">
-                <div class="o_setting_left_pane"/>
+            <div
+                    class="col-xs-12 col-md-6 o_setting_box"
+                    id="account_bank_reconciliation_start"
+                >
+                <div class="o_setting_left_pane" />
                 <div class="o_setting_right_pane">
-                    <label for="account_bank_reconciliation_start"/>
+                    <label for="account_bank_reconciliation_start" />
                     <div class="text-muted">
                     Date from which you started using bank statements in Odoo. Leave empty if you've been using bank statements in Odoo from the start.
                     </div>
-                    <field name="account_bank_reconciliation_start"/>
+                    <field name="account_bank_reconciliation_start" />
                 </div>
             </div>
         </xpath>

--- a/account_reconciliation_widget/wizards/res_config_settings_views.xml
+++ b/account_reconciliation_widget/wizards/res_config_settings_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2022 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+<record id="res_config_settings_view_form" model="ir.ui.view">
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+    <field name="arch" type="xml">
+        <xpath expr="//div[@id='bank_cash']" position="inside">
+            <div class="col-xs-12 col-md-6 o_setting_box" id="account_bank_reconciliation_start">
+                <div class="o_setting_left_pane"/>
+                <div class="o_setting_right_pane">
+                    <label for="account_bank_reconciliation_start"/>
+                    <div class="text-muted">
+                    Date from which you started using bank statements in Odoo. Leave empty if you've been using bank statements in Odoo from the start.
+                    </div>
+                    <field name="account_bank_reconciliation_start"/>
+                </div>
+            </div>
+        </xpath>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
Remove the condition on payment_id <> false in the method _domain_move_lines_for_reconciliation()
because the OCA module account_payment_order doesn't generate account.payment objects.