### PR TITLE
[16][FIX] account_reconcile_oca :  Wrong amount currency compute in case of change in liquidity line

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -442,10 +442,11 @@ class AccountBankStatementLine(models.Model):
             "debit": self.manual_amount if self.manual_amount > 0 else 0.0,
             "analytic_distribution": self.analytic_distribution,
         }
-        if self.manual_line_id:
+        liquidity_lines, _suspense_lines, _other_lines = self._seek_for_lines()
+        if self.manual_line_id and self.manual_line_id.id not in liquidity_lines.ids:
             vals.update(
                 {
-                    "currency_amount": self.manual_line_id.currency_id._convert(
+                    "currency_amount": self.manual_currency_id._convert(
                         self.manual_amount,
                         self.manual_in_currency_id,
                         self.company_id,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1260,7 +1260,10 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             )
             f.manual_reference = "account.move.line;%s" % line["id"]
             # simulate click on statement line, check amount does not recompute
+            f.manual_partner_id = inv1.partner_id
             self.assertEqual(f.manual_amount, 83.33)
+            # check currency amount is still fine
+            self.assertEqual(f.reconcile_data_info["data"][0]["currency_amount"], 100)
             f.add_account_move_line_id = inv1.line_ids.filtered(
                 lambda l: l.account_id.account_type == "asset_receivable"
             )


### PR DESCRIPTION
@etobella There is a regression in multi-currency management since the following commit was merged : https://github.com/OCA/account-reconcile/pull/694/commits/f0ae2f00ac2ea5ffbb1d3e19c79d2ee9c37b0635

I don't know the use case for which this code was added, but you can reproduce the issue it creates easily : 

On demo database with account_reconcile_oca (company currency is USD)
1) Create a bank journal with EURO currency
2) Create a statement line in this journal with amount = 100 euros
![image](https://github.com/user-attachments/assets/9d815159-40a8-4950-9ba8-0dd185ab4828)

3) Click on the liquidity line and update the partner
![image](https://github.com/user-attachments/assets/17f88923-878c-4edf-8f19-34e9405cdc44)

=> The USD amount is copied in the amount in currency.
This is because here : https://github.com/OCA/account-reconcile/blob/16.0/account_reconcile_oca/models/account_bank_statement_line.py#L448
The source and destination currency is EURO and the amount converted is USD !
But even if this was fine, I don't see any reason to update amounts for the liquidity line... It could lead to erros because the rate at this  time may be different than the one used at the time of the creation of the statement line.

There may be a better fix, but not knowing exactly the purpose of this part, I prefer to leave it.

By the way, I am always surprised that it is possible to modifiy the manual_amount/manual_amount_currency of the liquidity line, is there any reason or could we put it as readonly to avoid user mistakes ?

I have completed a test to show the failing case.