### PR TITLE
[16.0][FIX] account_reconcile_oca: missing this.form_controller

### DIFF
--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
@@ -113,7 +113,7 @@ export class ReconcileController extends KanbanController {
             resId = record.resId;
         }
         if (this.state.selectedRecordId && this.state.selectedRecordId !== resId) {
-            if (this.form_controller.model.root.isDirty) {
+            if (this.form_controller && this.form_controller.model.root.isDirty) {
                 await this.form_controller.model.root.save({
                     noReload: true,
                     stayInEdition: true,


### PR DESCRIPTION
Fixes https://github.com/OCA/account-reconcile/issues/750

I would think this is the correct solution, because depending on through which route the widget is opened, there is not always `this.form_controller`. And if it is not there, then its data also does not need to be saved upon switching between items.

