### PR TITLE
[15.0][FIX] account_reconcile_widget: analytic tags formatting

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -1351,7 +1351,12 @@ odoo.define("account.ReconciliationModel", function (require) {
         _formatMany2ManyTags: function (value) {
             var res = [];
             for (var i = 0, len = value.length; i < len; i++) {
-                res[i] = {id: value[i][0], display_name: value[i][1]};
+                res.push({
+                    id: value[i],
+                    display_name: this.analyticTags[value[i]]
+                        ? this.analyticTags[value[i]].display_name
+                        : "",
+                });
             }
             return res;
         },


### PR DESCRIPTION
Forward-port of #418

Before this commit. analytic tags are not correctly formatted when sent to the server after reconciliation, that lead to an error being raised.

Steps to reproduce the problem:

- Create a reconciliation model of type "Manually create a write-off on clicked button".
- Show analytic on the configuration and show the optional column "Analytic tags".
- Put any analytic tag.

When using such reconciliation model on the reconciliation, the analytic tag is not well formatted and you can't complete the reconciliation.