### PR TITLE
[16.0][FIX] account_reconcile_oca: Don't show partner label if none

### DIFF
--- a/account_reconcile_oca/static/src/xml/reconcile.xml
+++ b/account_reconcile_oca/static/src/xml/reconcile.xml
@@ -83,7 +83,7 @@
                         <td>
                             <span
                                 t-esc="reconcile_line.partner_id[1]"
-                                t-if="reconcile_line.partner_id"
+                                t-if="reconcile_line.partner_id and reconcile_line.partner_id[1]"
                             />
                         </td>
                         <td t-esc="reconcile_line.date_format" />


### PR DESCRIPTION
Avoid to show the ugly `false` text.

![imagen](https://github.com/OCA/account-reconcile/assets/7165771/7d0d9775-a56d-493d-9bc7-54c049952fd0)

@Tecnativa 