### PR TITLE
[16.0] fix odoo trace at install or update *account_reconcile_oca* module 

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -60,9 +60,18 @@ class AccountBankStatementLine(models.Model):
             "Percentage Analytic"
         ),
     )
-    manual_in_currency = fields.Boolean(readonly=True, store=False, prefetch=False)
+    manual_in_currency = fields.Boolean(
+        string="Is Manual in Currency?",
+        readonly=True,
+        store=False,
+        prefetch=False,
+    )
     manual_in_currency_id = fields.Many2one(
-        "res.currency", readonly=True, store=False, prefetch=False
+        comodel_name="res.currency",
+        string="Manual In Currency",
+        readonly=True,
+        store=False,
+        prefetch=False,
     )
     manual_amount_in_currency = fields.Monetary(
         store=False,


### PR DESCRIPTION
fix odoo trace at install or update *account_reconcile_oca* module : 'Two fields (manual_in_currency_id, manual_in_currency) of account.bank.statement.line() have the same label: Manual In Currency. [Modules: account_reconcile_oca and account_reconcile_oca]'
