### PR TITLE
[16.0] [FIX] account_statement_base: bug on new bank statement line fixed

### DIFF
--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -11,7 +11,18 @@ class AccountBankStatement(models.Model):
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "account_statement_base.account_bank_statement_line_action"
         )
-        action.update({"domain": [("statement_id", "=", self.id)]})
+        action.update(
+            {
+                "domain": [("statement_id", "=", self.id)],
+                "context": {
+                    "default_journal_id": self._context.get("active_id")
+                    if self._context.get("active_model") == "account.journal"
+                    else None,
+                    "account_bank_statement_line_main_view": True,
+                },
+            }
+        )
+
         return action
 
     def open_entries(self):


### PR DESCRIPTION
When we opened account_statement lines from little folder icon at the end of account_statement (in list view), account_statement_line creation was impossible because journal was not correctly set.
From now it should be. @alexis-via 