### PR TITLE
[16.0][FIX] account_reconcile_oca: Only filter by partner on receivable and payable lines

### DIFF
--- a/account_reconcile_oca/models/account_move_line.py
+++ b/account_reconcile_oca/models/account_move_line.py
@@ -22,7 +22,10 @@ class AccountMoveLine(models.Model):
             "account_reconcile_oca.account_account_reconcile_act_window"
         )
         action["domain"] = [("account_id", "=", self.mapped("account_id").id)]
-        if len(partner) == 1:
+        if len(partner) == 1 and self.account_id.account_type in [
+            "asset_receivable",
+            "liability_payable",
+        ]:
             action["domain"] += [("partner_id", "=", partner.id)]
         action["context"] = self.env.context.copy()
         action["context"]["default_account_move_lines"] = self.filtered(


### PR DESCRIPTION
Still testing, but should fix the manual reconciliation of non payable/receivable lines

@pedrobaeza 