### PR TITLE
[14.0][FIX] Missing dependency `account_reconciliation_widget`

### DIFF
--- a/account_partner_reconcile/__manifest__.py
+++ b/account_partner_reconcile/__manifest__.py
@@ -8,7 +8,10 @@
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-reconcile",
     "license": "AGPL-3",
-    "depends": ["account"],
+    "depends": [
+        "account",
+        "account_reconciliation_widget",
+    ],
     "data": ["views/res_partner_view.xml"],
     "installable": True,
 }


### PR DESCRIPTION
The "manual_reconciliation_view" tag is used but the module that includes it as a dependency is not added.