### PR TITLE
[17.0][FIX] account_statement_base: Allow statements to be created by clicking on the New button.

### DIFF
--- a/account_statement_base/views/account_bank_statement.xml
+++ b/account_statement_base/views/account_bank_statement.xml
@@ -95,6 +95,9 @@
          <field name="res_model">account.bank.statement</field>
          <field name="view_mode">tree,form,pivot,graph</field>
     </record>
+    <record id="account.action_view_bank_statement_tree" model="ir.actions.act_window">
+        <field name="view_mode">tree,form,pivot,graph</field>
+    </record>
 
     <record id="view_bank_statement_tree" model="ir.ui.view">
         <field name="name">account.bank.statement.tree</field>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-reconcile/pull/745

Allow statements to be created by clicking on the New button (only on cash ones).
If you access the list of statements from the Create button, you should be able to create new records.

**Before**
![antes](https://github.com/user-attachments/assets/6852586a-e414-4a42-a709-62a788959b9d)

**After**
![despues](https://github.com/user-attachments/assets/3bf9877d-a546-4a22-a5a6-7d1d11c30bad)

Please @pedrobaeza can you review it?

@Tecnativa TT51767