### PR TITLE
[14.0][IMP] account_reconcile_reconciliation_date: reconciliation date should not be copied

### DIFF
--- a/account_reconcile_reconciliation_date/models/account_move.py
+++ b/account_reconcile_reconciliation_date/models/account_move.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    reconciliation_date = fields.Date(string="Reconciliation Date")
+    reconciliation_date = fields.Date(string="Reconciliation Date", copy=False)

--- a/account_reconcile_reconciliation_date/models/account_payment.py
+++ b/account_reconcile_reconciliation_date/models/account_payment.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 
-    reconciliation_date = fields.Date(string="Reconciliation Date")
+    reconciliation_date = fields.Date(string="Reconciliation Date", copy=False)


### PR DESCRIPTION
Steps to reproduce : 
- duplicate a journal entry that has been reconciled
- reconciliation date is copied

Right behaviour 
- reconciliation date should be empty