### PR TITLE
[16.0] account_reconcile_oca: improve move line tree view

### DIFF
--- a/account_reconcile_oca/views/account_move_line.xml
+++ b/account_reconcile_oca/views/account_move_line.xml
@@ -10,13 +10,16 @@
         <field name="arch" type="xml">
             <tree js_class="reconcile_move_line">
                 <field name="date" />
-                <field name="move_id" />
+                <field name="move_id" optional="show" />
+                <field name="account_id" optional="show" />
                 <field name="partner_id" />
                 <field name="company_currency_id" invisible="1" />
                 <field name="currency_id" invisible="1" />
-                <field name="name" />
+                <field name="name" optional="show" />
                 <field name="amount_residual_currency" optional="hide" />
-                <field name="amount_residual" />
+                <field name="amount_residual" optional="show" />
+                <field name="debit" optional="hide" />
+                <field name="credit" optional="hide" />
                 <button
                     type="object"
                     name="action_open_business_doc"


### PR DESCRIPTION
The account was missing in the move line tree view in the reconcile interface.
I took the opportunity to give more choice to the user to customize the move line tree view, by adding some optional show/hide options.