### PR TITLE
[17.0][FIX] account_mass_reconcile: writeoff with currencies of opposite signs

### DIFF
--- a/account_mass_reconcile/models/base_reconciliation.py
+++ b/account_mass_reconcile/models/base_reconciliation.py
@@ -158,11 +158,12 @@ class MassReconcileBase(models.AbstractModel):
         currency = same_curr and lines[0].currency_id or lines[0].company_id.currency_id
         journal = self.journal_id
         partners = lines.mapped("partner_id")
+
+        # We only pass amount_currency. Odoo will compute debit/credit automatically
+        # based on the exchange rate, avoiding sign constraint violations.
         write_off_vals = {
             "name": _("Automatic writeoff"),
             "amount_currency": same_curr and amount_curr or amount,
-            "debit": amount > 0.0 and amount or 0.0,
-            "credit": amount < 0.0 and -amount or 0.0,
             "partner_id": len(partners) == 1 and partners.id or False,
             "account_id": account.id,
             "journal_id": journal.id,
@@ -170,8 +171,6 @@ class MassReconcileBase(models.AbstractModel):
         }
         counterpart_account = lines.mapped("account_id")
         counter_part = write_off_vals.copy()
-        counter_part["debit"] = write_off_vals["credit"]
-        counter_part["credit"] = write_off_vals["debit"]
         counter_part["amount_currency"] = -write_off_vals["amount_currency"]
         counter_part["account_id"] = (counterpart_account.id,)
 

--- a/account_mass_reconcile/tests/test_scenario_reconcile.py
+++ b/account_mass_reconcile/tests/test_scenario_reconcile.py
@@ -451,3 +451,238 @@ class TestScenarioReconcile(AccountTestInvoicingCommon):
         )
         self.assertEqual(len(writeoff_line), 1)
         self.assertEqual(writeoff_line.date, fields.Date.today())
+
+    def test_reconcile_with_writeoff_currency_opposite_signs(self):
+        """Test write-off when company and foreign residuals have opposite signs."""
+        self.env.ref("base.group_multi_currency").users |= self.env.user
+        self.company.currency_id = self.env.ref("base.EUR")
+        usd = self.env.ref("base.USD")
+        usd.active = True
+
+        inv_date = fields.Date.today() - timedelta(days=10)
+        pay_date = fields.Date.today() - timedelta(days=1)
+
+        # Create currency rates
+        self.env["res.currency.rate"].create(
+            [
+                {
+                    "name": inv_date,
+                    "currency_id": usd.id,
+                    "rate": 1.2,
+                    "company_id": self.company.id,
+                },
+                {
+                    "name": pay_date,
+                    "rate": 1.25,
+                    "currency_id": usd.id,
+                    "company_id": self.company.id,
+                },
+                {
+                    "name": fields.Date.today(),
+                    "rate": 1.25,
+                    "currency_id": usd.id,
+                    "company_id": self.company.id,
+                },
+            ]
+        )
+
+        # Create invoice and payment with opposing residual signs
+        common_ref = "INV-PAY-OPPOSITE-SIGNS"
+        invoice = self.init_invoice(
+            move_type="out_invoice",
+            partner=self.partner_a,
+            currency=usd,
+            amounts=[100],
+            invoice_date=inv_date,
+            post=True,
+        )
+        invoice.ref = common_ref
+
+        payment = self.env["account.payment"].create(
+            {
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "partner_id": self.partner_a.id,
+                "destination_account_id": self.company_data[
+                    "default_account_receivable"
+                ].id,
+                "amount": 100.10,
+                "currency_id": usd.id,
+                "journal_id": self.bank_journal.id,
+                "date": pay_date,
+                "ref": common_ref,
+            }
+        )
+        payment.action_post()
+
+        # Create and run mass reconciliation
+        mass_rec = self.mass_rec_obj.create(
+            {
+                "name": "mass_reconcile_currency_writeoff_opposite",
+                "account": self.company_data["default_account_receivable"].id,
+                "reconcile_method": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "mass.reconcile.advanced.ref",
+                            "account_lost_id": self.company_data[
+                                "default_account_expense"
+                            ].id,
+                            "account_profit_id": self.company_data[
+                                "default_account_revenue"
+                            ].id,
+                            "journal_id": self.company_data["default_journal_misc"].id,
+                            "write_off": 3.50,
+                            "date_base_on": "newest",
+                        },
+                    )
+                ],
+            }
+        )
+
+        invoice_receivable_line = invoice.line_ids.filtered(
+            lambda li: li.account_type == "asset_receivable"
+        )
+
+        mass_rec.run_reconcile()
+
+        # Assert full reconciliation happened
+        self.assertTrue(invoice_receivable_line.full_reconcile_id)
+
+        # invoice line, payment line, writeoff line, and exchange rate line
+        self.assertEqual(
+            len(invoice_receivable_line.full_reconcile_id.reconciled_line_ids), 4
+        )
+
+        writeoff_receivable_line = (
+            invoice_receivable_line.full_reconcile_id.reconciled_line_ids.filtered(
+                lambda li: li.journal_id.id
+                == self.company_data["default_journal_misc"].id
+            )
+        )
+        self.assertEqual(
+            writeoff_receivable_line.move_id.currency_id,
+            usd,
+            "USD should be the write-off currency",
+        )
+        self.assertAlmostEqual(writeoff_receivable_line.amount_currency, 0.1)
+
+    def test_reconcile_with_writeoff_mixed_currencies(self):
+        """Test write-off when reconciling lines with different currencies."""
+        self.env.ref("base.group_multi_currency").users |= self.env.user
+        self.company.currency_id = self.env.ref("base.EUR")
+        usd = self.env.ref("base.USD")
+        usd.active = True
+
+        today = fields.Date.today()
+
+        # Create currency rate (1 EUR = 1.2 USD)
+        self.env["res.currency.rate"].create(
+            {
+                "name": today,
+                "currency_id": usd.id,
+                "rate": 1.2,
+                "company_id": self.company.id,
+            }
+        )
+
+        common_ref = "INV-PAY-MIXED-CURRENCIES"
+
+        # Create Invoice in USD (120 USD = 100 EUR)
+        invoice = self.init_invoice(
+            move_type="out_invoice",
+            partner=self.partner_a,
+            currency=usd,
+            amounts=[120],
+            invoice_date=today,
+            post=True,
+        )
+        invoice.ref = common_ref
+
+        # Create Payment in Company Currency EUR (e.g., 99.50 EUR)
+        payment = self.env["account.payment"].create(
+            {
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "partner_id": self.partner_a.id,
+                "destination_account_id": self.company_data[
+                    "default_account_receivable"
+                ].id,
+                "amount": 99.50,
+                "currency_id": self.company.currency_id.id,  # EUR
+                "journal_id": self.bank_journal.id,
+                "date": today,
+                "ref": common_ref,
+            }
+        )
+        payment.action_post()
+
+        # Create and run mass reconciliation with write-off limit covering the 0.50 gap
+        mass_rec = self.mass_rec_obj.create(
+            {
+                "name": "mass_reconcile_mixed_currency_writeoff",
+                "account": self.company_data["default_account_receivable"].id,
+                "reconcile_method": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "mass.reconcile.advanced.ref",
+                            "account_lost_id": self.company_data[
+                                "default_account_expense"
+                            ].id,
+                            "account_profit_id": self.company_data[
+                                "default_account_revenue"
+                            ].id,
+                            "journal_id": self.company_data["default_journal_misc"].id,
+                            "write_off": 1.00,  # Covers the 0.50 EUR difference
+                            "date_base_on": "newest",
+                        },
+                    )
+                ],
+            }
+        )
+
+        existing_moves = self.env["account.move"].search(
+            [("journal_id", "=", self.company_data["default_journal_misc"].id)]
+        )
+
+        mass_rec.run_reconcile()
+
+        # Assert full reconciliation happened
+        invoice_receivable_line = invoice.line_ids.filtered(
+            lambda li: li.account_type == "asset_receivable"
+        )
+        self.assertTrue(
+            invoice_receivable_line.full_reconcile_id,
+            "Lines should be fully reconciled",
+        )
+
+        # Validate the write-off move was created in the company currency
+        writeoff_move = self.env["account.move"].search(
+            [
+                ("journal_id", "=", self.company_data["default_journal_misc"].id),
+                ("id", "not in", existing_moves.ids),
+            ]
+        )
+        self.assertEqual(
+            len(writeoff_move), 1, "Exactly one write-off move should exist"
+        )
+        self.assertEqual(
+            writeoff_move.currency_id,
+            self.company.currency_id,
+            "EUR should be the write-off currency since lines had mixed currencies",
+        )
+
+        expense_line = writeoff_move.line_ids.filtered(
+            lambda ml: ml.account_id == self.company_data["default_account_expense"]
+        )
+
+        # Verify the write-off handles the 0.50 EUR residual
+        self.assertAlmostEqual(
+            expense_line.debit,
+            0.50,
+            2,
+            "Expense line debit should cover the 0.50 EUR gap",
+        )


### PR DESCRIPTION
It appeared to be a bug related to account_mass_reconcile on method `create_write_off()` when creating write off journal items with different currencies. An error is raised, caused by this line:
https://github.com/OCA/account-reconcile/blob/17.0/account_mass_reconcile/models/base_reconciliation.py#L163

which triggers this standard Odoo sql constraint:
https://github.com/odoo/odoo/blob/17.0/addons/account/models/account_move_line.py#L428


Here is the full error:

```
2025-04-15 08:13:39,661 249 INFO odoo odoo.addons.account_mass_reconcile.tests.test_scenario_reconcile: ====================================================================== 
2025-04-15 08:13:39,661 249 ERROR odoo odoo.addons.account_mass_reconcile.tests.test_scenario_reconcile: ERROR: TestScenarioReconcile.test_reconcile_with_writeoff_currency_opposite_signs
Traceback (most recent call last):
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/mass_reconcile.py", line 201, in run_reconcile
    ml_rec_ids = self.with_env(new_env)._run_reconcile_method(method)
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/mass_reconcile.py", line 150, in _run_reconcile_method
    return auto_rec_id.automatic_reconcile()
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_reconciliation.py", line 30, in automatic_reconcile
    return self._action_rec()
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_advanced_reconciliation.py", line 211, in _action_rec
    result = self._rec_auto_lines_advanced(credit_lines, debit_lines)
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_advanced_reconciliation.py", line 310, in _rec_auto_lines_advanced
    reconciled_ids = self._rec_group(reconcile_groups, lines_by_id)
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_advanced_reconciliation.py", line 232, in _rec_group
    reconciled, full = self._reconcile_lines(group_lines, allow_partial=True)
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_reconciliation.py", line 220, in _reconcile_lines
    writeoff_line = self.create_write_off(
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/base_reconciliation.py", line 178, in create_write_off
    move = self.env["account.move"].create(
  File "<decorator-gen-203>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 430, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/addons/account/models/account_move.py", line 2498, in create
    moves = super().create(vals_list)
  File "<decorator-gen-137>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/addons/mail/models/mail_thread.py", line 259, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-12>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/odoo/models.py", line 4654, in create
    records = self._create(data_list)
  File "/opt/odoo/odoo/models.py", line 4901, in _create
    field.create([
  File "/opt/odoo/odoo/fields.py", line 4348, in create
    self.write_batch(record_values, True)
  File "/opt/odoo/odoo/fields.py", line 4374, in write_batch
    self.write_real(records_commands_list, create)
  File "/opt/odoo/odoo/fields.py", line 4564, in write_real
    flush()
  File "/opt/odoo/odoo/fields.py", line 4520, in flush
    comodel.create(to_create)
  File "<decorator-gen-204>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/addons/account/models/account_move_line.py", line 1582, in create
    lines = super().create([self._sanitize_vals(vals) for vals in vals_list])
  File "<decorator-gen-158>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/addons/analytic/models/analytic_mixin.py", line 126, in create
    return super().create(vals_list)
  File "<decorator-gen-12>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/odoo/models.py", line 4654, in create
    records = self._create(data_list)
  File "/opt/odoo/odoo/models.py", line 4842, in _create
    cr.execute(SQL(
  File "/opt/odoo/odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.CheckViolation: new row for relation "account_move_line" violates check constraint "account_move_line_check_amount_currency_balance_sign"
DETAIL:  Failing row contains (79, 30, 31, 6, 126, 100, 225, 1, 50, null, null, null, null, null, null, null, null, null, null, null, null, 9, 9, null, null, null, Automatic writeoff, null, product, null, null, null, null, null, 3.25, 0.00, 3.25, -0.10, null, null, null, 1.00, 0.00, null, null, 0.00, null, null, null, null, f, 2025-04-15 08:13:34.969427, 2025-04-15 08:13:34.969427).


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/tests/test_scenario_reconcile.py", line 546, in test_reconcile_with_writeoff_currency_opposite_signs
    mass_rec.run_reconcile()
  File "/__w/account-reconcile/account-reconcile/account_mass_reconcile/models/mass_reconcile.py", line 221, in run_reconcile
    rec.message_post(body=message)
  File "/opt/odoo/addons/sms/models/mail_thread.py", line 52, in message_post
    return super().message_post(*args, body=body, message_type=message_type, **kwargs)
  File "/opt/odoo/addons/mail/models/mail_thread.py", line 2206, in message_post
    'parent_id': self._message_compute_parent_id(parent_id),
  File "/opt/odoo/addons/mail/models/mail_thread.py", line 2863, in _message_compute_parent_id
    parent_message = MailMessage_sudo.search([('res_id', '=', self.id), ('model', '=', self._name), ('message_type', '!=', 'user_notification')], order="id ASC", limit=1)
  File "/opt/odoo/odoo/models.py", line [162](https://github.com/OCA/account-reconcile/actions/runs/14464536946/job/40563739331?pr=831#step:8:163)3, in search
    return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
  File "/opt/odoo/odoo/models.py", line 1654, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
  File "/opt/odoo/odoo/models.py", line 3986, in _fetch_query
    fetched = self.browse(query)
  File "/opt/odoo/odoo/models.py", line 5861, in browse
    if not ids:
  File "/opt/odoo/odoo/tools/query.py", line 261, in __bool__
    return bool(self.get_result_ids())
  File "/opt/odoo/odoo/tools/query.py", line 224, in get_result_ids
    self._cr.execute(self.select())
  File "/opt/odoo/odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block
```