### PR TITLE
[16.0] [IMP] account_reconcile_oca: adds reference field on reconcile form view

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -319,8 +319,11 @@
                         </group>
                     </page>
                     <page name="narration" string="Narration">
-                        <field name="payment_ref" />
-                        <field name="narration" />
+                        <group>
+                            <field name="ref" />
+                            <field name="payment_ref" string="Payment Ref" />
+                            <field name="narration" />
+                        </group>
                     </page>
                     <page name="chatter" string="Chatter">
                         <field name="move_id" widget="account_reconcile_oca_chatter" />


### PR DESCRIPTION
This PR adds the reference on the reconcile screen for the users to be able to see additional info for the bank statement lines without having to open the bank statement line move

![Bank Statement Line Form VIew](https://github.com/user-attachments/assets/5f4dfd2a-b23c-49d5-ad2c-dd903023206a)


![Reference info on reconcile screen](https://github.com/user-attachments/assets/5ab61af4-1d7d-4873-8e59-43c416aa71cf)
