### PR TITLE
[15.0][FIX] account_reconciliation_widget: Handle blue lines

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_model.js
@@ -49,7 +49,7 @@ odoo.define("account.ReconciliationModel", function (require) {
      *          label: string
      *          amount: number - real amount
      *          amount_str: string - formated amount
-     *          [is_liquidity_line]: boolean
+     *          [already_paid]: boolean
      *          [partner_id]: integer
      *          [partner_name]: string
      *          [account_code]: string
@@ -969,13 +969,13 @@ odoo.define("account.ReconciliationModel", function (require) {
                             partner_id: line.st_line.partner_id,
                             counterpart_aml_dicts: _.map(
                                 _.filter(props, function (prop) {
-                                    return !isNaN(prop.id) && !prop.is_liquidity_line;
+                                    return !isNaN(prop.id) && !prop.already_paid;
                                 }),
                                 self._formatToProcessReconciliation.bind(self, line)
                             ),
                             payment_aml_ids: _.pluck(
                                 _.filter(props, function (prop) {
-                                    return !isNaN(prop.id) && prop.is_liquidity_line;
+                                    return !isNaN(prop.id) && prop.already_paid;
                                 }),
                                 "id"
                             ),
@@ -1143,7 +1143,7 @@ odoo.define("account.ReconciliationModel", function (require) {
                     }
                     return;
                 }
-                if (!prop.is_liquidity_line && parseInt(prop.id)) {
+                if (!prop.already_paid && parseInt(prop.id)) {
                     prop.is_move_line = true;
                 }
                 reconciliation_proposition.push(prop);


### PR DESCRIPTION
When coming from previous versions of Odoo, you may have payments directly done against the bank account. On the reconciliation widget, they are represented as blue lines.

One possibility is to replace in all these pending entries the bank account by the outstanding payment/receipt account, but this means to modify past accounting that may be locked.

So this commit is restoring the ability to reconcile against these blue lines, although this is a deprecated thing.

Things done:

- Repair the JS widget for informing correctly about the blue lines to reconcile.
- Cleanup.
- When having such lines to reconcile, the temporary statement line is removed, and the payment one is linked.
- When reverting reconciliation of the statement lines linked to payments, the entry is not removed, just removed the link, and a new entry is created for the statement line.

@Tecnativa TT43018