### PR TITLE
[17.0][FIX] account_reconcile_oca: Replace name_get() to delete the warning log

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -572,7 +572,9 @@ class AccountBankStatementLine(models.Model):
             -liquidity_amount, partner.id
         ):
             new_line = line.copy()
-            new_line["partner_id"] = partner and partner.name_get()[0] or False
+            new_line["partner_id"] = (
+                (partner.id, partner.display_name) if partner else False
+            )
             amount = line.get("balance")
             if self.foreign_currency_id:
                 amount = self.foreign_currency_id._convert(


### PR DESCRIPTION
Replace `name_get()` to delete the warning log
`WARNING prod py.warnings: /opt/odoo/auto/addons/account_reconcile_oca/models/account_bank_statement_line.py:616: DeprecationWarning: Since 17.0, deprecated method, read display_name instead`

@Tecnativa