### PR TITLE
[16.0] account_statement_base: change licence AGPL -> LGPL

### DIFF
--- a/account_statement_base/__manifest__.py
+++ b/account_statement_base/__manifest__.py
@@ -1,12 +1,12 @@
 # Copyright 2023 Akretion France (http://www.akretion.com/)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 
 {
     "name": "Bank Statement Base",
     "version": "16.0.1.0.0",
     "category": "Accounting",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "summary": "Base module for Bank Statements",
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],


### PR DESCRIPTION
The module account_statement_base will be used by the modules from OCA/bank-statement-import which are LGPL (because they initially came from Odoo official addons), so it cannot be AGPL.