### PR TITLE
[16][FIX] account_reconcile_oca : keep aml label when empty on manual write-off reconcile model

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -511,6 +511,7 @@ class AccountBankStatementLine(models.Model):
                     "line_currency_id": self.company_id.currency_id.id,
                     "currency_id": self.company_id.currency_id.id,
                     "currency_amount": amount,
+                    "name": line.get("name") or self.payment_ref,
                 }
             )
             reconcile_auxiliary_id += 1


### PR DESCRIPTION
Before the PR : 
Create a reconciliation model with type "Button to generate counterpart entry" and one line with journal label item field as empty.
![image](https://github.com/user-attachments/assets/246678be-7b09-4fa3-a55d-441b528630b1)

Then, reconcile a statement line using this reconcile model, the accounting entry will have an empty name.
![image](https://github.com/user-attachments/assets/46dae8b8-bd27-4a33-84fa-0d35c7a51114)


After the PR : 
The accounting entry coming from the manual reconcile model will have the same name as the statement line.
![image](https://github.com/user-attachments/assets/5a6e2115-0b36-45d0-8f1c-3758ee67c1b9)



In previous versions, the name from the statement line was kept.
After a quick check on enterprise, it is also taken from the statement line if empty on the reconciliation model.

@hparfr @etobella 