### PR TITLE
[14.0][FIX] *: Run tests post-install

### DIFF
--- a/account_reconcile_payment_order/tests/test_account_reconcile_payment_order.py
+++ b/account_reconcile_payment_order/tests/test_account_reconcile_payment_order.py
@@ -2,11 +2,14 @@
 # Copyright 2021 Tecnativa - João Marques
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import odoo.tests
+
 from odoo.addons.account_payment_order.tests.test_payment_order_inbound import (
     TestPaymentOrderInboundBase,
 )
 
 
+@odoo.tests.tagged("post_install", "-at_install")
 class TestAccountReconcilePaymentOrder(TestPaymentOrderInboundBase):
     @classmethod
     def setUpClass(cls):

--- a/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
+++ b/account_reconcile_reconciliation_date/tests/test_account_reconcile_reconciliation_date.py
@@ -3,9 +3,12 @@
 
 import time
 
+import odoo.tests
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@odoo.tests.tagged("post_install", "-at_install")
 class TestAccountReconcileReconciliationDate(AccountTestInvoicingCommon):
     def setUp(self):
         super(TestAccountReconcileReconciliationDate, self).setUp()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/81aac30dd2278e43a43cf8fd6cef31e1e8c60f3f, all tests inheriting from AccountTestInvoicingCommon must be post-install.