### PR TITLE
[16.0][IMP] account_reconcile_oca: Only fix partner on payment accounts

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -47,7 +47,11 @@ class AccountAccountReconcile(models.Model):
             SELECT
                 min(aml.id) as id,
                 MAX({account_name}) as name,
-                aml.partner_id,
+                CASE
+                    WHEN a.account_type in ('asset_receivable', 'liability_payable')
+                        THEN aml.partner_id
+                    ELSE NULL
+                    END as partner_id,
                 a.id as account_id,
                 FALSE as is_reconciled,
                 aml.currency_id as currency_id,
@@ -73,7 +77,14 @@ class AccountAccountReconcile(models.Model):
     def _groupby(self):
         return """
             GROUP BY
-                a.id, aml.partner_id, aml.currency_id, a.company_id
+                a.id,
+                CASE
+                    WHEN a.account_type in ('asset_receivable', 'liability_payable')
+                        THEN aml.partner_id
+                    ELSE NULL
+                END,
+                aml.currency_id,
+                a.company_id
         """
 
     def _having(self):


### PR DESCRIPTION
Without the changes, if we have several Lines on the same account but different partners, we cannot reconcile them together. This is correct for Receivable and Liability accounts, but not on the others.

If we have this

![image](https://github.com/user-attachments/assets/d8116ab4-56ac-42e6-a5a8-c7735445143d)

We have 

![image](https://github.com/user-attachments/assets/bdb93fd5-48ec-4dba-a6b0-a5c0a25875f0)


But we expect

![image](https://github.com/user-attachments/assets/ffb0103c-3f35-4aa8-9b24-a14d07551836)
