### PR TITLE
[15.0][FIX] account_reconciliation_widget: only stop up down key events

### DIFF
--- a/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
+++ b/account_reconciliation_widget/static/src/js/reconciliation/reconciliation_action.js
@@ -53,7 +53,11 @@ odoo.define("account.ReconciliationClientAction", function (require) {
             const $input = ev.target.$input;
             // When we're on a relational field, we want to navigate inside the record
             // selector, otherwise we'll be catching a wrong navigation event
-            if ($input && $input.hasClass("ui-autocomplete-input")) {
+            if (
+                ["up", "down"].includes(ev.data.direction) &&
+                $input &&
+                $input.hasClass("ui-autocomplete-input")
+            ) {
                 ev.stopPropagation();
                 return;
             }


### PR DESCRIPTION
After the previous commit (311a0fa) users couldn't use the tab key to navigate over manual item fields.

cc @Tecnativa TT45219

please review @pedrobaeza @victoralmau 