### PR TITLE
[16.0][IMP] account_reconcile_oca: only store info on unreconciled items

### DIFF
--- a/account_reconcile_oca/__manifest__.py
+++ b/account_reconcile_oca/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Reconcile Oca",
     "summary": """
         Reconcile addons for Odoo CE accounting""",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "license": "AGPL-3",
     "author": "CreuBlanca,Odoo Community Association (OCA)",
     "maintainers": ["etobella"],

--- a/account_reconcile_oca/migrations/16.0.1.2.0/pre-migration.py
+++ b/account_reconcile_oca/migrations/16.0.1.2.0/pre-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Due to the big change we did, we need to loose how data is stored
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE account_bank_statement_line
+            SET reconcile_data = NULL
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            DELETE FROM account_account_reconcile_data
+        """,
+    )

--- a/account_reconcile_oca/static/src/xml/reconcile.xml
+++ b/account_reconcile_oca/static/src/xml/reconcile.xml
@@ -67,7 +67,7 @@
                 </th>
                 <th class="text-end">Debit</th>
                 <th class="text-end">Credit</th>
-                <th />
+                <th t-if="! props.record.data.is_reconciled" />
             </thead>
             <tbody>
                 <t
@@ -130,7 +130,7 @@
                                 class="btn fa fa-trash-o"
                                 role="button"
                                 t-on-click="(ev) => this.onTrashLine(ev, reconcile_line)"
-                                t-if="reconcile_line.kind == 'other'"
+                                t-if="reconcile_line.kind == 'other' &amp;&amp; ! props.record.data.is_reconciled"
                             />
                         </td>
                     </tr>


### PR DESCRIPTION
#584

The idea is to clear the data after reconciliation (we need to keep until it is reconciled in order to ensure that we can navigate without loosing everything).
Still missing a migration script in order to get out the old data.

WDYT @pedrobaeza ?