### PR TITLE
[15.0][FIX] account_reconciliation_widget: foreign currency in bank statement line handling

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1023,11 +1023,11 @@ class AccountReconciliation(models.AbstractModel):
         st_line_currency = (
             st_line.foreign_currency_id or st_line.currency_id or statement_currency
         )
-        if st_line.amount_currency and st_line.foreign_currency_id:
+        if st_line.amount_currency and (st_line_currency != statement_currency):
             amount = st_line.amount
             amount_currency = st_line.amount_currency
             amount_currency_str = formatLang(
-                self.env, abs(amount_currency), currency_obj=st_line.foreign_currency_id
+                self.env, abs(amount_currency), currency_obj=st_line_currency
             )
         else:
             amount = st_line.amount

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1020,11 +1020,14 @@ class AccountReconciliation(models.AbstractModel):
         statement_currency = (
             st_line.journal_id.currency_id or st_line.journal_id.company_id.currency_id
         )
-        if st_line.amount_currency and st_line.currency_id:
-            amount = st_line.amount_currency
-            amount_currency = st_line.amount
+        st_line_currency = (
+            st_line.foreign_currency_id or st_line.currency_id or statement_currency
+        )
+        if st_line.amount_currency and st_line.foreign_currency_id:
+            amount = st_line.amount
+            amount_currency = st_line.amount_currency
             amount_currency_str = formatLang(
-                self.env, abs(amount_currency), currency_obj=statement_currency
+                self.env, abs(amount_currency), currency_obj=st_line.foreign_currency_id
             )
         else:
             amount = st_line.amount
@@ -1045,7 +1048,7 @@ class AccountReconciliation(models.AbstractModel):
             "date": format_date(self.env, st_line.date),
             "amount": amount,
             "amount_str": amount_str,  # Amount in the statement line currency
-            "currency_id": st_line.currency_id.id or statement_currency.id,
+            "currency_id": st_line_currency.id,  # Currency according to statement line
             "partner_id": st_line.partner_id.id,
             "journal_id": st_line.journal_id.id,
             "statement_id": st_line.statement_id.id,


### PR DESCRIPTION
In reference to an earlier bug report: #522 

This is a bug fix which covers a rare case where multiple currencies are used in the same bank account.

**Bank Statement Line Error Demonstration**
![image](https://user-images.githubusercontent.com/69288384/222652093-c7a54c5d-f8c5-498a-b43f-fa5af86febb9.png)
**Before FIX - reconciliation is not possible at this stage due to wrong currency recognized by widget**
![image](https://user-images.githubusercontent.com/69288384/222651886-39bcf7c4-017b-4ae2-b687-5e963f23b4bf.png)
**After FIX**
![image](https://user-images.githubusercontent.com/69288384/222651930-891407d4-7a7a-47b0-942a-3684d993f461.png)
