### PR TITLE
[17.0] [FIX] account_reconcile_oca: Fix the layout of statement button on reconciliation screen

### DIFF
--- a/account_reconcile_oca/static/src/scss/reconcile.scss
+++ b/account_reconcile_oca/static/src/scss/reconcile.scss
@@ -16,9 +16,9 @@
         width: 100%;
         .o_reconcile_create_statement {
             position: absolute;
-            height: 4px;
+            height: 0px;
             margin: 0;
-            padding: 2px 0 0 0;
+            padding: 0 0 0 0;
             border: 0;
             top: -14px;
             opacity: 0;


### PR DESCRIPTION
This Pr aims to fix the layout of statement button on reconciliation screen

Currently, the statement button cuts out some portion of the other parts as seen in following image:

![Screenshot from 2024-10-07 14-20-23](https://github.com/user-attachments/assets/102b9c19-b148-4d25-8799-04f49251f97d)

After this PR, the button would look as follows:

![image](https://github.com/user-attachments/assets/d42e2971-6945-4628-b4c3-09e0671176f2)
