### PR TITLE
[15][IMP] FW port #420 (account_reconcile_widget: value cleaning & decimal separator choice)

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -1603,7 +1603,10 @@ odoo.define("account.ReconciliationModel", function (require) {
                     );
                     if (matching && matching.length === 2) {
                         matching = matching[1].replace(
-                            new RegExp("\\D" + reconcileModel.decimal_separator, "g"),
+                            new RegExp(
+                                "[^-\\d" + reconcileModel.decimal_separator + "]",
+                                "g"
+                            ),
                             ""
                         );
                         matching = matching.replace(


### PR DESCRIPTION
FW port of #420
When decimal separator is a dot, it has a special meaning in the regex (any character) that cause problem
For instance in 123.40 the regex will match .4 and remove it.
And then the proposal will be base on the number 120 instead of 123.40

The other problem with the actual regex is that minus sign get removed

In the fix, we start by replacing the decimal_separator by a dot (before it was done after the cleaning) and the clean with a character class that is clearly specified (dot, minus, numbers)

Bug was already present in odoo13 EE and CE