### PR TITLE
[FIX] account_mass_reconcile: Fix reconciliation with empty name

### DIFF
--- a/account_mass_reconcile/models/advanced_reconciliation.py
+++ b/account_mass_reconcile/models/advanced_reconciliation.py
@@ -60,7 +60,7 @@ class MassReconcileAdvancedRef(models.TransientModel):
         """
         return (
             ("partner_id", move_line["partner_id"]),
-            ("ref", move_line["ref"].lower().strip()),
+            ("ref", (move_line["ref"] or "").lower().strip()),
         )
 
     @staticmethod
@@ -107,7 +107,7 @@ class MassReconcileAdvancedRef(models.TransientModel):
             "ref",
             (
                 (move_line["ref"] or "").lower().strip(),
-                move_line["name"].lower().strip(),
+                (move_line["name"] or "").lower().strip(),
             ),
         )
 
@@ -167,7 +167,7 @@ class MassReconcileAdvancedName(models.TransientModel):
         """
         return (
             ("partner_id", move_line["partner_id"]),
-            ("name", move_line["name"].lower().strip()),
+            ("name", (move_line["name"] or "").lower().strip()),
         )
 
     @staticmethod
@@ -212,5 +212,5 @@ class MassReconcileAdvancedName(models.TransientModel):
         yield ("partner_id", move_line["partner_id"])
         yield (
             "name",
-            (move_line["name"].lower().strip(),),
+            ((move_line["name"] or "").lower().strip(),),
         )


### PR DESCRIPTION
The field name on account.move.line is not required anymore.
Avoid a call of `lower()` on None

https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L3176