### PR TITLE
[17.0][IMP] account_reconcile_model_oca: Create _get_write_off_move_move_line_dict() method to allow extension

### DIFF
--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -135,18 +135,7 @@ class AccountReconcileModel(models.Model):
             if currency.is_zero(balance):
                 continue
 
-            writeoff_line = {
-                "name": line.label,
-                "balance": balance,
-                "debit": balance > 0 and balance or 0,
-                "credit": balance < 0 and -balance or 0,
-                "account_id": line.account_id.id,
-                "currency_id": currency.id,
-                "analytic_distribution": line.analytic_distribution,
-                "reconcile_model_id": self.id,
-                "journal_id": line.journal_id.id,
-                "tax_ids": [],
-            }
+            writeoff_line = line._get_write_off_move_line_dict(balance, currency)
             lines_vals_list.append(writeoff_line)
 
             residual_balance -= balance
@@ -688,3 +677,22 @@ class AccountReconcileModel(models.Model):
             return {"allow_write_off", "allow_auto_reconcile"}
 
         return {"rejected"}
+
+
+class AccountReconcileModelLine(models.Model):
+    _inherit = "account.reconcile.model.line"
+
+    def _get_write_off_move_line_dict(self, balance, currency):
+        self.ensure_one()
+        return {
+            "name": self.label,
+            "balance": balance,
+            "debit": balance > 0 and balance or 0,
+            "credit": balance < 0 and -balance or 0,
+            "account_id": self.account_id.id,
+            "currency_id": currency.id,
+            "analytic_distribution": self.analytic_distribution,
+            "reconcile_model_id": self.model_id.id,
+            "journal_id": self.journal_id.id,
+            "tax_ids": [],
+        }


### PR DESCRIPTION
Create `_get_write_off_move_move_line_dict()` method to allow extension

FWP from 16.0: https://github.com/odoo/odoo/pull/188808

Related to OCA/account-reconcile#761

Please @pedrobaeza can you review it?

@Tecnativa TT51885