### PR TITLE
[16][FIX] account_move_line_reconcile_manual with multi currency

### DIFF
--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
@@ -26,7 +26,7 @@
                             <field name="total_credit" />
                             <field name="state" invisible="1" />
                             <field name="company_id" invisible="1" />
-                            <field name="company_currency_id" invisible="1" />
+                            <field name="currency_id" invisible="1" />
                             <field name="partner_count" invisible="1" />
                             <field name="partner_id" invisible="1" />
                     </group>


### PR DESCRIPTION
This PR cover the case of reconciliation account move lines with a same foreign currency, with and without write off.

It does not work yet for reconciliation of account move lines of 2 currencies, a foreign currency and the company currency.
The last added test show there is still an issue with this case

@alexis-via 