### PR TITLE
[13.0][FIX] account_move_reconcile_helper: Error with Journal Items for Tax Audit (enterprise)

### DIFF
--- a/account_move_reconcile_helper/views/account_move_line.xml
+++ b/account_move_reconcile_helper/views/account_move_line.xml
@@ -2,6 +2,16 @@
 <!-- Copyright 2017 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <record id="view_move_line_tax_audit_tree" model="ir.ui.view">
+        <field name="name">account.move.line.tax.audit.tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tax_audit_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="full_reconcile_id" invisible="1" />
+            </xpath>
+        </field>
+    </record>
     <record id="account_move_line_tree_view" model="ir.ui.view">
         <field
             name="name"


### PR DESCRIPTION
Step to Error:

1. Go to menu Reporting > Audit Reports > Tax Report
2. select line > Audit > expand line, it will error
![Selection_001](https://user-images.githubusercontent.com/20896369/155284203-5f8c7e9f-989a-4062-ba97-3416f9ebcab3.png)

it's because view `view_move_line_tax_audit_tree` has replace `full_reconcile_id`
https://github.com/odoo/odoo/blob/13.0/addons/account/views/account_move_views.xml#L289
