### PR TITLE
[16.0] [IMP] account_reconcile_oca: move remaining amount to suspense account when marking partially paid invoice as fully paid

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -827,34 +827,13 @@ class AccountBankStatementLine(models.Model):
         reconcile_auxiliary_id = self.reconcile_data_info["reconcile_auxiliary_id"]
         for line in data:
             if line["reference"] == manual_reference and line.get("id"):
-                total_amount = -line["amount"] + line["original_amount_unsigned"]
-                original_amount = line["original_amount_unsigned"]
                 reconcile_auxiliary_id, lines = self._get_reconcile_line(
                     self.env["account.move.line"].browse(line["id"]),
                     "other",
                     is_counterpart=True,
                     reconcile_auxiliary_id=reconcile_auxiliary_id,
-                    max_amount=original_amount,
+                    max_amount=line["original_amount_unsigned"],
                 )
-                new_data += lines
-                new_data.append(
-                    {
-                        "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,
-                        "id": False,
-                        "account_id": line["account_id"],
-                        "partner_id": line.get("partner_id"),
-                        "date": line["date"],
-                        "name": line["name"],
-                        "amount": -total_amount,
-                        "credit": total_amount if total_amount > 0 else 0.0,
-                        "debit": -total_amount if total_amount < 0 else 0.0,
-                        "kind": "other",
-                        "currency_id": line["currency_id"],
-                        "line_currency_id": line["currency_id"],
-                        "currency_amount": -total_amount,
-                    }
-                )
-                reconcile_auxiliary_id += 1
             else:
                 new_data.append(line)
         self.reconcile_data_info = self._recompute_suspense_line(

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -143,13 +143,11 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertEqual(-50, f.manual_amount)
         self.assertEqual(2, len(bank_stmt_line.reconcile_data_info["data"]))
         bank_stmt_line.button_manual_reference_full_paid()
-        self.assertEqual(3, len(bank_stmt_line.reconcile_data_info["data"]))
-        with Form(
-            bank_stmt_line,
-            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
-        ) as f:
-            f.manual_reference = "account.move.line;%s" % receivable1.id
-            self.assertEqual(-100, f.manual_amount)
+        self.assertTrue(
+            bank_stmt_line.move_id.line_ids.filtered(
+                lambda r: r.account_id == self.bank_journal_euro.suspense_account_id
+            )
+        )
 
     def test_reconcile_invoice_unreconcile(self):
         """


### PR DESCRIPTION
When a partial payment is set to fully paid, currently the remaining amount line is set to the debtor or creditor account. This PR will change the account to the suspense account. This change is needed to make sure that the remaining amount is set on the proper account and to be able to use a reconcile model in a more user friendly way.