### PR TITLE
[14.0][IMP] account_reconcile_widget : Look for amount in all bank fields

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -1601,6 +1601,16 @@ odoo.define("account.ReconciliationModel", function (require) {
                     var matching = line.st_line.name.match(
                         new RegExp(values.amount_string)
                     );
+                    if (!matching || !matching.length == 2) { // if we have no match on payment_ref we try on other fields
+                        var matching = line.st_line.ref.match(
+                            new RegExp(values.amount_string)
+                        );
+                    }
+                    if (!matching || !matching.length == 2) { // if we have no match on payment_ref we try on other fields
+                        var matching = line.st_line.narration.match(
+                            new RegExp(values.amount_string)
+                        );
+                    }
                     if (matching && matching.length == 2) {
                         matching = matching[1].replace(
                             new RegExp("\\D" + reconcileModel.decimal_separator, "g"),


### PR DESCRIPTION
When using a regex to obtain an amount from the statement, it look only on payment_ref (when #412 will be merged) 
It would be nice if it's also look in ref and narration (other field that come from the bank files and that may contain infos