### PR TITLE
[16.0] [IMP] Show reconcile button even if there no entries for reconciliation through configuration

### DIFF
--- a/account_reconcile_oca/models/account_journal.py
+++ b/account_reconcile_oca/models/account_journal.py
@@ -31,3 +31,21 @@ class AccountJournal(models.Model):
         if self.get_journal_dashboard_datas()["number_to_reconcile"] > 0:
             return False
         return _("Well done! Everything has been reconciled")
+
+    def _fill_bank_cash_dashboard_data(self, dashboard_data):
+        """Populate all bank and cash journal's data dict with
+        relevant information for the kanban card."""
+        super()._fill_bank_cash_dashboard_data(dashboard_data)
+        bank_cash_journals = self.filtered(
+            lambda journal: journal.type in ("bank", "cash")
+        )
+        if not bank_cash_journals:
+            return
+        for journal in bank_cash_journals:
+            dashboard_data[journal.id].update(
+                {
+                    "show_reconcile_button_with_no_entries_to_reconcile": (
+                        journal.company_id.show_reconcile_button_with_no_entries_to_reconcile
+                    )
+                }
+            )

--- a/account_reconcile_oca/models/res_company.py
+++ b/account_reconcile_oca/models/res_company.py
@@ -12,3 +12,7 @@ class ResCompany(models.Model):
         ._fields["reconcile_aggregate"]
         .selection
     )
+    show_reconcile_button_with_no_entries_to_reconcile = fields.Boolean(
+        string="Show Reconcile Button Even If There Are No Entries to reconcile",
+        default=False,
+    )

--- a/account_reconcile_oca/models/res_config_settings.py
+++ b/account_reconcile_oca/models/res_config_settings.py
@@ -10,3 +10,7 @@ class ResConfigSettings(models.TransientModel):
     reconcile_aggregate = fields.Selection(
         related="company_id.reconcile_aggregate", readonly=False
     )
+    show_reconcile_button_with_no_entries_to_reconcile = fields.Boolean(
+        related="company_id.show_reconcile_button_with_no_entries_to_reconcile",
+        readonly=False,
+    )

--- a/account_reconcile_oca/views/account_journal.xml
+++ b/account_reconcile_oca/views/account_journal.xml
@@ -32,7 +32,9 @@
                 expr="//kanban/templates//div[@id='dashboard_bank_cash_left']/t[1]"
                 position="before"
             >
-                <t t-if="dashboard.number_to_reconcile > 0">
+                <t
+                    t-if="dashboard.number_to_reconcile > 0 or dashboard.show_reconcile_button_with_no_entries_to_reconcile"
+                >
                     <button
                         type="action"
                         name="%(account_reconcile_oca.action_bank_statement_line_reconcile)s"

--- a/account_reconcile_oca/views/res_config_settings.xml
+++ b/account_reconcile_oca/views/res_config_settings.xml
@@ -29,6 +29,26 @@
                         </div>
                     </div>
                 </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="show_reconcile_button"
+                    title="Show Reconcile Button Even If There Are No Entries to reconcile"
+                >
+                  <div class="o_setting_left_pane">
+                      <field
+                            name="show_reconcile_button_with_no_entries_to_reconcile"
+                        />
+                  </div>
+                  <div class="o_setting_right_pane">
+                        <label
+                            for="show_reconcile_button_with_no_entries_to_reconcile"
+                            string="Show Reconcile Button"
+                        />
+                        <div class="text-muted">
+                            Show Reconcile Button Even If There Are No Entries to reconcile
+                        </div>
+                    </div>
+                  </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Adds a option in the configuration to show reconcile button even if there no entries for reconciliation

![Configuration Settings](https://github.com/user-attachments/assets/9575c4b1-be20-46c7-8c3b-7a2431d27ccf)

If the option is enabled , it will show the reconcile button even if there are no entries to reconcile

![Reconcile Button](https://github.com/user-attachments/assets/95643f4a-4691-4b35-a6ba-73a03e105dfc)

