### PR TITLE
[14.0][FIX] account_reconcile_widget : Fix foreign_currency_id vs currency_id on bank statement

### DIFF
--- a/account_reconciliation_widget/models/account_bank_statement.py
+++ b/account_reconciliation_widget/models/account_bank_statement.py
@@ -150,7 +150,7 @@ class AccountBankStatementLine(models.Model):
 
         # Fully reconciled moves are just linked to the bank statement
         total = self.amount
-        currency = self.currency_id or statement_currency
+        currency = self.foreign_currency_id or statement_currency
         for aml_rec in payment_aml_rec:
             balance = (
                 aml_rec.amount_currency if aml_rec.currency_id else aml_rec.balance
@@ -275,9 +275,9 @@ class AccountBankStatementLine(models.Model):
         self.ensure_one()
         company_currency = self.journal_id.company_id.currency_id
         statement_currency = self.journal_id.currency_id or company_currency
-        st_line_currency = self.currency_id or statement_currency
+        st_line_currency = self.foreign_currency_id or statement_currency
         st_line_currency_rate = (
-            self.currency_id and (self.amount_currency / self.amount) or False
+            self.foreign_currency_id and (self.amount_currency / self.amount) or False
         )
         company = self.company_id
 
@@ -285,7 +285,7 @@ class AccountBankStatementLine(models.Model):
             aml_dict["amount_currency"] = aml_dict["debit"] - aml_dict["credit"]
             aml_dict["currency_id"] = st_line_currency.id
             if (
-                self.currency_id
+                self.foreign_currency_id
                 and statement_currency.id == company_currency.id
                 and st_line_currency_rate
             ):
@@ -297,7 +297,7 @@ class AccountBankStatementLine(models.Model):
                 aml_dict["credit"] = company_currency.round(
                     aml_dict["credit"] / st_line_currency_rate
                 )
-            elif self.currency_id and st_line_currency_rate:
+            elif self.foreign_currency_id and st_line_currency_rate:
                 # Statement is in foreign currency and the transaction is in
                 # another one
                 aml_dict["debit"] = statement_currency._convert(

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -135,7 +135,7 @@ class AccountReconciliation(models.AbstractModel):
             recs_count = 0
         aml_recs = self.env["account.move.line"].browse([i[0] for i in res])
         target_currency = (
-            st_line.currency_id
+            st_line.foreign_currency_id
             or st_line.journal_id.currency_id
             or st_line.journal_id.company_id.currency_id
         )
@@ -255,7 +255,7 @@ class AccountReconciliation(models.AbstractModel):
                 aml_ids = matching_amls[line.id]["aml_ids"]
                 bank_statements_left += line.statement_id
                 target_currency = (
-                    line.currency_id
+                    line.foreign_currency_id
                     or line.journal_id.currency_id
                     or line.journal_id.company_id.currency_id
                 )
@@ -1019,7 +1019,7 @@ class AccountReconciliation(models.AbstractModel):
         statement_currency = (
             st_line.journal_id.currency_id or st_line.journal_id.company_id.currency_id
         )
-        if st_line.amount_currency and st_line.currency_id:
+        if st_line.amount_currency and st_line.foreign_currency_id:
             amount = st_line.amount_currency
             amount_currency = st_line.amount
             amount_currency_str = formatLang(
@@ -1032,7 +1032,7 @@ class AccountReconciliation(models.AbstractModel):
         amount_str = formatLang(
             self.env,
             abs(amount),
-            currency_obj=st_line.currency_id or statement_currency,
+            currency_obj=st_line.foreign_currency_id or statement_currency,
         )
 
         data = {
@@ -1044,7 +1044,7 @@ class AccountReconciliation(models.AbstractModel):
             "date": format_date(self.env, st_line.date),
             "amount": amount,
             "amount_str": amount_str,  # Amount in the statement line currency
-            "currency_id": st_line.currency_id.id or statement_currency.id,
+            "currency_id": st_line.foreign_currency_id.id or statement_currency.id,
             "partner_id": st_line.partner_id.id,
             "journal_id": st_line.journal_id.id,
             "statement_id": st_line.statement_id.id,


### PR DESCRIPTION
Fix 13 to 14 migration that broke because upstream field change on bank.statement.line
currency_id was renamed foreign_currency_id
and a new currency_id field was created (wich seem to contain the statement value)