### PR TITLE
[16.0][FIX]account_statement_base: add form view for bank statement and related fixes

### DIFF
--- a/account_statement_base/__init__.py
+++ b/account_statement_base/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_statement_base/models/__init__.py
+++ b/account_statement_base/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_bank_statement

--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -1,0 +1,17 @@
+# Copyright 2024 Onestein
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountBankStatement(models.Model):
+    _inherit = "account.bank.statement"
+
+    @api.depends("line_ids.internal_index", "line_ids.state")
+    def _compute_date_index(self):
+        for stmt in self:
+            sorted_lines = stmt.line_ids.filtered(lambda l: l.internal_index).sorted(
+                "internal_index"
+            )
+            stmt.first_line_index = sorted_lines[:1].internal_index
+            stmt.date = sorted_lines.filtered(lambda l: l.state == "posted")[-1:].date

--- a/account_statement_base/views/account_bank_statement.xml
+++ b/account_statement_base/views/account_bank_statement.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <!--
   Copyright 2023 Therp BV
+  Copyright 2024 Onestein
   Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 -->
 <odoo>
@@ -9,6 +10,102 @@
     <record id="account.action_bank_statement_tree" model="ir.actions.act_window">
          <field name="res_model">account.bank.statement</field>
          <field name="view_mode">tree,form,pivot,graph</field>
+    </record>
+
+    <record id="account_bank_statement_form" model="ir.ui.view">
+        <field name="name">account.bank.statement</field>
+        <field name="model">account.bank.statement</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet string="Bank Statement">
+                    <group>
+                        <group>
+                            <field name="name" />
+                            <field name="date" />
+                            <field name="balance_start" />
+                            <field name="balance_end_real" />
+                            <field name="currency_id" />
+                        </group>
+                        <group>
+                            <field name="reference" />
+                            <field name="balance_end" />
+                            <field name="company_id" />
+                            <field name="journal_id" />
+                        </group>
+                    </group>
+                    <notebook>
+                      <page string="Statements">
+                        <field
+                                name="line_ids"
+                                context="{'default_journal_id':journal_id}"
+                                nolabel="1"
+                            >
+                            <tree
+                                    decoration-muted="is_reconciled"
+                                    editable="top"
+                                    multi_edit="1"
+                                >
+                                <field name="sequence" widget="handle" />
+                                <field
+                                        name="date"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]], 'required': True}"
+                                    />
+                                <field
+                                        name="payment_ref"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <field
+                                        name="ref"
+                                        optional="hide"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <field
+                                        name="partner_id"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <field
+                                        name="amount"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <field
+                                        name="narration"
+                                        optional="hide"
+                                        string="Notes"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <field name="suitable_journal_ids" invisible="1" />
+                                <field name="is_reconciled" invisible="1" />
+                                <field name="statement_id" invisible="1" />
+                                <field name="state" invisible="1" />
+                                <field
+                                        name="journal_id"
+                                        optional="hide"
+                                        attrs="{'readonly': ['|', ['statement_id', '!=', False], ['is_reconciled', '=', True], ['amount', '!=', 0]], 'required': True}"
+                                    />
+                                <field
+                                        name="partner_bank_id"
+                                        optional="hide"
+                                        attrs="{'readonly': [['is_reconciled', '=', True], ['amount', '!=', 0]]}"
+                                    />
+                                <button
+                                        name="action_undo_reconciliation"
+                                        type="object"
+                                        string="Revert reconciliation"
+                                        icon="fa-undo"
+                                        attrs="{'invisible': [('is_reconciled', '=', False)]}"
+                                    />
+                                <field name="company_id" invisible="1" />
+                                <field name="is_reconciled" invisible="1" />
+                                <field name="currency_id" invisible="1" />
+                                <field name="country_code" invisible="1" />
+                                <field name="state" invisible="1" />
+                            </tree>
+                        </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
     </record>
 
 </odoo>


### PR DESCRIPTION
Add form view for bank statement to pass default journal id for bank statement lines and fix compute of internal index for bank statement lines.

This PR aims to resolve 2 issues:

One is it resolves the issue coming up when trying to add new bank statement line from bank statement form view.
![image](https://github.com/OCA/account-reconcile/assets/157343079/be1b9b33-4573-4adf-bab2-9946a6313fc4)

Secondly, it passes the journal id from statement to statement lines which otherwise would cause issues