### PR TITLE
[17.0][FIX] Allow reconciliation of general journal items

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -91,7 +91,7 @@ class AccountAccountReconcile(models.Model):
         return """
             HAVING
                 SUM(aml.debit) > 0
-                AND SUM(aml.credit) > 0
+                OR SUM(aml.credit) > 0
         """
 
     def _compute_reconcile_data_info(self):


### PR DESCRIPTION
This PR fixes the query for allowing reconciliation of journal items

Steps to reproduce : 
- enter a journal entry with 2 journal items with accounts that are "allow reconciliation = True"
- clic on the menu Accoounting/Actions/Reconcile

Wrong behavior 
- no items are shown
 
Right behavior 
- items should be shown and allow their reconciliation 

cc @alexis-via that's what I was talking about at OXP