### PR TITLE
[17.0][IMP] account_reconcile_oca: Use receivable/payable account on statements with partner as suspense account

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -239,13 +239,17 @@ class AccountBankStatementLine(models.Model):
                     }
                 )
             else:
+                account = self.journal_id.suspense_account_id
+                if self.partner_id and total_amount > 0:
+                    can_reconcile = True
+                    account = self.partner_id.property_account_receivable_id
+                elif self.partner_id and total_amount < 0:
+                    can_reconcile = True
+                    account = self.partner_id.property_account_payable_id
                 suspense_line = {
                     "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,
                     "id": False,
-                    "account_id": [
-                        self.journal_id.suspense_account_id.id,
-                        self.journal_id.suspense_account_id.display_name,
-                    ],
+                    "account_id": [account.id, account.display_name],
                     "partner_id": self.partner_id
                     and [self.partner_id.id, self.partner_id.display_name]
                     or (self.partner_name and (False, self.partner_name))

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1162,3 +1162,51 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.add_account_move_line_id)
             self.assertTrue(f.can_reconcile)
             self.assertEqual(3, len(f.reconcile_data_info["data"]))
+
+    def test_receivable_line(self):
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "partner_id": self.partner_agrolait_id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertTrue(bank_stmt_line.can_reconcile)
+        suspense_line = False
+        for line in bank_stmt_line.reconcile_data_info["data"]:
+            if line["kind"] == "suspense":
+                suspense_line = line
+                break
+        self.assertTrue(suspense_line)
+        self.assertEqual(
+            self.env["account.account"]
+            .browse(suspense_line["account_id"][0])
+            .account_type,
+            "asset_receivable",
+        )
+
+    def test_payable_line(self):
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "partner_id": self.partner_agrolait_id,
+                "amount": -100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertTrue(bank_stmt_line.can_reconcile)
+        suspense_line = False
+        for line in bank_stmt_line.reconcile_data_info["data"]:
+            if line["kind"] == "suspense":
+                suspense_line = line
+                break
+        self.assertTrue(suspense_line)
+        self.assertEqual(
+            self.env["account.account"]
+            .browse(suspense_line["account_id"][0])
+            .account_type,
+            "liability_payable",
+        )


### PR DESCRIPTION
With this change, it sets the proper account automatically