### PR TITLE
[17.0][FIX] Allow matching of partner in not at the begining of the string

### DIFF
--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -478,14 +478,14 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = (
-                re.match(partner_mapping.payment_ref_regex, ".*"+st_line.payment_ref)
+                re.match(partner_mapping.payment_ref_regex, ".*" + st_line.payment_ref)
                 if partner_mapping.payment_ref_regex
                 else True
             )
             match_narration = (
                 re.match(
                     partner_mapping.narration_regex,
-                    ".*"+tools.html2plaintext(st_line.narration or "").rstrip(),
+                    ".*" + tools.html2plaintext(st_line.narration or "").rstrip(),
                 )
                 if partner_mapping.narration_regex
                 else True

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -478,12 +478,12 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = (
-                re.match(partner_mapping.payment_ref_regex, st_line.payment_ref)
+                re.search(partner_mapping.payment_ref_regex, st_line.payment_ref)
                 if partner_mapping.payment_ref_regex
                 else True
             )
             match_narration = (
-                re.match(
+                re.search(
                     partner_mapping.narration_regex,
                     tools.html2plaintext(st_line.narration or "").rstrip(),
                 )

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -478,14 +478,14 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = (
-                re.search(partner_mapping.payment_ref_regex, st_line.payment_ref)
+                re.match(partner_mapping.payment_ref_regex, ".*"+st_line.payment_ref)
                 if partner_mapping.payment_ref_regex
                 else True
             )
             match_narration = (
-                re.search(
+                re.match(
                     partner_mapping.narration_regex,
-                    tools.html2plaintext(st_line.narration or "").rstrip(),
+                    ".*"+tools.html2plaintext(st_line.narration or "").rstrip(),
                 )
                 if partner_mapping.narration_regex
                 else True


### PR DESCRIPTION
re.match will yield a partner only if the search string is at the begining of the string. The match partner functionality does not specify the string needs to be at the begining. Therefore search would be more suitable.