### PR TITLE
[17.0][FIX] account_reconcile_oca: Replace name_get() to delete the warning log

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1020,7 +1020,7 @@ class AccountBankStatementLine(models.Model):
                     suspense_lines,
                     _other_lines,
                 ) = st_line._seek_for_lines()
-                line_vals = {"partner_id": st_line.partner_id}
+                line_vals = {"partner_id": st_line.partner_id.id}
                 line_ids_commands = [(1, liquidity_lines.id, line_vals)]
                 if suspense_lines:
                     line_ids_commands.append((1, suspense_lines.id, line_vals))

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -613,7 +613,10 @@ class AccountBankStatementLine(models.Model):
                     self.env["res.partner"].browse(line["partner_id"]).display_name,
                 )
             elif self.partner_id:
-                new_line["partner_id"] = self.partner_id.name_get()[0]
+                new_line["partner_id"] = (
+                    self.partner_id.id,
+                    self.partner_id.display_name,
+                )
             new_data.append(new_line)
         return new_data, reconcile_auxiliary_id
 


### PR DESCRIPTION
Changes done:

Replace `name_get()` to delete the warning log
`WARNING prod py.warnings: /opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py:616: DeprecationWarning: Since 17.0, deprecated method, read display_name instead`

Set the appropriate value for `partner_id` to avoid warning log
`WARNING prod py.warnings: /opt/odoo/auto/addons/account/models/account_move.py:4651: UserWarning: unsupported operand type(s) for "==": 'res.partner()' == '403'`

@Tecnativa