### PR TITLE
[16.0] [FIX] account_reconcile_oca: Fix the layout of statement button on reconciliation screen

### DIFF
--- a/account_reconcile_oca/static/src/scss/reconcile.scss
+++ b/account_reconcile_oca/static/src/scss/reconcile.scss
@@ -20,9 +20,9 @@
         width: 100%;
         .o_reconcile_create_statement {
             position: absolute;
-            height: 4px;
+            height: 0px;
             margin: 0;
-            padding: 2px 0 0 0;
+            padding: 0 0 0 0;
             border: 0;
             top: -14px;
             opacity: 0;


### PR DESCRIPTION
This Pr aims to fix the layout of statement button on reconciliation screen

Currently, the statement button cuts out some portion of the other parts as seen in following image:

![Current Button](https://github.com/user-attachments/assets/4e96f883-bf90-4111-a91e-eee0a84d502d)

After this PR, the button would look as follows:

![Button After Changes](https://github.com/user-attachments/assets/58061d5d-b516-4c17-9ec6-ba621f3dd406)
