### PR TITLE
[17.0][FIX] account_reconcile_oca: use the right parameters on views

### DIFF
--- a/account_reconcile_oca/views/account_account_reconcile.xml
+++ b/account_reconcile_oca/views/account_account_reconcile.xml
@@ -135,7 +135,7 @@
         <field name="name">Reconcile</field>
         <field name="res_model">account.account.reconcile</field>
         <field name="view_mode">kanban</field>
-        <field name="domain">[("partner_id", "=", id)]</field>
+        <field name="domain">[("partner_id", "=", active_id)]</field>
         <field
             name="context"
         >{'view_ref': 'account_reconcile_oca.account_account_reconcile_form_view'}</field>
@@ -150,7 +150,7 @@
         <field name="name">Reconcile</field>
         <field name="res_model">account.account.reconcile</field>
         <field name="view_mode">kanban</field>
-        <field name="domain">[("account_id", "=", id)]</field>
+        <field name="domain">[("account_id", "=", active_id)]</field>
         <field
             name="context"
         >{'view_ref': 'account_reconcile_oca.account_account_reconcile_form_view'}</field>


### PR DESCRIPTION
Steps to Reproduce the Error.
1. Click menu Accounting\Configuration\Accounting\Chart of Accounts
2. Click **Reconcile** button in list view
3. Raise error below

```
UncaughtPromiseError > EvalError
Uncaught Promise > Can not evaluate python expression: ([("account_id", "=", id)]) Error: Name 'id' is not defined
```

![image](https://github.com/OCA/account-reconcile/assets/13941941/428698ae-9229-4cb5-a7b3-f5a5478916fb)
