### PR TITLE
[FIX] account_reconciliation_widget: better where_clause SQL request

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -157,7 +157,9 @@ class AccountReconciliation(models.AbstractModel):
         self.env["res.partner.bank"]._apply_ir_rules(ir_rules_query, "read")
         from_clause, where_clause, where_clause_params = ir_rules_query.get_sql()
         if where_clause:
-            where_bank = ("AND %s" % where_clause).replace("res_partner_bank", "bank")
+            where_bank = ("AND %s" % where_clause).replace(
+                '"res_partner_bank"', '"bank"'
+            )
             params += where_clause_params
         else:
             where_bank = ""
@@ -169,7 +171,7 @@ class AccountReconciliation(models.AbstractModel):
         self.env["res.partner"]._apply_ir_rules(ir_rules_query, "read")
         from_clause, where_clause, where_clause_params = ir_rules_query.get_sql()
         if where_clause:
-            where_partner = ("AND %s" % where_clause).replace("res_partner", "p3")
+            where_partner = ("AND %s" % where_clause).replace('"res_partner"', '"p3"')
             params += where_clause_params
         else:
             where_partner = ""


### PR DESCRIPTION
Some clients have infinite imagination. If one day you need to create a rule restriction on res.partner.category for some users, the `_where_calc` method will add some `SELECT partner_id FROM res_partner_res_partner_category WHERE ...`.

Thus the actual `replace` will transform this request to  `SELECT partner_id FROM p3_p3_category WHERE ...` and will raise an error.
This new `replace` avoid this problem.

cc @rvalyi 