### PR TITLE
[16][FIX] account_move_line_reconcile_manual fix foreign currency reconciliation

### DIFF
--- a/account_move_line_reconcile_manual/ROADMAP.rst
+++ b/account_move_line_reconcile_manual/ROADMAP.rst
@@ -1,0 +1,1 @@
+- Full reconcilation (with write-off) between an entry in a foreign currency and an entry in company currency is not implemented for now.

--- a/account_move_line_reconcile_manual/tests/test_reconcile_manual.py
+++ b/account_move_line_reconcile_manual/tests/test_reconcile_manual.py
@@ -253,8 +253,11 @@ class TestReconcileManual(TransactionCase):
 
         self.assertTrue(self.line1.full_reconcile_id)
         self.assertEqual(self.line1.full_reconcile_id, self.line2.full_reconcile_id)
+        self.assertTrue(self.line1.reconciled)
+        self.assertTrue(self.line2.reconciled)
         self.assertFalse(self.line1.amount_residual_currency)
         self.assertFalse(self.line1.amount_residual)
+        self.assertEqual(len(self.line1.full_reconcile_id.reconciled_line_ids), 3)
 
     def test_foreign_currency_reconcile_with_write_off(self):
         self.move1 = self._generate_debit_reconcile_move(100, currency_amount=95)
@@ -287,3 +290,5 @@ class TestReconcileManual(TransactionCase):
 
         self.assertTrue(self.line1.full_reconcile_id)
         self.assertEqual(self.line1.full_reconcile_id, self.line2.full_reconcile_id)
+        self.assertTrue(self.line1.reconciled)
+        self.assertTrue(self.line2.reconciled)

--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
@@ -26,7 +26,7 @@
                             <field name="total_credit" />
                             <field name="state" invisible="1" />
                             <field name="company_id" invisible="1" />
-                            <field name="company_currency_id" invisible="1" />
+                            <field name="currency_id" invisible="1" />
                             <field name="partner_count" invisible="1" />
                             <field name="partner_id" invisible="1" />
                     </group>


### PR DESCRIPTION
This PR fix the full reconciliation case for the cases when all entries have the same foreign currency. We compare the currency amount to detect if the reconciliation is full instead of the company currency.

After this PR there is one more problematic case : when we try to reconcile a line with foreign currency with a ligne with company currency.
During reconciliation, Odoo convert the line with company currency to foreign currency... and in the wizard, the company currency amounts are compared.
So in case of full reconciliation (with writeoff) it does not work. I have added the issue in the README.


@alexis-via 
