### PR TITLE
[17][FIX] account_reconcile_oca : keep aml label when empty on manual write-off reconcile model

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -507,6 +507,7 @@ class AccountBankStatementLine(models.Model):
                     "line_currency_id": self.company_id.currency_id.id,
                     "currency_id": self.company_id.currency_id.id,
                     "currency_amount": amount,
+                    "name": line.get("name") or self.payment_ref,
                 }
             )
             reconcile_auxiliary_id += 1


### PR DESCRIPTION
Forwad port of https://github.com/OCA/account-reconcile/pull/744


