### PR TITLE
[15.0][FIX] account_reconciliation_widget: Show correct currency

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -1050,7 +1050,7 @@ class AccountReconciliation(models.AbstractModel):
             "date": format_date(self.env, st_line.date),
             "amount": amount,
             "amount_str": amount_str,  # Amount in the statement line currency
-            "currency_id": st_line_currency.id,  # Currency according to statement line
+            "currency_id": (st_line.currency_id or statement_currency).id,
             "partner_id": st_line.partner_id.id,
             "journal_id": st_line.journal_id.id,
             "statement_id": st_line.statement_id.id,


### PR DESCRIPTION
When reconciling bank statement lines in a foreign currency, it shows amounts in a company's currency while the symbol is shown of foreign currency. Wrong currency appears on counterpart lines and open balance line.

The wrong currency symbol only effects representation in the UI. When reconciliation is validated, it sets company's currency on account move lines.

The first screenshot how it looks without the fix:

![screenshot2](https://github.com/OCA/account-reconcile/assets/7900/33e80b91-e17a-46b4-bdb8-85aad741007b)

The next screenshot shows how the journal entry looks after reconciliation:

![screenshot3](https://github.com/OCA/account-reconcile/assets/7900/7935775a-a975-427e-bee8-e8c9643cfe3c)

And the last screenshot shows how the reconciliation lines looks after the fix. Journal entry is not effected by the fix.

![screenshot4](https://github.com/OCA/account-reconcile/assets/7900/c7a478e0-36bb-443c-b7de-8c78c15fa014)

No extra migration/update steps needed for existing data.
It is a fixup for PR #531 