### PR TITLE
[14.0][IMP] account_mass_reconcile: take into account fiscalyear_lock_date

### DIFF
--- a/account_mass_reconcile/models/base_reconciliation.py
+++ b/account_mass_reconcile/models/base_reconciliation.py
@@ -2,6 +2,7 @@
 # Copyright 2010 Sébastien Beau
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import datetime
 from operator import itemgetter
 
 from odoo import _, fields, models
@@ -206,6 +207,10 @@ class MassReconcileBase(models.AbstractModel):
             same_curr,
         ) = self._below_writeoff_limit(lines, self.write_off)
         rec_date = self._get_rec_date(lines, self.date_base_on)
+        if rec_date <= self.env.company.fiscalyear_lock_date:
+            rec_date = self.env.company.fiscalyear_lock_date + datetime.timedelta(
+                days=1
+            )
         line_rs = ml_obj.browse([line["id"] for line in lines]).with_context(
             date_p=rec_date, comment=_("Automatic Write Off")
         )


### PR DESCRIPTION
This module avoids the issue of making an automatic write-off in a date previous to the fiscalyear_lock_date. It changes the write-off date to a day after the fiscalyear_lock_date in order to avoid errors. @ForgeFlow