### PR TITLE
[15.0][FIX] account_reconciliation_widget: Error when click reconcile button

### DIFF
--- a/account_reconciliation_widget/models/reconciliation_widget.py
+++ b/account_reconciliation_widget/models/reconciliation_widget.py
@@ -160,7 +160,9 @@ class AccountReconciliation(models.AbstractModel):
         self.env["res.partner.bank"]._apply_ir_rules(ir_rules_query, "read")
         from_clause, where_clause, where_clause_params = ir_rules_query.get_sql()
         if where_clause:
-            where_bank = ("AND %s" % where_clause).replace("res_partner_bank", "bank")
+            where_bank = ("AND %s" % where_clause).replace(
+                '"res_partner_bank"', '"bank"'
+            )
             params += where_clause_params
         else:
             where_bank = ""
@@ -172,7 +174,7 @@ class AccountReconciliation(models.AbstractModel):
         self.env["res.partner"]._apply_ir_rules(ir_rules_query, "read")
         from_clause, where_clause, where_clause_params = ir_rules_query.get_sql()
         if where_clause:
-            where_partner = ("AND %s" % where_clause).replace("res_partner", "p3")
+            where_partner = ("AND %s" % where_clause).replace('"res_partner"', '"p3"')
             params += where_clause_params
         else:
             where_partner = ""


### PR DESCRIPTION
When click reconcile button on bank statement, I found error as below text. This PR is fixed for this issue

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1324, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 465, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 438, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account_reconciliation_widget/models/reconciliation_widget.py", line 333, in get_bank_statement_data
    results = self.get_bank_statement_line_data(
  File "/opt/odoo/auto/addons/account_reconciliation_widget/models/reconciliation_widget.py", line 245, in get_bank_statement_line_data
    partner_map = self._get_bank_statement_line_partners(bank_statement_lines)
  File "/opt/odoo/auto/addons/account_reconciliation_widget/models/reconciliation_widget.py", line 206, in _get_bank_statement_line_partners
    self._cr.execute(query, params)
  File "<decorator-gen-5>", line 2, in execute
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 90, in check
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 654, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
psycopg2.errors.UndefinedTable: relation "res_company_p3_rel" does not exist
LINE 12:                             SELECT 1 FROM "res_company_p3_re...