### PR TITLE
[15.0][FIX] account_reconciliation_widget: m2x record keyboard  navigation

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
@@ -50,6 +50,13 @@ odoo.define("account.ReconciliationClientAction", function (require) {
         }),
 
         _onNavigationMove: function (ev) {
+            const $input = ev.target.$input;
+            // When we're on a relational field, we want to navigate inside the record
+            // selector, otherwise we'll be catching a wrong navigation event
+            if ($input && $input.hasClass("ui-autocomplete-input")) {
+                ev.stopPropagation();
+                return;
+            }
             var non_reconciled_keys = _.keys(
                 // eslint-disable-next-line no-unused-vars
                 _.pick(this.model.lines, function (value, key, object) {


### PR DESCRIPTION
We couldn't  use our direction keys to go down the record list on a many2one field as the navigation events are propagated from the field it self and go up to the widget where a navigation through the reconcile keys is expected.

Both behaviors are preserved.

![Peek 04-10-2023 15-45](https://github.com/OCA/account-reconcile/assets/5040182/659c2d58-f498-4782-87ac-e94ada675424)


cc @Tecnativa TT45219

please review @pedrobaeza @victoralmau 