### PR TITLE
[15.0][FIX] account_reconciliation_widget: foreign currency in bank statement line handling

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1020,11 +1020,11 @@ class AccountReconciliation(models.AbstractModel):
         statement_currency = (
             st_line.journal_id.currency_id or st_line.journal_id.company_id.currency_id
         )
-        if st_line.amount_currency and st_line.currency_id:
-            amount = st_line.amount_currency
-            amount_currency = st_line.amount
+        if st_line.amount_currency and st_line.foreign_currency_id:
+            amount = st_line.amount
+            amount_currency = st_line.amount_currency
             amount_currency_str = formatLang(
-                self.env, abs(amount_currency), currency_obj=statement_currency
+                self.env, abs(amount_currency), currency_obj=st_line.foreign_currency_id
             )
         else:
             amount = st_line.amount
@@ -1045,7 +1045,7 @@ class AccountReconciliation(models.AbstractModel):
             "date": format_date(self.env, st_line.date),
             "amount": amount,
             "amount_str": amount_str,  # Amount in the statement line currency
-            "currency_id": st_line.currency_id.id or statement_currency.id,
+            "currency_id": st_line.foreign_currency_id.id or st_line.currency_id.id or statement_currency.id,
             "partner_id": st_line.partner_id.id,
             "journal_id": st_line.journal_id.id,
             "statement_id": st_line.statement_id.id,


### PR DESCRIPTION
In reference to an earlier bug report: #522 

This is a bug fix which covers a rare case where multiple currencies are used in the same bank account.

**Bank Statement Line Setup**
![image](https://user-images.githubusercontent.com/69288384/222047300-cc16ba17-c686-4ae3-9b15-bd832951db21.png)

**Before FIX - reconciliation is not possible due to wrong currency**
![image](https://user-images.githubusercontent.com/69288384/222047934-2c3b6cf4-fbad-4d68-be57-6fd50fbb5198.png)

**After FIX**
![image](https://user-images.githubusercontent.com/69288384/222047954-2d773479-72c1-4728-944b-61ef4aa3d5a6.png)

Not sure whether older version have the same bug
