### PR TITLE
[16.0][FIX] account_reconcile_oca: Don't apply max_amount on intermediate counterparts

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -162,8 +162,9 @@ class AccountAccountReconcile(models.Model):
         counterparts = data["counterparts"]
         amount = 0.0
         for line_id in counterparts:
+            max_amount = amount if line_id == counterparts[-1] else 0
             lines = self._get_reconcile_line(
-                self.env["account.move.line"].browse(line_id), "other", True, amount
+                self.env["account.move.line"].browse(line_id), "other", True, max_amount
             )
             new_data["data"] += lines
             amount += sum(line["amount"] for line in lines)


### PR DESCRIPTION
**Steps to reproduce:**

- Have 3 or more items to reconcile. Example: 200, -350, 150. One of the intermediate items should be higher than the current running balance.

  ![imagen](https://github.com/user-attachments/assets/05d0512b-c335-477f-935f-67bcfee104b2)

- Select all the items, and click on Action > Reconcile.

**Current behavior:**

The second item appears with its amount strike-throughed (and putting the current runnning balance as the amount to reconcile).

![imagen](https://github.com/user-attachments/assets/0b043037-bb51-49b1-a195-e821b5939986)

**Expected behavior:**

Only strike-through the amount if the last balance is not matching the amount.

The solution to this is to only put a maximum amount when checking the reconciliability of the last line of the counterparts.

@Tecnativa TT50888