### PR TITLE
[15.0][FIX] account_reconciliation_widget: Avoid unbalanced foreign currency reconciliations + exclude own amls in reconcile models propositions

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -328,7 +328,10 @@ class AccountReconciliation(models.AbstractModel):
             domain += srch_domain
         bank_statement_lines = self.env["account.bank.statement.line"].search(domain)
 
-        results = self.get_bank_statement_line_data(bank_statement_lines.ids)
+        results = self.get_bank_statement_line_data(
+            bank_statement_lines.ids,
+            excluded_ids=bank_statement_lines.move_id.line_ids.ids,
+        )
         bank_statement_lines_left = self.env["account.bank.statement.line"].browse(
             [line["st_line"]["id"] for line in results["lines"]]
         )


### PR DESCRIPTION
Forward-port of #603 

When having a statement line in a foreign currency, each resulting journal item computes the debit/credit amount from the foreign currency rate, and then rounding the result to company currency digits.

There's a chance in this process that the journal entry final balance is not 0 summing the rounded balances in company currency.

For fixing this, there can be several strategies, like creating an extra journal item for the difference, but I have opted for removing the difference in the latest counterpart aml, so no extra noise and no need of account decision algorithm for this extra move.

As currency amounts are correct and are the ones used in reconciliation, there won't be any problem adjusting this amount.

@Tecnativa TT45568