### PR TITLE
[14.0] account_reconciliation_widget: fix notifications, show analytic and add ability to edit 'ref'

### DIFF
--- a/account_reconciliation_widget/models/account_bank_statement.py
+++ b/account_reconciliation_widget/models/account_bank_statement.py
@@ -245,6 +245,9 @@ class AccountBankStatementLine(models.Model):
             if aml_dict["move_line"].partner_id.id:
                 aml_dict["partner_id"] = aml_dict["move_line"].partner_id.id
             aml_dict["account_id"] = aml_dict["move_line"].account_id.id
+            aml_dict["analytic_account_id"] = (
+                aml_dict["move_line"].analytic_account_id.id or False
+            )
 
             counterpart_move_line = aml_dict.pop("move_line")
             new_aml = aml_obj.with_context(check_move_validity=False).create(aml_dict)

--- a/account_reconciliation_widget/models/account_bank_statement.py
+++ b/account_reconciliation_widget/models/account_bank_statement.py
@@ -222,7 +222,6 @@ class AccountBankStatementLine(models.Model):
         aml_obj.with_context(check_move_validity=False).create(liquidity_aml_dict)
 
         self.sequence = self.statement_id.line_ids.ids.index(self.id) + 1
-        self.move_id.ref = self._get_move_ref(self.statement_id.name)
         counterpart_moves = counterpart_moves | self.move_id
 
         # Complete dicts to create both counterpart move lines and write-offs
@@ -271,12 +270,6 @@ class AccountBankStatementLine(models.Model):
         self.write({"move_name": self.move_id.name})
 
         return counterpart_moves
-
-    def _get_move_ref(self, move_ref):
-        ref = move_ref or ""
-        if self.ref:
-            ref = move_ref + " - " + self.ref if move_ref else self.ref
-        return ref
 
     def _prepare_move_line_for_currency(self, aml_dict, date):
         self.ensure_one()

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -911,6 +911,7 @@ class AccountReconciliation(models.AbstractModel):
                 "already_paid": line.account_id.internal_type == "liquidity",
                 "account_code": line.account_id.code,
                 "account_name": line.account_id.name,
+                "analytic_account_code": line.analytic_account_id.display_name or "",
                 "account_type": line.account_id.internal_type,
                 "date_maturity": format_date(self.env, line.date_maturity),
                 "date": format_date(self.env, line.date),
@@ -1021,6 +1022,8 @@ class AccountReconciliation(models.AbstractModel):
         """Returns the data required by the bank statement reconciliation
         widget to display a statement line"""
 
+        group_analytic = self.env.user.has_group("analytic.group_analytic_accounting")
+        group_analytic_tags = self.env.user.has_group("analytic.group_analytic_tags")
         statement_currency = (
             st_line.journal_id.currency_id or st_line.journal_id.company_id.currency_id
         )
@@ -1067,6 +1070,8 @@ class AccountReconciliation(models.AbstractModel):
             "amount_currency": amount_currency,
             "has_no_partner": not st_line.partner_id.id,
             "company_id": st_line.company_id.id,
+            "group_analytic_accounting": group_analytic,
+            "group_analytic_tags": group_analytic_tags,
         }
         if st_line.partner_id:
             data["open_balance_account_id"] = (

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -42,8 +42,13 @@ class AccountReconciliation(models.AbstractModel):
                 )
                 del aml_dict["counterpart_aml_id"]
 
+            vals = {}
             if datum.get("partner_id") is not None:
-                st_line.write({"partner_id": datum["partner_id"]})
+                vals["partner_id"] = datum["partner_id"]
+            if datum.get("ref") is not None:
+                vals["ref"] = datum["ref"]
+            if vals:
+                st_line.write(vals)
 
             ctx["default_to_check"] = datum.get("to_check")
             moves = st_line.with_context(ctx).process_reconciliation(

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
@@ -87,6 +87,7 @@ odoo.define("account.ReconciliationClientAction", function (require) {
             this._super.apply(this, arguments);
             this.action_manager = parent;
             this.params = params;
+            this.notifications = params.context.notifications || [];
             this.searchModelConfig.modelName = "account.bank.statement.line";
             this.controlPanelProps.cp_content = {};
             this.model = new this.config.Model(this, {
@@ -158,6 +159,7 @@ odoo.define("account.ReconciliationClientAction", function (require) {
                         valuemax: self.model.valuemax,
                         defaultDisplayQty: self.model.defaultDisplayQty,
                         title: title,
+                        notifications: self.notifications,
                     });
                 });
             });

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
@@ -21,6 +21,7 @@ odoo.define("account.ReconciliationClientAction", function (require) {
             change_filter: "_onAction",
             change_offset: "_onAction",
             change_partner: "_onAction",
+            change_ref: "_onAction",
             add_proposition: "_onAction",
             remove_proposition: "_onAction",
             update_proposition: "_onAction",

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -298,6 +298,13 @@ odoo.define("account.ReconciliationModel", function (require) {
                     );
                 });
         },
+        // eslint-disable-next-line no-unused-vars
+        changeRef: function (handle, ref, preserveMode) {
+            var line = this.getLine(handle);
+            line.st_line.ref = ref;
+            return Promise.resolve();
+        },
+
         /**
          * Close the statement
          * @returns {Promise<Number>} resolves to the res_id of the closed statements
@@ -479,6 +486,7 @@ odoo.define("account.ReconciliationModel", function (require) {
                     self.lines[handle] = {
                         id: res.st_line.id,
                         partner_id: res.st_line.partner_id,
+                        ref: res.st_line.ref,
                         handle: handle,
                         reconciled: false,
                         mode: "inactive",
@@ -967,6 +975,7 @@ odoo.define("account.ReconciliationModel", function (require) {
                     Promise.resolve(computeLinePromise).then(function () {
                         var values_dict = {
                             partner_id: line.st_line.partner_id,
+                            ref: line.st_line.ref,
                             counterpart_aml_dicts: _.map(
                                 _.filter(props, function (prop) {
                                     return !isNaN(prop.id) && !prop.is_liquidity_line;

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
@@ -38,6 +38,9 @@ odoo.define("account.ReconciliationRenderer", function (require) {
             var defs = [this._super.apply(this, arguments)];
             this.time = Date.now();
             this.$progress = $("");
+            if (this._initialState.notifications.length > 0) {
+                this._renderNotifications(this._initialState.notifications);
+            }
 
             return Promise.all(defs);
         },

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
@@ -601,6 +601,7 @@ odoo.define("account.ReconciliationRenderer", function (require) {
                                 }
                                 if (fieldName === "tax_ids") {
                                     if (
+                                        state.createForm[fieldName] === undefined ||
                                         !state.createForm[fieldName].length ||
                                         state.createForm[fieldName].length > 1
                                     ) {

--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_renderer.js
@@ -353,16 +353,6 @@ odoo.define("account.ReconciliationRenderer", function (require) {
                 }
             );
 
-            var def3 = session
-                .user_has_group("analytic.group_analytic_tags")
-                .then(function (has_group) {
-                    self.group_tags = has_group;
-                });
-            var def4 = session
-                .user_has_group("analytic.group_analytic_accounting")
-                .then(function (has_group) {
-                    self.group_acc = has_group;
-                });
             $('<span class="line_info_button fa fa-info-circle"/>')
                 .appendTo(this.$("thead .cell_info_popover"))
                 .attr(
@@ -384,7 +374,7 @@ odoo.define("account.ReconciliationRenderer", function (require) {
                 toggle: "popover",
             });
             var def2 = this._super.apply(this, arguments);
-            return Promise.all([def1, def2, def3, def4, def5]);
+            return Promise.all([def1, def2, def5]);
         },
 
         // --------------------------------------------------------------------------
@@ -861,8 +851,6 @@ odoo.define("account.ReconciliationRenderer", function (require) {
                     var $create = $(
                         qweb.render("reconciliation.line.create", {
                             state: state,
-                            group_tags: self.group_tags,
-                            group_acc: self.group_acc,
                         })
                     );
 

--- a/account_reconciliation_widget/static/src/scss/account_reconciliation.scss
+++ b/account_reconciliation_widget/static/src/scss/account_reconciliation.scss
@@ -56,6 +56,16 @@
         .strike_amount {
             text-decoration: line-through;
         }
+        .move_name {
+            font-size: 80%;
+            margin-left: 1em;
+            display: flex;
+            align-items: center;
+        }
+        .caption-input {
+            margin-left: 1em;
+            display: inline-flex;
+        }
         tbody tr:hover .cell_account_code::before {
             content: "\f068";
             font-family: FontAwesome;

--- a/account_reconciliation_widget/static/src/scss/account_reconciliation.scss
+++ b/account_reconciliation_widget/static/src/scss/account_reconciliation.scss
@@ -156,6 +156,9 @@
             width: 80px;
             padding-left: 5px;
         }
+        .cell_analytic_account {
+            width: 230px;
+        }
         .cell_due_date {
             width: 100px;
         }
@@ -187,6 +190,7 @@
             .cell_label,
             .cell_due_date,
             .cell_account_code,
+            .cell_analytic_account,
             .cell_info_popover {
                 box-shadow: 0 1px 0 #eaeaea;
             }

--- a/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
+++ b/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
@@ -151,6 +151,12 @@
                                 t-esc="state.st_line.account_code"
                             /></td>
                     <td class="cell_due_date"><t t-esc="state.st_line.date" /></td>
+                    <td
+                            class="cell_analytic_account"
+                            t-if="state.st_line.group_analytic_accounting"
+                        >
+                        <t t-esc="state.st_line.analytic_account_code" />
+                    </td>
                     <td class="cell_label"><t
                                 t-if="state.st_line.payment_ref"
                                 t-esc="state.st_line.payment_ref"
@@ -283,6 +289,12 @@
     <tr t-if="state.balance.show_balance">
         <td class="cell_account_code"><t t-esc="state.balance.account_code" /></td>
         <td class="cell_due_date" />
+        <td
+                class="cell_analytic_account"
+                t-if="state.st_line.group_analytic_accounting"
+            >
+            <t t-esc="state.balance.analytic_account_code" />
+        </td>
         <td class="cell_label"><t t-if="state.st_line.partner_id">Open balance</t><t
                     t-else=""
                 >Choose counterpart or Create Write-off</t></td>
@@ -387,13 +399,19 @@
                                 >Taxes</label></td>
                     <td class="o_td_field" />
                 </tr>
-                <tr class="create_analytic_account_id" t-if="group_acc">
+                <tr
+                            class="create_analytic_account_id"
+                            t-if="state.st_line.group_analytic_accounting"
+                        >
                     <td class="o_td_label"><label
                                     class="o_form_label"
                                 >Analytic Acc.</label></td>
                     <td class="o_td_field" />
                 </tr>
-                <tr class="create_analytic_tag_ids" t-if="group_tags">
+                <tr
+                            class="create_analytic_tag_ids"
+                            t-if="state.st_line.group_analytic_tags"
+                        >
                     <td class="o_td_label"><label
                                     class="o_form_label"
                                 >Analytic Tags.</label></td>
@@ -500,6 +518,12 @@
                 <span class="badge badge-secondary">New</span>
             </t>
             <t t-else="" t-esc="line.date_maturity || line.date" />
+        </td>
+        <td
+                class="cell_analytic_account"
+                t-if="state.st_line.group_analytic_accounting"
+            >
+            <t t-esc="line.analytic_account_code" />
         </td>
         <td class="cell_label">
             <t

--- a/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
+++ b/account_reconciliation_widget/static/src/xml/account_reconciliation.xml
@@ -126,6 +126,9 @@
     <div class="o_reconciliation_line" t-att-data-mode="state.mode" tabindex="0">
         <table class="accounting_view">
             <caption style="caption-side: top;">
+                <div class="caption-input">
+                    <span class="move_name"><t t-esc="state.st_line.name" /></span>
+                </div>
                 <div class="float-right o_buttons">
                     <button
                             t-attf-class="o_no_valid btn btn-secondary #{state.balance.type &lt; 0 ? '' : 'd-none'}"


### PR DESCRIPTION
With this PR, 'ref' of account.move can now be customized in the reconciliation widget and 'name' of account.move is displayed for information.

One of my users asked me for this ; he wanted this for his classification/archive methodology. I decided to propose this development here: if you think it's useful for the module, we can review/merge it. If you think this feature is not useful for the module, I'll maintain this branch for that specific user and we cancel the PR.

![reconcile_widget-edit_ref](https://user-images.githubusercontent.com/1157917/182189688-1cfd453d-0166-44ea-89c6-5ecdb8db5ef2.png)
