### PR TITLE
[16.0][FIX] account_reconcile_oca: improve error messages and allow to reconcile with different partners

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -33,8 +33,10 @@ class AccountAccountReconcile(models.Model):
         )
 
     def _select(self):
-        account_account_name_field = self.env["ir.model.fields"].search(
-            [("model", "=", "account.account"), ("name", "=", "name")]
+        account_account_name_field = (
+            self.env["ir.model.fields"]
+            .sudo()
+            .search([("model", "=", "account.account"), ("name", "=", "name")])
         )
         account_name = (
             f"a.name ->> '{self.env.user.lang}'"


### PR DESCRIPTION
* There was an error reading to the user due to read of "ir.model.fields" without sudo.
* If you tried to reconcile journal items of different accounts, a technical error message was issued. Generate a more nice looking  user-oriented message
*  Sometimes you may need to reconcile journal items where the partner is different. It's not a good practice
 but may need to be done in cases such as when an invoice and a payment are posted with two partners that
 are in reality the same company, or because you just need to reconcile to clean up.

@etobella 