### PR TITLE
[FIX] Prefill partner in reconciliation widget if matched by rule

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -269,14 +269,19 @@ class AccountReconciliation(models.AbstractModel):
                     and matching_amls[line.id]["model"].id,
                     "write_off": matching_amls[line.id].get("status") == "write_off",
                 }
-                if not line.partner_id and partner_map.get(line.id):
-                    partner = self.env["res.partner"].browse(partner_map[line.id])
-                    line_vals.update(
-                        {
-                            "partner_id": partner.id,
-                            "partner_name": partner.name,
-                        }
-                    )
+                if not line.partner_id:
+                    partner = False
+                    if matching_amls[line.id].get("partner"):
+                        partner = matching_amls[line.id]["partner"]
+                    elif partner_map.get(line.id):
+                        partner = self.env["res.partner"].browse(partner_map[line.id])
+                    if partner:
+                        line_vals.update(
+                            {
+                                "partner_id": partner.id,
+                                "partner_name": partner.name,
+                            }
+                        )
                 results["lines"].append(line_vals)
 
         return results


### PR DESCRIPTION
During the reconcile model rule evaluation, Odoo can find a partner from the rules : 
https://github.com/OCA/OCB/blob/14.0/addons/account/models/account_reconcile_model.py#L486
Then, if candidates have been found the the statement line, the partner is added to the result : https://github.com/OCA/OCB/blob/14.0/addons/account/models/account_reconcile_model.py#L511

Today, if a partner is found this way, it is still empty in the reconciliation widget. With this fix, it will be prefilled.

@alexis-via @pedrobaeza @ozono 