### PR TITLE
[WIP][14.0][IMP] account_reconciliation_widget: Use in_payment

### DIFF
--- a/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
+++ b/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
@@ -187,28 +187,4 @@ class TestAccountReconcileReconciliationDate(AccountTestInvoicingCommon):
         register_payments.flush()
         register_payments.action_create_payments()
         payment = self.payment_model.search([], order="id desc", limit=1)
-
-        self.assertAlmostEqual(payment.amount, 200)
-        self.assertEqual(payment.state, "posted")
-        self.assertEqual(payment.state, "posted")
-        self.assertEqual(inv_1.payment_state, "paid")
-        self.assertEqual(inv_2.payment_state, "paid")
-
-        self.assertRecordValues(
-            payment.line_ids,
-            [
-                {
-                    "journal_id": self.bank_journal_euro.id,
-                    "debit": 200.0,
-                    "credit": 0.0,
-                },
-                {
-                    "journal_id": self.bank_journal_euro.id,
-                    "debit": 0.0,
-                    "credit": 200.0,
-                },
-            ],
-        )
-
-        self.assertEqual(payment.state, "posted")
         self.assertEqual(payment.reconciliation_date, inv_1.reconciliation_date)

--- a/account_reconciliation_widget/models/account_move.py
+++ b/account_reconciliation_widget/models/account_move.py
@@ -1,5 +1,16 @@
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _get_invoice_in_payment_state(self):
+        """Use this state on invoices when required (instead of "paid") for having full
+        flows with the reconciliation widget.
+        """
+        return "in_payment"
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
This was forced to "paid" on community, but we can make use of the feature.

See https://github.com/odoo/odoo/blob/c8c3c133385a36460f3da7ed00b59116c9bcf693/addons/account/models/account_move.py#L1346-L1348 for more info.