### PR TITLE
[14.0][FIX] account_reconciliation_widget: set statement name to move ref

### DIFF
--- a/account_reconciliation_widget/models/account_bank_statement.py
+++ b/account_reconciliation_widget/models/account_bank_statement.py
@@ -222,6 +222,7 @@ class AccountBankStatementLine(models.Model):
         aml_obj.with_context(check_move_validity=False).create(liquidity_aml_dict)
 
         self.sequence = self.statement_id.line_ids.ids.index(self.id) + 1
+        self.move_id.ref = self._get_move_ref(self.statement_id.name)
         counterpart_moves = counterpart_moves | self.move_id
 
         # Complete dicts to create both counterpart move lines and write-offs
@@ -270,6 +271,12 @@ class AccountBankStatementLine(models.Model):
         self.write({"move_name": self.move_id.name})
 
         return counterpart_moves
+
+    def _get_move_ref(self, move_ref):
+        ref = move_ref or ""
+        if self.ref:
+            ref = move_ref + " - " + self.ref if move_ref else self.ref
+        return ref
 
     def _prepare_move_line_for_currency(self, aml_dict, date):
         self.ensure_one()


### PR DESCRIPTION
When the Odoo module was ported to OCA, there was an oversight.

![image](https://user-images.githubusercontent.com/25005517/168796698-4822e85a-70bc-4034-9b61-26a4ff58f190.png)

As you can see in the deleted code, the move that was being created, was using the dict values of `_prepare_reconciliation_move` method.

This `_prepare_reconciliation_move` method was this one:
![Selection_388](https://user-images.githubusercontent.com/25005517/168797267-b6566f23-d000-4ad5-b59e-01cf6442c9d6.png)

As you can see, this method doesn't make sense now because in v14 the values of this dict are already in the move of the statement. But, except the `ref`, here is the oversight.

Thus, in order to restore this "set ref" functionality, this PR adds the method `_update_move_ref`.
