### PR TITLE
[16.0][FIX] account_reconcile_oca: Avoiding the singleton error related to _get_reconcile_line()

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -681,13 +681,16 @@ class AccountBankStatementLine(models.Model):
                         reconciled_line.move_id.journal_id
                         == self.company_id.currency_exchange_journal_id
                     ):
-                        reconcile_auxiliary_id, lines = self._get_reconcile_line(
-                            reconciled_line.move_id.line_ids - reconciled_line,
-                            "other",
-                            from_unreconcile=False,
-                            move=True,
-                        )
-                        data += lines
+                        for rl_item in (
+                            reconciled_line.move_id.line_ids - reconciled_line
+                        ):
+                            reconcile_auxiliary_id, lines = self._get_reconcile_line(
+                                rl_item,
+                                "other",
+                                from_unreconcile=False,
+                                move=True,
+                            )
+                            data += lines
                         continue
                     partial = partial_lines.filtered(
                         lambda r: r.debit_move_id == reconciled_line


### PR DESCRIPTION
Avoiding the singleton error related to `_get_reconcile_line()`

Related to https://github.com/OCA/account-reconcile/pull/694

```
Example use case:
 File "/opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 541, in _compute_reconcile_data_info
    record.reconcile_data_info = record._default_reconcile_data(
  File "/opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 698, in _default_reconcile_data
    reconcile_auxiliary_id, lines = self._get_reconcile_line(
  File "/opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py", line 1164, in _get_reconcile_line
    new_vals = super()._get_reconcile_line(
  File "/opt/odoo/auto/addons/account_reconcile_oca/models/account_reconcile_abstract.py", line 49, in _get_reconcile_line
    original_amount = amount = net_amount = line.debit - line.credit
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1154, in __get__
    record.ensure_one()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5204, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move.line(208, 211, 212)
```

Please @pedrobaeza and @etobella can you review it?

@Tecnativa TT55221