### PR TITLE
[16.0][FIX] account_reconcile_oca: Fixed analytic distribution update

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -294,6 +294,7 @@ class AccountBankStatementLine(models.Model):
                 self.manual_partner_id and self.manual_partner_id.name_get()[0] or False
             )
             != line.get("partner_id")
+            or self.analytic_distribution != line.get("analytic_distribution", False)
         )
 
     def _get_manual_delete_vals(self):


### PR DESCRIPTION
This fixes a bug that occurred when both account_reconcile_oca and account_reconcile_model_oca modules were installed. The issue arose when assigning an analytic account and making no further changes, causing the analytic account to not be set correctly. As a result, the reconciliation process failed to create the analytic entries properly. This line: ensures that if the analytic distribution has changed, it will be correctly updated.

cc https://github.com/APSL 164854

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review