### PR TITLE
[14.0][IMP] account_reconcile_widget: Allow to reconcile payment/debit orders from OCA/bank-payment

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -771,13 +771,23 @@ class AccountReconciliation(models.AbstractModel):
         domain_reconciliation = [
             "&",
             "&",
-            "&",
             ("statement_line_id", "=", False),
             ("account_id", "in", aml_accounts),
-            ("payment_id", "<>", False),
             ("balance", "!=", 0.0),
         ]
-
+        if st_line.company_id.account_bank_reconciliation_start:
+            domain_reconciliation = expression.AND(
+                [
+                    domain_reconciliation,
+                    [
+                        (
+                            "date",
+                            ">=",
+                            st_line.company_id.account_bank_reconciliation_start,
+                        )
+                    ],
+                ]
+            )
         # default domain matching
         domain_matching = [
             "&",
@@ -830,20 +840,6 @@ class AccountReconciliation(models.AbstractModel):
         # filter on account.move.line having the same company as the statement
         # line
         domain = expression.AND([domain, [("company_id", "=", st_line.company_id.id)]])
-
-        if st_line.company_id.account_bank_reconciliation_start:
-            domain = expression.AND(
-                [
-                    domain,
-                    [
-                        (
-                            "date",
-                            ">=",
-                            st_line.company_id.account_bank_reconciliation_start,
-                        )
-                    ],
-                ]
-            )
         return domain
 
     @api.model


### PR DESCRIPTION
Payments without payment_id related aren't showed in statement reconciliation.

With this change, we show them as blue lines, the same as other coming from Odoo core payments.

Similar to OCA/OCB#884

@Tecnativa TT34508