### PR TITLE
[14.0][FIX]account_reconcile_payment_order - wrong match logic

### DIFF
--- a/account_reconcile_payment_order/models/account_reconciliation_widget.py
+++ b/account_reconcile_payment_order/models/account_reconciliation_widget.py
@@ -14,7 +14,7 @@ class AccountReconciliationWidget(models.AbstractModel):
         """
         return self.env["account.payment.order"].search(
             [
-                ("total_company_currency", "=", st_line.amount),
+                ("total_company_currency", "=", -st_line.amount),
                 ("state", "in", ["done", "uploaded"]),
             ]
         )


### PR DESCRIPTION
The code tries to match the positive account.payment.order,total_company_currency with a negative st_line.amount hence resulting in no match at all.