### PR TITLE
[16][account_reconcile_oca] take payment ref as counterpart bank line ref

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -183,7 +183,7 @@ class AccountBankStatementLine(models.Model):
                     and self.partner_id.name_get()[0]
                     or False,
                     "date": fields.Date.to_string(self.date),
-                    "name": self.name,
+                    "name": self.payment_ref or self.name,
                     "amount": -total_amount,
                     "credit": total_amount if total_amount > 0 else 0.0,
                     "debit": -total_amount if total_amount < 0 else 0.0,
@@ -396,7 +396,7 @@ class AccountBankStatementLine(models.Model):
                     "account_id": account.name_get()[0],
                     "partner_id": False,
                     "date": fields.Date.to_string(self.date),
-                    "name": self.name,
+                    "name": self.payment_ref or self.name,
                     "amount": -amount,
                     "credit": amount if amount > 0 else 0.0,
                     "debit": -amount if amount < 0 else 0.0,


### PR DESCRIPTION
Today, the reference by default on the bank counterpart is the number of the accounting entry, which is no help for accountant to know what it is about.
Once the statement line is reconciled, when searching the account move lines from me, or in the reports (general ledger...) you may want to see the information that you have on your bank statement line.

what do you think @etobella ?