### PR TITLE
[16][FIX] account_reconcile_oca: Fix account_account_reconcile id to avoi…

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -36,13 +36,7 @@ class AccountAccountReconcile(models.Model):
     def _select(self):
         return """
             SELECT
-                CAST(
-                    (
-                        coalesce(aml.partner_id, 0) + a.id
-                    )*(
-                        COALESCE(aml.partner_id, 0)+a.id - 1
-                    )/2 + COALESCE(aml.partner_id, 0) AS INTEGER
-                ) as id,
+                min(aml.id) as id,
                 MAX(a.name) as name,
                 aml.partner_id,
                 a.id as account_id,


### PR DESCRIPTION
…d big int

I have 2 issues with current implementation, the account_account_reconcile query fails because the returned id is too big (big int).
Also, I have a case of an account with id 1 containing account move lines with no partner which give 0 as id which cause an access error on the reconcile widget.
From what I understand, we just want a unique ID and it seems this make the job.

What do you think @etobella ?
The database where I have the issue is quite small, with max partner id = 97519 and max account id 1125