### PR TITLE
[16.0][FIX] account_statement_base: statement end balance compute new lines

### DIFF
--- a/account_statement_base/models/account_bank_statement.py
+++ b/account_statement_base/models/account_bank_statement.py
@@ -42,3 +42,12 @@ class AccountBankStatement(models.Model):
                 ("statement_id", "=", self.id),
             ],
         }
+
+    def _compute_balance_end(self):
+        # Consider new lines amount in the balance
+        # Remove if merged: https://github.com/odoo/odoo/pull/188675
+        res = super()._compute_balance_end()
+        for stmt in self:
+            lines = stmt.line_ids.filtered(lambda x: not x._origin)
+            stmt.balance_end += sum(lines.mapped("amount"))
+        return res


### PR DESCRIPTION
In a form view, the default state for a new statement line is 'draft'. However, once it's saved is automatically posted.

Remove if merged: https://github.com/odoo/odoo/pull/188675

![Peek 26-11-2024 16-46](https://github.com/user-attachments/assets/8a0ff777-f1ba-4562-b47e-d513c0d73023)

cc @Tecnativa TT51834


please review @pedrobaeza @victoralmau 