### PR TITLE
[16][FIX] account_reconcile_oca : keep partner line case of manual button reconcile

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -519,6 +519,8 @@ class AccountBankStatementLine(models.Model):
                 new_line["partner_id"] = (
                     self.env["res.partner"].browse(line["partner_id"]).name_get()[0]
                 )
+            elif self.partner_id:
+                new_line["partner_id"] = self.partner_id.name_get()[0]
             new_data.append(new_line)
         return new_data, reconcile_auxiliary_id
 


### PR DESCRIPTION
Similar to https://github.com/OCA/account-reconcile/pull/744 but for partner

You have a statement line with partner already filled : 
![image](https://github.com/user-attachments/assets/68f343bb-58cf-493d-a79b-c6bbe4d37e90)

Before this PR, if you click on a reconcile button "test", the partner disapear : 
![image](https://github.com/user-attachments/assets/6aa3e012-7e7b-46b3-84f5-e85b7ed10190)

After this PR, if you click on the reconcile button, the partner is not erased : 
![image](https://github.com/user-attachments/assets/a546c13a-d3b7-4d57-ac77-6cea7ef6b700)


@hparfr 

