### PR TITLE
[17.0][FIX] account_statement_base: Add default_statement_id to the context to create the statement lines linked to it

### DIFF
--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -34,6 +34,7 @@ class AccountBankStatement(models.Model):
             {
                 "domain": [("statement_id", "=", self.id)],
                 "context": {
+                    "default_statement_id": self.id,
                     "default_journal_id": self._context.get("active_id")
                     if self._context.get("active_model") == "account.journal"
                     else None,

--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -15,7 +15,7 @@
                 <field name="company_id" invisible="1" />
                 <field name="currency_id" invisible="1" />
                 <field name="country_code" invisible="1" />
-                <field5c1485a3 name="state" invisible="1" />
+                <field name="state" invisible="1" />
                 <field name="suitable_journal_ids" invisible="1" />
                 <field name="date" />
                 <field name="payment_ref" required="1" />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-reconcile/pull/749

Add `default_statement_id` to the context to create the statement lines linked to it

**Before**
![antes](https://github.com/user-attachments/assets/9a0438b3-6023-4294-bd6e-fcdf1972dff4)

**After**
![despues](https://github.com/user-attachments/assets/5526d986-669a-4800-9c78-013ffd99c4a5)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51767