### PR TITLE
[FIX] remove product from mass_reconcily_by_purchase_line

### DIFF
--- a/account_mass_reconcile_by_purchase_line/models/advanced_reconciliation.py
+++ b/account_mass_reconcile_by_purchase_line/models/advanced_reconciliation.py
@@ -16,16 +16,12 @@ class MassReconcileAdvancedByPurchaseLine(models.TransientModel):
         will be skipped for reconciliation. Can be inherited to
         skip on some conditions. ie: ref or partner_id is empty.
         """
-        return not (move_line.get("product_id") and move_line.get("purchase_line_id"))
+        return not (move_line.get("purchase_line_id"))
 
     @staticmethod
     def _matchers(move_line):
-        return (
-            ("product_id", move_line["product_id"]),
-            ("purchase_line_id", move_line["purchase_line_id"]),
-        )
+        return (("purchase_line_id", move_line["purchase_line_id"]),)
 
     @staticmethod
     def _opposite_matchers(move_line):
-        yield ("product_id", move_line["product_id"])
         yield ("purchase_line_id", move_line["purchase_line_id"])

--- a/account_mass_reconcile_by_purchase_line/models/base_advanced_reconciliation.py
+++ b/account_mass_reconcile_by_purchase_line/models/base_advanced_reconciliation.py
@@ -10,5 +10,4 @@ class MassReconcileAdvanced(models.AbstractModel):
     def _selection_columns(self):
         aml_cols = super(MassReconcileAdvanced, self)._selection_columns()
         aml_cols.append("account_move_line.purchase_line_id")
-        aml_cols.append("account_move_line.product_id")
         return aml_cols

--- a/account_mass_reconcile_by_purchase_line/models/mass_reconcile.py
+++ b/account_mass_reconcile_by_purchase_line/models/mass_reconcile.py
@@ -12,7 +12,7 @@ class AccountMassReconcileMethod(models.Model):
         methods += [
             (
                 "mass.reconcile.advanced.by.purchase.line",
-                "Advanced. Product, purchase order line.",
+                "Advanced. Purchase order line.",
             ),
         ]
         return methods

--- a/account_mass_reconcile_by_purchase_line/readme/DESCRIPTION.rst
+++ b/account_mass_reconcile_by_purchase_line/readme/DESCRIPTION.rst
@@ -1,5 +1,5 @@
 This module extends the functionality of account_mass_reconcile and
 allow an user to reconcile debits and credits of an Account
-using the PO Line and Product as key fields. This type of
+using the PO Line as key field. This type of
 reconciliation is to be used in the context of the Perpetual Inventory
 accounting system, with the accrual account '*Goods Received Not Invoiced*'.

--- a/account_mass_reconcile_by_purchase_line/readme/USAGE.rst
+++ b/account_mass_reconcile_by_purchase_line/readme/USAGE.rst
@@ -3,4 +3,4 @@ To use this module, you need to:
 * Go to 'Invoicing / Accounting / Actions / Mass Automatic Reconcile'.
 
 * Create a new reconciliation profile, and select a new configuration entry
-  with type 'Advanced. Product, purchase order line'.
+  with type 'Advanced. Purchase order line'.

--- a/account_mass_reconcile_by_purchase_line/views/mass_reconcile.xml
+++ b/account_mass_reconcile_by_purchase_line/views/mass_reconcile.xml
@@ -15,7 +15,7 @@
                     <label
                         for="reconcile_method"
                         string="Match multiple debit vs multiple credit entries. Allow partial reconciliation.
-The lines should have the same partner, product and PO lines to be reconciled."
+The lines should have the same partner, PO lines to be reconciled."
                         colspan="4"
                     />
                 </group>


### PR DESCRIPTION
actually exists cases where product can be different, on subcontracting process you not necessary have on every journal item related with the same product

@ForgeFlow