### PR TITLE
[16.0] account_move_line_reconcile_manual : writeoff_journal_id initialisation

### DIFF
--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
@@ -120,8 +120,7 @@ class AccountMoveLineReconcileManual(models.TransientModel):
                 journals = self.env["account.journal"].search(
                     [("type", "=", "general"), ("company_id", "=", wiz.company_id.id)]
                 )
-                if len(journals) == 1:
-                    wiz.writeoff_journal_id = journals.id
+                wiz.writeoff_journal_id = journals[0].id if journals else False
 
     @api.depends("writeoff_account_id")
     def _compute_writeoff_analytic_distribution(self):


### PR DESCRIPTION
Currently in the interface, the selection list displays the first item in the list, but as the value is not initialized, it makes an alert empty value error when visually it's not.