### PR TITLE
[IMP] Account reconcilation widget allows statement in open state

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -312,7 +312,7 @@ class AccountReconciliation(models.AbstractModel):
              FROM account_bank_statement_line line
              LEFT JOIN res_partner p on p.id = line.partner_id
              INNER JOIN account_bank_statement st ON line.statement_id = st.id
-                AND st.state = 'posted'
+                AND st.state IN ('posted', 'open')
              WHERE line.is_reconciled = FALSE
              AND line.amount != 0.0
              AND line.id IN %(ids)s

--- a/account_reconciliation_widget/views/account_bank_statement_view.xml
+++ b/account_reconciliation_widget/views/account_bank_statement_view.xml
@@ -12,7 +12,7 @@
                         string="Reconcile"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':['|','|',('all_lines_reconciled','=',True),('line_ids','=',[]),('state', '!=', 'posted')]}"
+                        attrs="{'invisible':['|','|',('all_lines_reconciled','=',True),('line_ids','=',[]),('state', 'not in', ('posted','open'))]}"
                     />
                 </xpath>
                 <xpath expr="//field[@name='date']" position="after">


### PR DESCRIPTION
Allow partial reconciliation for monthly bank statements.
Before PR: After importing a bank statement, you have to post it before being able to reconcile.
After PR: After importing a bank statement, you have can reconcile items, even if the statement is in open state. It allows to import a partial bank statement and reconcile the items, then import new lines in the same bank statement, and post it when the statement is complete.

Use case: our client wants to import and reconcile the items daily (so the bills are paid), even thought his official bank statement is available one a month.

cc @cvinh