### PR TITLE
[16.0] account_statement_base: add development_status in manifest

### DIFF
--- a/account_statement_base/__manifest__.py
+++ b/account_statement_base/__manifest__.py
@@ -10,6 +10,7 @@
     "summary": "Base module for Bank Statements",
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],
+    "development_status": "Mature",
     "website": "https://github.com/OCA/account-reconcile",
     "depends": ["account"],
     "data": ["views/account_bank_statement_line.xml"],


### PR DESCRIPTION
All the migration of OCA/bank-statement-import are blocked by this, cf https://github.com/OCA/bank-statement-import/pull/550