### PR TITLE
[16.0][FIX] account_reconcile_oca: Replace invoice_due_date for date_maturity field on reconcile view.

### DIFF
--- a/account_reconcile_oca/models/account_move_line.py
+++ b/account_reconcile_oca/models/account_move_line.py
@@ -1,18 +1,13 @@
 # Copyright 2023 Dixmit
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import _, models
 from odoo.exceptions import ValidationError
 
 
 class AccountMoveLine(models.Model):
 
     _inherit = "account.move.line"
-
-    invoice_due_date = fields.Date(
-        related="move_id.invoice_date_due",
-        readonly=True,
-    )
 
     def action_reconcile_manually(self):
         if not self:

--- a/account_reconcile_oca/views/account_move_line.xml
+++ b/account_reconcile_oca/views/account_move_line.xml
@@ -11,7 +11,7 @@
             <tree js_class="reconcile_move_line">
                 <field name="date" />
                 <field name="move_id" optional="show" />
-                <field name="invoice_due_date" optional="show" />
+                <field name="date_maturity" optional="show" />
                 <field name="account_id" optional="show" />
                 <field name="partner_id" />
                 <field name="company_currency_id" invisible="1" />


### PR DESCRIPTION
We change the field display on reconcile views. Instead of showing `invoice_due_date`, we show `date_maturity`. This also add the possibility to order the list by this field (`asc` or `desc`).