### PR TITLE
[16.0][FIX] account_reconcile_oca: Fix currency and amount when using reconciliation models

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -537,6 +537,8 @@ class AccountBankStatementLine(models.Model):
     def _reconcile_data_by_model(self, data, reconcile_model, reconcile_auxiliary_id):
         new_data = []
         liquidity_amount = 0.0
+        currency = self._get_reconcile_currency()
+        currency_amount = False
         default_name = ""
         for line_data in data:
             if line_data["kind"] == "suspense":
@@ -555,6 +557,13 @@ class AccountBankStatementLine(models.Model):
                 amount = self.foreign_currency_id.compute(
                     amount, self.journal_id.currency_id or self.company_currency_id
                 )
+            if currency != self.company_id.currency_id:
+                currency_amount = self.company_id.currency_id._convert(
+                    amount,
+                    currency,
+                    self.company_id,
+                    self.date,
+                )
             new_line.update(
                 {
                     "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,
@@ -567,9 +576,9 @@ class AccountBankStatementLine(models.Model):
                     .browse(line["account_id"])
                     .name_get()[0],
                     "date": fields.Date.to_string(self.date),
-                    "line_currency_id": self.company_id.currency_id.id,
+                    "line_currency_id": currency.id,
                     "currency_id": self.company_id.currency_id.id,
-                    "currency_amount": amount,
+                    "currency_amount": currency_amount or amount,
                     "name": line.get("name") or self.payment_ref,
                 }
             )

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -613,6 +613,57 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         self.assertTrue(reconcile_move.reversal_move_id)
         self.assertFalse(bank_stmt_line.is_reconciled)
 
+    def test_reconcile_model_with_foreign_currency(self):
+        """
+        We want to test what happens when we select a reconcile model to fill a
+        bank statement with a foreign currency.
+        """
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_usd.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_usd.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_model_id = self.rule
+            self.assertTrue(f.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
+        self.assertEqual(2, len(bank_stmt_line.move_id.line_ids))
+        self.assertTrue(
+            bank_stmt_line.move_id.line_ids.filtered(
+                lambda r: r.account_id == self.current_assets_account
+            )
+        )
+        expected_amount = bank_stmt_line._get_reconcile_currency()._convert(
+            bank_stmt_line.amount,
+            bank_stmt_line.company_id.currency_id,
+            bank_stmt_line.company_id,
+            bank_stmt_line.date,
+        )
+        self.assertEqual(
+            bank_stmt_line.move_id.line_ids[0].amount_currency, bank_stmt_line.amount
+        )
+        self.assertEqual(bank_stmt_line.move_id.line_ids[0].debit, expected_amount)
+        self.assertEqual(bank_stmt_line.move_id.line_ids[1].credit, expected_amount)
+
     # Testing to check functionality
 
     def test_reconcile_invoice_to_check_reconciled(self):


### PR DESCRIPTION
When using manual reconcile model to reconcile, the amount in currency is not properly updated.

#### Steps to reproduce in runbot:
1. Create Journal with foreign currency (for example EUR) and bank type.
2. Create Reconciliation Model as writeoff_button type with some account in counterpart entries.
3. Go to Dashboard -> Get into journal created in step 1 -> Create.
4. Set any amount and any label and Save it.
5. Click on your statement and click on reconciliation model button.
6. Amount in currency has the wrong currency and wrong amount.


https://github.com/user-attachments/assets/1c404d26-6b8b-42dd-b45b-d22108e0152c


#### Behaviour with PR:
Reproducing the same steps, currency and amount are now correctly displayed.


https://github.com/user-attachments/assets/81f8d2a2-5e86-4502-91f4-4b8c9d53338f



