### PR TITLE
[15.0][FIX] account_reconciliation_widget: Hide own reconcilable items

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -794,6 +794,8 @@ class AccountReconciliation(models.AbstractModel):
             "&",
             "&",
             "&",
+            "&",
+            ("id", "not in", st_line.move_id.line_ids.ids),
             ("reconciled", "=", False),
             ("account_id.reconcile", "=", True),
             ("balance", "!=", 0.0),


### PR DESCRIPTION
If the journal destination account is reconcilable, as the journal entry is pre-generated before reconciling, the line is appearing in the reconciliation widget, provoking user confusion and error if that one is selected.

We explicitly exclude them in the matching domain for avoiding the problem.

This applies to v14 as well, and it will be backported when merged.

@Tecnativa TT42983