### PR TITLE
[16.0][FIX] account_reconcile_oca: KeyError on data

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -629,7 +629,7 @@ class AccountBankStatementLine(models.Model):
                     )
                     amount -= sum(line.get("amount") for line in line_data)
                     data += line_data
-                if res.get("auto_reconcile"):
+                if res.get("auto_reconcile") and self.reconcile_data_info:
                     self.reconcile_bank_line()
                 return self._recompute_suspense_line(
                     data,


### PR DESCRIPTION
I'm not quite sure if this is the proper solution to the below problem:

```
RPC_ERROR

  File "/home/ubuntu/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 456, in _compute_reconcile_data_info
    record.reconcile_data_info = record._default_reconcile_data(
  File "/home/ubuntu/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 570, in _default_reconcile_data
    self.reconcile_bank_line()
  File "/home/ubuntu/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 595, in reconcile_bank_line
    self._prepare_reconcile_line_data(self.reconcile_data_info["data"])
KeyError: 'data'
```