### PR TITLE
[13.0][FIX] account_reconciliation_widget_due_date: Avoid assigning the date_maturity always.

### DIFF
--- a/account_reconciliation_widget_due_date/models/reconciliation_widget.py
+++ b/account_reconciliation_widget_due_date/models/reconciliation_widget.py
@@ -24,4 +24,5 @@ class AccountReconciliation(models.AbstractModel):
             move_record = account_move_obj.browse(move_id)
             st_line = st_line_move_obj.browse(st_line_ids[index])
             st_line.date_due = parse_date(self.env, dates[index])
-            move_record.line_ids.date_maturity = st_line.date_due
+            if st_line.date_due:
+                move_record.line_ids.date_maturity = st_line.date_due

--- a/account_reconciliation_widget_due_date/tests/test_account_reconciliation_widget_date_due.py
+++ b/account_reconciliation_widget_due_date/tests/test_account_reconciliation_widget_date_due.py
@@ -81,6 +81,12 @@ class TestAccountReconciliationWidgetDueDate(TransactionCase):
         move_line_credit = move.line_ids.filtered(lambda x: x.debit > 0)
         self.assertFalse(move_line_credit.date_maturity)
         self.assertEqual(move_line_credit.partner_id, self.partner_a)
+        # Check that the date_maturity does not change
+        move_line_credit.date_maturity = date(2021, 2, 5)
+        reconciliation_widget.update_bank_statement_line_due_date(
+            res["moves"], [line_a.id], [line_a.date_due],
+        )
+        self.assertEqual(move_line_credit.date_maturity, date(2021, 2, 5))
         # line_b
         line_b = self.statement.line_ids.filtered(
             lambda x: x.partner_id == self.partner_b


### PR DESCRIPTION
Avoid assigning the `date_maturity` always.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT32479