### PR TITLE
[16.0] [IMP] account_statement_base: add form to statement view_mode

### DIFF
--- a/account_statement_base/__manifest__.py
+++ b/account_statement_base/__manifest__.py
@@ -13,6 +13,9 @@
     "development_status": "Mature",
     "website": "https://github.com/OCA/account-reconcile",
     "depends": ["account"],
-    "data": ["views/account_bank_statement_line.xml"],
+    "data": [
+        "views/account_bank_statement.xml",
+        "views/account_bank_statement_line.xml",
+    ],
     "installable": True,
 }

--- a/account_statement_base/views/account_bank_statement.xml
+++ b/account_statement_base/views/account_bank_statement.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<!--
+  Copyright 2023 Therp BV
+  Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+-->
+<odoo>
+
+    <!-- Add form to view mode. -->
+    <record id="account.action_bank_statement_tree" model="ir.actions.act_window">
+         <field name="res_model">account.bank.statement</field>
+         <field name="view_mode">tree,form,pivot,graph</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
At present there is no way to actually see the statement lines in a bank statement. This PR adds form to the view_mode of the bank statement action to solve this.