### PR TITLE
[14.0][IMP] account_reconcile_widget: Payments without payment_id related aren't showed in statement reconciliation

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -761,10 +761,8 @@ class AccountReconciliation(models.AbstractModel):
         domain_reconciliation = [
             "&",
             "&",
-            "&",
             ("statement_line_id", "=", False),
             ("account_id", "in", aml_accounts),
-            ("payment_id", "<>", False),
             ("balance", "!=", 0.0),
         ]
 
@@ -776,6 +774,19 @@ class AccountReconciliation(models.AbstractModel):
             ("account_id.reconcile", "=", True),
             ("balance", "!=", 0.0),
         ]
+        if st_line.company_id.account_bank_reconciliation_start:
+            domain_reconciliation = expression.AND(
+                [
+                    domain_reconciliation,
+                    [
+                        (
+                            "date",
+                            ">=",
+                            st_line.company_id.account_bank_reconciliation_start,
+                        )
+                    ],
+                ]
+            )
 
         domain = expression.OR([domain_reconciliation, domain_matching])
         if partner_id:
@@ -821,19 +832,6 @@ class AccountReconciliation(models.AbstractModel):
         # line
         domain = expression.AND([domain, [("company_id", "=", st_line.company_id.id)]])
 
-        if st_line.company_id.account_bank_reconciliation_start:
-            domain = expression.AND(
-                [
-                    domain,
-                    [
-                        (
-                            "date",
-                            ">=",
-                            st_line.company_id.account_bank_reconciliation_start,
-                        )
-                    ],
-                ]
-            )
         return domain
 
     @api.model


### PR DESCRIPTION
Port of https://github.com/OCA/OCB/pull/678

`account.reconciliation.widget` has been removed from Odoo community in v14 and ported to `account_reconcile_widget`

@pedrobaeza @carlosdauden can you review please?