### PR TITLE
account_reconciliation_widget_partial: JS error on input click

### DIFF
--- a/account_reconciliation_widget_partial/static/src/js/reconciliation_action.js
+++ b/account_reconciliation_widget_partial/static/src/js/reconciliation_action.js
@@ -12,7 +12,7 @@ odoo.define("account_reconcile_partial.ReconciliationClientAction", function (re
             var handle = event.target.handle;
             var line = this.model.getLine(handle);
             var amount = this.model.getPartialReconcileAmount(handle, event.data);
-            self._getWidget(handle).updatePartialAmount(event.data.data, amount);
+            self._getWidget(handle).updatePartialAmount(event, amount);
         },
     });
 });

--- a/account_reconciliation_widget_partial/static/src/js/reconciliation_model.js
+++ b/account_reconciliation_widget_partial/static/src/js/reconciliation_model.js
@@ -36,6 +36,7 @@ odoo.define("account_reconcile_partial.ReconciliationModel", function (require) 
                     amount >= Math.abs(prop.amount)
                     || amount <= 0 || isNaN(amount)
                 ) {
+                    prop.partial_reconcile = false;
                     delete prop.partial_amount_str;
                     delete prop.partial_amount;
                     if (isNaN(amount) || amount < 0) {

--- a/account_reconciliation_widget_partial/static/src/js/reconciliation_renderer.js
+++ b/account_reconciliation_widget_partial/static/src/js/reconciliation_renderer.js
@@ -50,5 +50,15 @@ odoo.define('account_reconcile_partial.ReconciliationRenderer', function (requir
             }
             return this._super.apply(this, arguments);
         },
+        _onSelectProposition: function (event) {
+            var $el = $(event.target);
+            if ($el.hasClass('edit_amount_input')) {
+                // When the input is clicked, it is not to select the line
+                // but simply to write in the input field.
+                // so there is no need to call super that usually removes the line
+                return;
+            }
+            return this._super.apply(this, arguments);
+        },
     });
 });

--- a/account_reconciliation_widget_partial/static/src/js/reconciliation_renderer.js
+++ b/account_reconciliation_widget_partial/static/src/js/reconciliation_renderer.js
@@ -1,6 +1,7 @@
 odoo.define('account_reconcile_partial.ReconciliationRenderer', function (require) {
     "use strict";
 
+    var field_utils = require('web.field_utils');
     var renderer = require('account.ReconciliationRenderer')
 
     renderer.LineRenderer.include({
@@ -15,12 +16,22 @@ odoo.define('account_reconcile_partial.ReconciliationRenderer', function (requir
                 {'data': $line.closest('.mv_line').data('line-id')}
             );
         },
-        updatePartialAmount: function(line_id, amount) {
+        updatePartialAmount: function(event, amount) {
+            var line_id = event.data.data;
             var $line = this.$('.mv_line[data-line-id='+line_id+']');
+            var handle = event.target.handle;
+            var line = this.model.getLine(handle);
+            var format_options = {
+                currency_id: line.st_line.currency_id,
+                noSymbol: true,
+            };
+            var amount = field_utils.format.monetary(
+                    amount, {}, format_options);
+
             $line.find('.line_info_edit').addClass('o_hidden');
             $line.find('.edit_amount_input').removeClass('o_hidden');
             $line.find('.edit_amount_input').focus();
-            $line.find('.edit_amount_input').val(amount.toFixed(2));
+            $line.find('.edit_amount_input').val(amount);
             $line.find('.edit_amount_input').select();
             $line.find('.line_amount').addClass('o_hidden');
         },


### PR DESCRIPTION
**Steps**

1. Create a bank statement and start its reconciliation
2. Select a movement to reconcile
3. Click in the blank space of the input field

**Actual behavior**
The following error is raised (assets debug activated):
> http://localhost:8169/web/static/lib/jquery/jquery.js:5799
Traceback:
Error: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?
    at jQuery.fn.init.empty (http://localhost:8169/web/static/lib/jquery/jquery.js:5799:38)
    at Class.update (http://localhost:8169/account/static/src/js/reconciliation/reconciliation_renderer.js:376:55)
    at http://localhost:8169/account/static/src/js/reconciliation/reconciliation_action.js:224:37
    at fire (http://localhost:8169/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://localhost:8169/web/static/lib/jquery/jquery.js:3231:49)
    at deferred.<computed> (http://localhost:8169/web/static/lib/jquery/jquery.js:3321:62)
    at fire (http://localhost:8169/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://localhost:8169/web/static/lib/jquery/jquery.js:3231:49)
    at deferred.<computed> (http://localhost:8169/web/static/lib/jquery/jquery.js:3321:62)
    at fire (http://localhost:8169/web/static/lib/jquery/jquery.js:3119:58)

**Expected behavior**
You can continue editing the amount.

**Additional context**
I added a few more commits to:
- fix the amount formatting in the input field
- correctly reset the line when an unaccepted input is written, otherwise it shows like this:
  ![image](https://user-images.githubusercontent.com/101628000/173856744-8a4c6f3c-f7ec-44c6-9134-f3527b301446.png)
  with the crossed out amount and pencil in the new line