### PR TITLE
[16.0][FIX] account_reconcile_oca: Pass partner parameter correctly to _get_write_off_move_lines_dict

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -416,8 +416,9 @@ class AccountBankStatementLine(models.Model):
                 continue
             new_data.append(line_data)
             liquidity_amount += line_data["amount"]
+
         for line in reconcile_model._get_write_off_move_lines_dict(
-            -liquidity_amount, self._retrieve_partner()
+            -liquidity_amount, self._retrieve_partner().id
         ):
             new_line = line.copy()
             amount = line.get("balance")


### PR DESCRIPTION
Fixes #669
