### PR TITLE
[14.0] account_reconciliation_widget: improve when label=False on account.reconcile.model.line

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -1626,7 +1626,7 @@ odoo.define("account.ReconciliationModel", function (require) {
 
             var prop = {
                 id: _.uniqueId("createLine"),
-                label: values.label || line.st_line.name,
+                label: values.label || line.st_line.payment_ref,
                 account_id: account,
                 account_code: account ? this.accounts[account.id] : "",
                 analytic_account_id: this._formatNameGet(values.analytic_account_id),


### PR DESCRIPTION
When you define an account.reconcile.model with rule_type=writeoff_button and an account.reconcile.model.line with an empty label.
Before:
![before_reconcile](https://user-images.githubusercontent.com/1157917/116276731-12a19380-a785-11eb-90de-a80ac656938d.png)

After:
![after_reconcile](https://user-images.githubusercontent.com/1157917/116276758-1a613800-a785-11eb-8de5-73c1e06d7588.png)

