### PR TITLE
[17.0][IMP] account_reconcile_model_oca: excludes account_accountant module

### DIFF
--- a/account_reconcile_model_oca/__manifest__.py
+++ b/account_reconcile_model_oca/__manifest__.py
@@ -10,6 +10,7 @@
     "author": "Dixmit,Odoo,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-reconcile",
     "depends": ["account"],
+    "excludes": ["account_accountant"],
     "data": [],
     "demo": [],
 }

--- a/account_reconcile_model_oca/static/description/index.html
+++ b/account_reconcile_model_oca/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -412,7 +413,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
This code of `account_reconcile_model_oca` was originally extracted from Odoo CE 16.0. Meanwhile the `account.reconcile.model` model evolved on its side in Odoo EE, with impactful methods signatures changes. As a consequence `account_reconcile_model_oca` is incompatible with Odoo EE, so we make it explicit by adding an excludes key in manifest.
`account_accountant` is the Accounting module in EE.
- `_get_invoice_matching_st_line_tokens` in `account_reconcile_model_oca` is return a list in [here](https://github.com/xaviedoanhduy/account-reconcile/blob/0d217b9e10b36479ae4690a48b31c0bafc036d2c/account_reconcile_model_oca/models/account_reconcile_model.py#L357)
- `_get_invoice_matching_st_line_tokens` in `account_accountant` is return a tuple (3 elements), so if list is empty `_get_invoice_matching_st_line_tokens` can be raise error in [here](https://github.com/odoo/enterprise/blob/971e225c85508edc5baa0735e79b278fbf57703b/account_accountant/models/account_reconcile_model.py#L208): 
- `account_accountant_batch_payment` and `sale_account_accountant` in odoo EE can also cause errors when calling `_get_invoice_matching_st_line_tokens` expecting to get 3 values ​​from this method ([example](https://github.com/odoo/enterprise/blob/971e225c85508edc5baa0735e79b278fbf57703b/account_accountant_batch_payment/models/account_reconcile_model.py#L14)).