### PR TITLE
[14.0][IMP] account_mass_reconcile as job fix early commit

### DIFF
--- a/account_mass_reconcile_as_job/data/queue_job_function_data.xml
+++ b/account_mass_reconcile_as_job/data/queue_job_function_data.xml
@@ -10,4 +10,15 @@
         />
         <field name="method">reconcile_as_job</field>
     </record>
+    <record id="job_function_reconcile_lines_as_job" model="queue.job.function">
+        <field
+            name="model_id"
+            ref="account_mass_reconcile_as_job.model_account_mass_reconcile"
+        />
+        <field
+            name="channel_id"
+            ref="account_mass_reconcile_as_job.channel_mass_reconcile"
+        />
+        <field name="method">reconcile_lines_as_job</field>
+    </record>
 </odoo>

--- a/account_mass_reconcile_as_job/models/__init__.py
+++ b/account_mass_reconcile_as_job/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mass_reconcile
+from . import base_reconciliation

--- a/account_mass_reconcile_as_job/models/base_reconciliation.py
+++ b/account_mass_reconcile_as_job/models/base_reconciliation.py
@@ -1,0 +1,47 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import ast
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from odoo.addons.queue_job.job import job
+except ImportError:
+    _logger.debug('Can not `import queue_job`.')
+
+
+class MassReconcileBase(models.AbstractModel):
+    _inherit = 'mass.reconcile.base'
+
+    # WARNING: this has limitation as it creates a job based on an object wizard
+    # when the transient model will be garbadge collected the job won't
+    # be able to run anymore.
+    # FIXME: move or copy wizard data configuration in a standard model or refactor
+    # to have it as a parameter.
+
+    def _reconcile_lines(self, lines, allow_partial=False):
+        as_job = self.env['ir.config_parameter'].sudo().get_param(
+            'account.mass.reconcile.lines.as.job', default=False
+        )
+        try:
+            as_job = ast.literal_eval(as_job) if as_job else False
+        except ValueError:
+            as_job = False
+
+        if as_job and self.env.context.get("reconcile_lines_as_job", True):
+            self.with_delay().reconcile_lines_as_job(
+                lines,
+                allow_partial=allow_partial
+            )
+            # Report is not available with reconcile jobs
+            return False, False
+        else:
+            return super()._reconcile_lines(lines, allow_partial=allow_partial)
+
+    @job(default_channel='root.mass_reconcile')
+    def reconcile_lines_as_job(self, lines, allow_partial=False):
+        self.with_context(reconcile_lines_as_job=False)._reconcile_lines(lines, allow_partial=allow_partial)

--- a/account_mass_reconcile_as_job/models/base_reconciliation.py
+++ b/account_mass_reconcile_as_job/models/base_reconciliation.py
@@ -8,14 +8,9 @@ from odoo import models
 
 _logger = logging.getLogger(__name__)
 
-try:
-    from odoo.addons.queue_job.job import job
-except ImportError:
-    _logger.debug('Can not `import queue_job`.')
-
 
 class MassReconcileBase(models.AbstractModel):
-    _inherit = 'mass.reconcile.base'
+    _inherit = "mass.reconcile.base"
 
     # WARNING: this has limitation as it creates a job based on an object wizard
     # when the transient model will be garbadge collected the job won't
@@ -24,8 +19,10 @@ class MassReconcileBase(models.AbstractModel):
     # to have it as a parameter.
 
     def _reconcile_lines(self, lines, allow_partial=False):
-        as_job = self.env['ir.config_parameter'].sudo().get_param(
-            'account.mass.reconcile.lines.as.job', default=False
+        as_job = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("account.mass.reconcile.lines.as.job", default=False)
         )
         try:
             as_job = ast.literal_eval(as_job) if as_job else False
@@ -42,6 +39,5 @@ class MassReconcileBase(models.AbstractModel):
         else:
             return super()._reconcile_lines(lines, allow_partial=allow_partial)
 
-    @job(default_channel='root.mass_reconcile')
     def reconcile_lines_as_job(self, lines, allow_partial=False):
         self.with_context(reconcile_lines_as_job=False)._reconcile_lines(lines, allow_partial=allow_partial)

--- a/account_mass_reconcile_as_job/models/mass_reconcile.py
+++ b/account_mass_reconcile_as_job/models/mass_reconcile.py
@@ -5,6 +5,7 @@ import ast
 import logging
 
 from odoo import models
+from odoo.addons.queue_job.job import identity_exact
 
 _logger = logging.getLogger(__name__)
 
@@ -25,7 +26,8 @@ class AccountMassReconcile(models.Model):
 
         if as_job and self.env.context.get("mass_reconcile_as_job", True):
             for rec in self:
-                rec.with_delay().reconcile_as_job()
+                job_options = {"identity_key": identity_exact}
+                rec.with_delay(**job_options).reconcile_as_job()
             return True
         else:
             return super().run_reconcile()

--- a/account_mass_reconcile_as_job/models/mass_reconcile.py
+++ b/account_mass_reconcile_as_job/models/mass_reconcile.py
@@ -5,6 +5,7 @@ import ast
 import logging
 
 from odoo import models
+
 from odoo.addons.queue_job.job import identity_exact
 
 _logger = logging.getLogger(__name__)

--- a/account_mass_reconcile_as_job/tests/__init__.py
+++ b/account_mass_reconcile_as_job/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_mass_reconcile_as_job
+from . import test_scenario_reconcile_as_job

--- a/account_mass_reconcile_as_job/tests/test_scenario_reconcile_as_job.py
+++ b/account_mass_reconcile_as_job/tests/test_scenario_reconcile_as_job.py
@@ -1,0 +1,112 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import tagged
+
+from odoo.addons.account_mass_reconcile.tests.test_scenario_reconcile import (
+    TestScenarioReconcile,
+)
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+
+@tagged("post_install", "-at_install")
+class TestScenarioReconcileAsJob(TestScenarioReconcile):
+    def test_scenario_reconcile_as_job(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account.mass.reconcile.as.job", True
+        )
+        invoice = self.create_invoice()
+        self.assertEqual("posted", invoice.state)
+
+        receivalble_account_id = invoice.partner_id.property_account_receivable_id.id
+        # create payment
+        payment = self.env["account.payment"].create(
+            {
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "partner_id": invoice.partner_id.id,
+                "destination_account_id": receivalble_account_id,
+                "amount": 50.0,
+                "journal_id": self.bank_journal.id,
+            }
+        )
+        payment.action_post()
+
+        # create the mass reconcile record
+        mass_rec = self.mass_rec_obj.create(
+            {
+                "name": "mass_reconcile_1",
+                "account": invoice.partner_id.property_account_receivable_id.id,
+                "reconcile_method": [(0, 0, {"name": "mass.reconcile.simple.partner"})],
+            }
+        )
+        with trap_jobs() as trap:
+            # call the automatic reconcilation method
+            mass_rec.run_reconcile()
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                self.env["account.mass.reconcile"].reconcile_as_job,
+                args=(),
+            )
+            job = trap.enqueued_jobs[0]
+            self.assertEqual(job.state, "pending")
+            trap.perform_enqueued_jobs()
+            self.assertEqual("paid", invoice.payment_state)
+
+    def test_scenario_reconcile_lines_as_job(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account.mass.reconcile.as.job", True
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account.mass.reconcile.lines.as.job", True
+        )
+        invoice = self.create_invoice()
+        self.assertEqual("posted", invoice.state)
+
+        receivalble_account_id = invoice.partner_id.property_account_receivable_id.id
+        # create payment
+        payment = self.env["account.payment"].create(
+            {
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "partner_id": invoice.partner_id.id,
+                "destination_account_id": receivalble_account_id,
+                "amount": 50.0,
+                "journal_id": self.bank_journal.id,
+            }
+        )
+        payment.action_post()
+
+        # create the mass reconcile record
+        mass_rec = self.mass_rec_obj.create(
+            {
+                "name": "mass_reconcile_1",
+                "account": invoice.partner_id.property_account_receivable_id.id,
+                "reconcile_method": [(0, 0, {"name": "mass.reconcile.simple.partner"})],
+            }
+        )
+        with trap_jobs() as trap:
+            self.assertFalse(self.env["mass.reconcile.simple.partner"].search([]))
+            # call the automatic reconcilation method
+            mass_rec.run_reconcile()
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                self.env["account.mass.reconcile"].reconcile_as_job,
+                args=(),
+            )
+            job = trap.enqueued_jobs[0]
+            self.assertEqual(job.state, "pending")
+            self.assertFalse(self.env["mass.reconcile.simple.partner"].search([]))
+            trap.perform_enqueued_jobs()
+            trap.assert_jobs_count(2)
+            job_2 = trap.enqueued_jobs[1]
+            # Cannot use assert_enqueue_job with all the parameters
+            self.assertEqual(job_2.model_name, "mass.reconcile.simple.partner")
+            self.assertEqual(job_2.method_name, "reconcile_lines_as_job")
+            self.assertEqual(job_2.state, "pending")
+            # Delete existing wizard to make sure the job can still after after
+            #  the wizard is garbage collected
+            wiz = self.env["mass.reconcile.simple.partner"].search([])
+            self.assertTrue(wiz)
+            wiz.unlink()
+            trap.perform_enqueued_jobs()
+            self.assertEqual("paid", invoice.payment_state)


### PR DESCRIPTION
This is an aggregation of multiple improvements for account_mass_reconcile:
- [x] Migration of account_mass_reconcile_as_job: https://github.com/OCA/account-reconcile/pull/424  by @anothingguy 
- [ ] Improvement to use identity key in account_mass_reconcile_as_job: https://github.com/anothingguy/account-reconcile/pull/1 by @sebalix 
- [ ] Migration of extra commits to fix early commits done in account_mass_reconcile for v12.0: https://github.com/OCA/account-reconcile/pull/322 by @yvaucher 
- [ ] Migration of extra commit to run each reconciliation as a job done in account_mass_reconcile_as_job for v12.0: https://github.com/camptocamp/account-reconcile/commit/c4ce973b13bf036bb7b70399da45e65d827feda1 by @yvaucher 