### PR TITLE
[14.0][IMP] account_reconciliation_widget: date_maturity and id sorted in DESC order, amount move to second ORDER BY

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -116,9 +116,9 @@ class AccountReconciliation(models.AbstractModel):
             SELECT "account_move_line".id, COUNT(*) OVER() FROM {from_clause}
             {where_str}
             ORDER BY ("account_move_line".debit -
-                      "account_move_line".credit) = {amount} DESC,
-                "account_move_line".date_maturity ASC,
-                "account_move_line".id ASC
+                    "account_move_line".credit) = {amount} DESC,
+                    "account_move_line".date_maturity DESC,
+                    "account_move_line".id DESC
             {limit_str}
         """.format(
                 from_clause=from_clause,


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @WesleyOliveira98 @Matthwhy 

In Odoo version 12, the `account.reconciliation.widget` sorted the `date_maturity` in `DESC` order along with the `id`. However, in version 14, this behavior was changed to sort the date maturity in `ASC` order. 

This change was implemented to improve the user's visibility into how their transactions are presented. Sorting the date maturity and `id` in `DESC` order provides users with a clearer view of their transaction history, enhancing the overall user experience.

Before:

![image](https://github.com/OCA/account-reconcile/assets/53870822/ac4a1818-2a60-4171-b567-c16c4b8004a3)

After:

![image](https://github.com/OCA/account-reconcile/assets/53870822/03d8a74b-a569-4031-b18c-9a30108b6fa8)
