### PR TITLE
[17.0][IMP] account_reconcile_oca: Remove warnings

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -60,9 +60,15 @@ class AccountBankStatementLine(models.Model):
             "Percentage Analytic"
         ),
     )
-    manual_in_currency = fields.Boolean(readonly=True, store=False, prefetch=False)
+    manual_in_currency = fields.Boolean(
+        readonly=True, store=False, prefetch=False, string="Manual In Currency?"
+    )
     manual_in_currency_id = fields.Many2one(
-        "res.currency", readonly=True, store=False, prefetch=False
+        "res.currency",
+        readonly=True,
+        store=False,
+        prefetch=False,
+        string="Manual In Currency",
     )
     manual_amount_in_currency = fields.Monetary(
         store=False,

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -935,7 +935,7 @@ class AccountBankStatementLine(models.Model):
             "original_exchange_line_id": line.id,
             "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,
             "id": False,
-            "account_id": account.name_get()[0],
+            "account_id": (account.id, account.display_name),
             "partner_id": False,
             "date": fields.Date.to_string(self.date),
             "name": self.payment_ref or self.name,


### PR DESCRIPTION
Remove warnings
```

WARNING devel py.warnings: /opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py:938: DeprecationWarning: Since 17.0, deprecated method, read display_name instead

WARNING devel odoo.addons.base.models.ir_model: Two fields (manual_in_currency_id, manual_in_currency) of account.bank.statement.line() have the same label: Manual In Currency. [Modules: account_reconcile_oca and account_reconcile_oca]
```

@Tecnativa