### PR TITLE
[16.0][IMP] account_reconcile_oca: reconcile lines from statement

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement.py
+++ b/account_reconcile_oca/models/account_bank_statement.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Dixmit
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
+from odoo.tools.safe_eval import safe_eval
 
 
 class AccountBankStatement(models.Model):
@@ -12,4 +13,18 @@ class AccountBankStatement(models.Model):
             "account_reconcile_oca.account_bank_statement_action_edit"
         )
         action["res_id"] = self.id
+        return action
+
+    def action_open_statement_lines(self):
+        """Open in reconciling view directly"""
+        self.ensure_one()
+        if not self:
+            return {}
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_reconcile_oca.action_bank_statement_line_reconcile"
+        )
+        action["domain"] = [("statement_id", "=", self.id)]
+        action["context"] = safe_eval(
+            action["context"], locals_dict={"active_id": self._context.get("active_id")}
+        )
         return action

--- a/account_reconcile_oca/views/account_bank_statement.xml
+++ b/account_reconcile_oca/views/account_bank_statement.xml
@@ -31,7 +31,22 @@
             </form>
         </field>
     </record>
-
+    <record id="view_bank_statement_form" model="ir.ui.view">
+        <field name="model">account.bank.statement</field>
+        <field
+            name="inherit_id"
+            ref="account_statement_base.view_bank_statement_form"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//button[contains(@context,'search_default_statement_id')]"
+                position="attributes"
+            >
+                <attribute name="type">object</attribute>
+                <attribute name="name">action_open_statement_lines</attribute>
+            </xpath>
+        </field>
+    </record>
     <record id="account_bank_statement_action_edit" model="ir.actions.act_window">
         <field name="name">Edit Bank Statement</field>
         <field name="res_model">account.bank.statement</field>


### PR DESCRIPTION
UX: override the statement lines button action so we can reconcile
directly from the statement itself.

cc @Tecnativa TT51834


![Peek 26-11-2024 10-33](https://github.com/user-attachments/assets/8190a5e4-7cad-4269-bc09-fb3a33eec183)

please review @pedrobaeza @victoralmau 