### PR TITLE
[17.0][FIX] account_reconcile_oca: Fix selection_badge_uncheck to correctly apply the corresponding domain

### DIFF
--- a/account_reconcile_oca/static/src/js/widgets/selection_badge_uncheck.esm.js
+++ b/account_reconcile_oca/static/src/js/widgets/selection_badge_uncheck.esm.js
@@ -1,10 +1,9 @@
 /** @odoo-module **/
 import {
     BadgeSelectionField,
-    preloadSelection,
+    badgeSelectionField,
 } from "@web/views/fields/badge_selection/badge_selection_field";
 import {registry} from "@web/core/registry";
-import {standardFieldProps} from "@web/views/fields/standard_field_props";
 
 export class FieldSelectionBadgeUncheck extends BadgeSelectionField {
     async onChange(value) {
@@ -20,19 +19,11 @@ export class FieldSelectionBadgeUncheck extends BadgeSelectionField {
     }
 }
 
-FieldSelectionBadgeUncheck.props = {...standardFieldProps};
-FieldSelectionBadgeUncheck.supportedTypes = ["many2one", "selection"];
-FieldSelectionBadgeUncheck.additionalClasses = ["o_field_selection_badge"];
-
 export const FieldSelectionBadgeUncheckField = {
+    ...badgeSelectionField,
     component: FieldSelectionBadgeUncheck,
     supportedTypes: ["many2one"],
 };
 registry
     .category("fields")
     .add("selection_badge_uncheck", FieldSelectionBadgeUncheckField);
-
-registry.category("preloadedData").add("selection_badge_uncheck", {
-    loadOnTypes: ["many2one"],
-    preload: preloadSelection,
-});


### PR DESCRIPTION
Fix selection_badge_uncheck to correctly apply the corresponding domain.

Previously the widget selection_badge_uncheck (wrongly migrated to v17) was not defined correctly, which caused the domain not to be applied, causing that the reconciliation models of any type (instead of those defined as buttons) were shown as buttons.

**Before**
![antes](https://github.com/user-attachments/assets/958d6d3a-15f4-4557-ac0c-0e594e2a9d99)

**After**
![despues](https://github.com/user-attachments/assets/14d26ce6-a4c1-4aaa-9acb-b00a4566dc09)

Please @CarlosRoca13 can you review it?

@Tecnativa TT52238