### PR TITLE
[16.0][FIX] account_reconcile_oca: Fix wrong display on reconciled moves

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -442,7 +442,7 @@ class AccountBankStatementLine(models.Model):
             return
         self.partner_id = self.manual_partner_id
 
-    @api.depends("reconcile_data")
+    @api.depends("reconcile_data", "is_reconciled")
     def _compute_reconcile_data_info(self):
         for record in self:
             if record.reconcile_data:
@@ -553,11 +553,6 @@ class AccountBankStatementLine(models.Model):
                     reconcile_auxiliary_id,
                     self.manual_reference,
                 )
-        else:
-            other_lines = (
-                other_lines.matched_credit_ids.credit_move_id
-                | other_lines.matched_debit_ids.debit_move_id
-            )
         for line in other_lines:
             reconcile_auxiliary_id, lines = self._get_reconcile_line(
                 line, "other", from_unreconcile=from_unreconcile
@@ -579,7 +574,7 @@ class AccountBankStatementLine(models.Model):
         result = getattr(self, "_reconcile_bank_line_%s" % self.reconcile_mode)(
             self._prepare_reconcile_line_data(self.reconcile_data_info["data"])
         )
-        self.reconcile_data_info = False
+        self.reconcile_data = False
         return result
 
     def _reconcile_bank_line_edit(self, data):

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -193,7 +193,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
                 lambda r: r.account_id == self.bank_journal_euro.suspense_account_id
             )
         )
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertTrue(bank_stmt_line.is_reconciled)
         self.assertFalse(
             bank_stmt_line.move_id.line_ids.filtered(
@@ -260,7 +264,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertTrue(f.can_reconcile)
         self.assertEqual(inv1.amount_residual_signed, 100)
         self.assertEqual(inv2.amount_residual_signed, 100)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertEqual(inv1.amount_residual_signed, 30)
         self.assertEqual(inv2.amount_residual_signed, 70)
 
@@ -320,7 +328,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertTrue(f.can_reconcile)
         self.assertEqual(inv1.amount_residual_signed, -100)
         self.assertEqual(inv2.amount_residual_signed, -100)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertEqual(inv1.amount_residual_signed, -30)
         self.assertEqual(inv2.amount_residual_signed, -70)
 
@@ -353,7 +365,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.can_reconcile)
             f.manual_model_id = self.rule
             self.assertTrue(f.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertEqual(2, len(bank_stmt_line.move_id.line_ids))
         self.assertTrue(
             bank_stmt_line.move_id.line_ids.filtered(
@@ -393,7 +409,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.can_reconcile)
             f.manual_model_id = self.rule
             self.assertTrue(f.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertEqual(3, len(bank_stmt_line.move_id.line_ids))
         self.assertTrue(
             bank_stmt_line.move_id.line_ids.filtered(
@@ -446,7 +466,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.can_reconcile)
             f.manual_model_id = self.rule
             self.assertTrue(f.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertNotEqual(self.current_assets_account, receivable1.account_id)
         self.assertTrue(
             bank_stmt_line.move_id.line_ids.filtered(
@@ -534,7 +558,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             f.add_account_move_line_id = receivable1
             self.assertFalse(f.add_account_move_line_id)
         self.assertTrue(bank_stmt_line.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertIn(
             self.bank_journal_euro.suspense_account_id,
             bank_stmt_line.mapped("move_id.line_ids.account_id"),
@@ -1011,7 +1039,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertFalse(f.add_account_move_line_id)
             self.assertTrue(f.can_reconcile)
         self.assertTrue(bank_stmt_line.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
         bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
         self.assertEqual(0, inv1.amount_residual)
         self.assertTrue(
             inv1.line_ids.filtered(


### PR DESCRIPTION
Right now we see this

![image](https://github.com/user-attachments/assets/d4950d12-2d9e-4540-92ac-bbddf2e3460e)

And we expect

![image](https://github.com/user-attachments/assets/76a99a9b-6546-46e6-a913-2567c7a3331e)
