### PR TITLE
[16.0] [IMP] account_reconcile_oca: pass default name for lines created through reconciliation models

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -481,16 +481,19 @@ class AccountBankStatementLine(models.Model):
     def _reconcile_data_by_model(self, data, reconcile_model, reconcile_auxiliary_id):
         new_data = []
         liquidity_amount = 0.0
+        default_name = ""
         for line_data in data:
             if line_data["kind"] == "suspense":
                 continue
             new_data.append(line_data)
             liquidity_amount += line_data["amount"]
-
+            if line_data["kind"] == "liquidity":
+                default_name = line_data["name"]
         for line in reconcile_model._get_write_off_move_lines_dict(
             -liquidity_amount, self._retrieve_partner().id
         ):
             new_line = line.copy()
+            new_line["name"] = new_line.get("name") or default_name
             amount = line.get("balance")
             if self.foreign_currency_id:
                 amount = self.foreign_currency_id.compute(


### PR DESCRIPTION
This PR aims to pass a default name/label(same as the label on the bank statement line) for the new line that is created through reconciliation models if no label is passed through the reconciliation model