### PR TITLE
[16.0][FIX] account_statement_base: Add default_statement_id to the context to create the statement lines linked to it

### DIFF
--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -34,6 +34,7 @@ class AccountBankStatement(models.Model):
             {
                 "domain": [("statement_id", "=", self.id)],
                 "context": {
+                    "default_statement_id": self.id,
                     "default_journal_id": self._context.get("active_id")
                     if self._context.get("active_model") == "account.journal"
                     else None,


### PR DESCRIPTION
Add `default_statement_id` to the context to create the statement lines linked to it

**Before**
![antes](https://github.com/user-attachments/assets/9a0438b3-6023-4294-bd6e-fcdf1972dff4)

**After**
![despues](https://github.com/user-attachments/assets/5526d986-669a-4800-9c78-013ffd99c4a5)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51767