### PR TITLE
[14.0][FIX] account_reconciliation_widget: Avoid unbalanced foreign currency reconciliations + exclude own amls in reconcile models propositions

### DIFF
--- a/account_reconciliation_widget/models/account_bank_statement.py
+++ b/account_reconciliation_widget/models/account_bank_statement.py
@@ -1,5 +1,6 @@
 from odoo import _, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_is_zero
 
 
 class AccountBankStatement(models.Model):
@@ -195,7 +196,26 @@ class AccountBankStatementLine(models.Model):
             aml_dict["partner_id"] = self.partner_id.id
             aml_dict["statement_line_id"] = self.id
             self._prepare_move_line_for_currency(aml_dict, date)
-
+        # Adjust latest counterpart move debit/credit if currency amount is balanced
+        # but company amount is not
+        if self.currency_id != self.company_currency_id:
+            all_amls = to_create + [liquidity_aml_dict]
+            balance_currency = sum([x["amount_currency"] for x in all_amls])
+            balance = sum([x["debit"] - x["credit"] for x in all_amls])
+            if float_is_zero(
+                balance_currency, precision_rounding=self.currency_id.rounding
+            ) and not float_is_zero(
+                balance, precision_rounding=self.company_currency_id.rounding
+            ):
+                aml_dict = to_create[-1]
+                if aml_dict["debit"]:
+                    aml_dict["debit"] = self.company_currency_id.round(
+                        aml_dict["debit"] - balance
+                    )
+                else:
+                    aml_dict["credit"] = self.company_currency_id.round(
+                        aml_dict["credit"] + balance
+                    )
         # Create write-offs
         wo_aml = self.env["account.move.line"]
         for aml_dict in new_aml_dicts:

--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -332,7 +332,10 @@ class AccountReconciliation(models.AbstractModel):
             domain += srch_domain
         bank_statement_lines = self.env["account.bank.statement.line"].search(domain)
 
-        results = self.get_bank_statement_line_data(bank_statement_lines.ids)
+        results = self.get_bank_statement_line_data(
+            bank_statement_lines.ids,
+            excluded_ids=bank_statement_lines.move_id.line_ids.ids,
+        )
         bank_statement_lines_left = self.env["account.bank.statement.line"].browse(
             [line["st_line"]["id"] for line in results["lines"]]
         )


### PR DESCRIPTION
When having a statement line in a foreign currency, each resulting journal item computes the debit/credit amount from the foreign currency rate, and then rounding the result to company currency digits.

There's a chance in this process that the journal entry final balance is not 0 summing the rounded balances in company currency.

For fixing this, there can be several strategies, like creating an extra journal item for the difference, but I have opted for removing the difference in the latest counterpart aml, so no extra noise and no need of account decision algorithm for this extra move.

As currency amounts are correct and are the ones used in reconciliation, there won't be any problem adjusting this amount.

@Tecnativa TT45568