### PR TITLE
[16.0][IMP] make the statements views editable=top by default

### DIFF
--- a/account_statement_base/models/__init__.py
+++ b/account_statement_base/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_journal_dashboard
 from . import account_bank_statement_line
+from . import account_bank_statement

--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class AccountBankStatement(models.Model):
+    _inherit = "account.bank.statement"
+
+    def action_open_statement_lines(self):
+        self.ensure_one()
+        if not self:
+            return {}
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_statement_base.account_bank_statement_line_action"
+        )
+        action.update({"domain": [("statement_id", "=", self.id)]})
+        return action

--- a/account_statement_base/views/account_bank_statement.xml
+++ b/account_statement_base/views/account_bank_statement.xml
@@ -86,4 +86,23 @@
          <field name="view_mode">tree,form,pivot,graph</field>
     </record>
 
+    <record id="view_bank_statement_tree" model="ir.ui.view">
+        <field name="name">account.bank.statement.tree</field>
+        <field name="model">account.bank.statement</field>
+        <field name="inherit_id" ref="account.view_bank_statement_tree" />
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="editable">bottom</attribute>
+            </tree>
+            <field name="balance_end_real" position="after">
+                <button
+                    name="action_open_statement_lines"
+                    type="object"
+                    title="Open Statement Lines"
+                    icon="fa-folder-open-o"
+                />
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
And add an icon to allow users to navigate to the statement lines. Currently it's not possible to open the statement form view. When editing the view an error occurs, related with the recomputation of running balances.

![image](https://github.com/user-attachments/assets/46e751e4-2f24-423f-b445-eb5bd55bca54)


cc @pedrobaeza @alexis-via @etobella 