### PR TITLE
[14.0][IMP] account_reconciliation_widget: allow to search move lines to reconcile by the name of the associated statement.

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -678,6 +678,8 @@ class AccountReconciliation(models.AbstractModel):
             ("move_id.ref", "ilike", search_str),
             "|",
             ("date_maturity", "like", parse_date(self.env, search_str)),
+            "|",
+            ("statement_id.name", "like", search_str),
             "&",
             ("name", "!=", "/"),
             ("name", "ilike", search_str),


### PR DESCRIPTION
This is necessary in the cases where you are reconciling a bank charge with move lines associated with credit cards.

How to reproduce the example:
1. You have a bank journal 'Credit card XXX' where the statements corresponds to the credit card statement. You reconcile the statement lines with the invoices that were paid using the credit card.
2. You have a bank journal 'Bank YYY' corresponding to your normal bank. You receive a statement line containing a charge of $1000, that corresponds to the settlement of the credit card made by the bank.
3. When you reconcile Bank YYY, and the settlement line, you want to be able to search for all the 'Credit Card XXX' lines that were reconciled in 1. 

In previous version this was naturally resolved because the journal entry resulting from the statement reconciliation of Credit Card XXX would include in the account.move 'ref' field the name of the statement. But that is no longer the case in v14.