### PR TITLE
[FIX] account_reconciliation_widget: show journal

### DIFF
--- a/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
+++ b/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
@@ -532,7 +532,7 @@
                     /> <t t-esc="line.account_name" /></td></tr>
         <tr><td>Date</td><td><t t-esc="line.date" /></td></tr>
         <tr><td>Due Date</td><td><t t-esc="line.date_maturity || line.date" /></td></tr>
-        <tr><td>Journal</td><td><t t-esc="line.journal_id.display_name" /></td></tr>
+        <tr><td>Journal</td><td><t t-esc="line.journal_id[1]" /></td></tr>
         <tr t-if="line.partner_id"><td>Partner</td><td><t
                         t-esc="line.partner_name"
                     /></td></tr>


### PR DESCRIPTION
This pull request fixes showing the journal in the reconciliation widget.

**Before:** Not show Journal
![Screenshot from 2022-01-19 16-14-02](https://user-images.githubusercontent.com/51266019/150113040-4b993f95-1cda-4610-8243-aa4dc1572160.png)

**After:** Show Journal
![Screenshot from 2022-01-19 17-32-50](https://user-images.githubusercontent.com/51266019/150113470-16353b61-7ea1-4c54-ad07-70583d4514a0.png)

