### PR TITLE
[13.0][account_reconcile_only_posted][new]

### DIFF
--- a/account_reconcile_only_posted/__init__.py
+++ b/account_reconcile_only_posted/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_reconcile_only_posted/__manifest__.py
+++ b/account_reconcile_only_posted/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ForgeFlow
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Account Reconcile Only Posted",
+    "summary": "Ensures that only posted journal entries can be reconciled " "together",
+    "version": "13.0.1.0.1",
+    "depends": ["account"],
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "http://www.github.com/OCA/account-reconcile",
+    "category": "Finance",
+    "data": ["views/res_config_settings.xml"],
+    "license": "LGPL-3",
+    "auto_install": False,
+    "installable": True,
+}

--- a/account_reconcile_only_posted/models/__init__.py
+++ b/account_reconcile_only_posted/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_partial_reconcile
+from . import account_move_line
+from . import res_config

--- a/account_reconcile_only_posted/models/account_move_line.py
+++ b/account_reconcile_only_posted/models/account_move_line.py
@@ -1,0 +1,40 @@
+# Copyright 2021 ForgeFlow
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = "account.move.line"
+
+    @api.constrains("matched_credit_ids", "matched_debit_ids", "parent_state")
+    def _check_matched_state(self):
+        params = self.env["ir.config_parameter"].sudo()
+        allow_reconcile_only_posted = params.get_param(
+            "account_reconcile_only_posted" ".allow_reconcile_only_posted",
+            default=False,
+        )
+        if not allow_reconcile_only_posted:
+            return True
+        for rec in self.sudo():
+            active_model = self.env.context.get("active_model")
+            # During bank statement reconciliation the bank journal entry is
+            # first created in draft, matched and then posted. Not like I
+            # like that...
+            if active_model == "account.bank.statement":
+                continue
+            mls = (
+                rec.matched_credit_ids.mapped("credit_move_id")
+                + rec.matched_debit_ids.mapped("debit_move_id")
+                + rec
+            )
+            states = mls.mapped("parent_state")
+            if len(mls) > 1 and (len(states) > 1 or (states and states[0] != "posted")):
+                raise ValidationError(
+                    _(
+                        "Only posted journal items should be reconciled "
+                        "together. In no other status it is allowed."
+                    )
+                )

--- a/account_reconcile_only_posted/models/account_partial_reconcile.py
+++ b/account_reconcile_only_posted/models/account_partial_reconcile.py
@@ -1,0 +1,35 @@
+# Copyright 2021 ForgeFlow
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountPartialReconcile(models.Model):
+
+    _inherit = "account.partial.reconcile"
+
+    @api.constrains("credit_move_id", "debit_move_id")
+    def _check_debit_credit_state(self):
+        params = self.env["ir.config_parameter"].sudo()
+        allow_reconcile_only_posted = params.get_param(
+            "account_reconcile_only_posted" ".allow_reconcile_only_posted",
+            default=False,
+        )
+        if not allow_reconcile_only_posted:
+            return True
+        for rec in self.sudo():
+            cr_move = rec.credit_move_id.move_id
+            dr_move = rec.debit_move_id.move_id
+            active_model = self.env.context.get("active_model")
+            if active_model == "account.bank.statement":
+                return True
+            if dr_move.state != "posted" or cr_move.state != "posted":
+                raise ValidationError(
+                    _(
+                        "It is only possible to match posted journal entries. "
+                        "Journal entry %s is in status %s, and Journal Entry "
+                        "%s is in status %s"
+                    )
+                    % (cr_move.name, cr_move.state, dr_move.name, dr_move.state)
+                )

--- a/account_reconcile_only_posted/models/res_config.py
+++ b/account_reconcile_only_posted/models/res_config.py
@@ -1,0 +1,35 @@
+# Copyright 2014-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    allow_reconcile_only_posted = fields.Boolean(
+        string="Allow reconciliations only between posted entries",
+        help="When set, it won't be possible to reconcile journal entries if "
+        "if any of them is not posted.",
+    )
+
+    @api.model
+    def get_values(self):
+        res = super(AccountConfigSettings, self).get_values()
+        params = self.env["ir.config_parameter"].sudo()
+        res.update(
+            allow_reconcile_only_posted=bool(
+                params.get_param(
+                    "account_reconcile_only_posted" ".allow_reconcile_only_posted",
+                    default=False,
+                )
+            )
+        )
+        return res
+
+    def set_values(self):
+        super(AccountConfigSettings, self).set_values()
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account_reconcile_only_posted.allow_reconcile_only_posted",
+            self.allow_reconcile_only_posted,
+        )

--- a/account_reconcile_only_posted/readme/CONFIGURATION.rst
+++ b/account_reconcile_only_posted/readme/CONFIGURATION.rst
@@ -1,0 +1,2 @@
+To activate this feature go to *Accounting > Settings* and activate the
+option *Allow reconciliations only between posted entries*.

--- a/account_reconcile_only_posted/readme/CONTRIBUTORS.rst
+++ b/account_reconcile_only_posted/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Jordi Ballester Alomar

--- a/account_reconcile_only_posted/readme/DESCRIPTION.rst
+++ b/account_reconcile_only_posted/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module ensures that only posted entries can be reconciled together. This
+ensures the consistency of accounting numbers. Allows, for example, that
+reports such as the Open Items will match with the Trial Balance for a
+reconcilable account.

--- a/account_reconcile_only_posted/views/res_config_settings.xml
+++ b/account_reconcile_only_posted/views/res_config_settings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).-->
+<odoo>
+    <record model="ir.ui.view" id="res_config_settings_form_view">
+        <field
+            name="name"
+        >res.config.settings.form (in account_reconcile_only_posted)</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invoicing_settings']" position="after">
+                <h2>Reconciliations</h2>
+                <div class="row mt16 o_settings_container" id="reconcile_only_posted">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="allow_reconcile_only_posted" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="allow_reconcile_only_posted" />
+                            <div class="text-muted">
+                                Restrict the reconciliation between journal
+                                items only to occur when all the items have
+                                been posted.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
+# See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca-dependencies-txt
 bank-payment

--- a/setup/account_reconcile_only_posted/odoo/addons/account_reconcile_only_posted
+++ b/setup/account_reconcile_only_posted/odoo/addons/account_reconcile_only_posted
@@ -1,0 +1,1 @@
+../../../../account_reconcile_only_posted

--- a/setup/account_reconcile_only_posted/setup.py
+++ b/setup/account_reconcile_only_posted/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module ensures that only posted entries can be reconciled together. This ensures the consistency of accounting numbers. Allows, for example, that reports such as the Open Items will match with the Trial Balance for a reconcilable account.

@ForgeFlow