### PR TITLE
[16.0][FIX] account_reconcile_oca: When doing manual reconciliations, allowto set the amount to reconcile in the invoice currency.

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -10,6 +10,7 @@ from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.fields import first
 from odoo.tools import float_compare, float_is_zero
+from odoo.tools.misc import formatLang
 
 
 class AccountBankStatementLine(models.Model):
@@ -86,6 +87,11 @@ class AccountBankStatementLine(models.Model):
         prefetch=False,
         currency_field="manual_in_currency_id",
     )
+    changed_manual_amount_in_currency = fields.Boolean(
+        store=False,
+        default=False,
+        prefetch=False,
+    )
     manual_exchange_counterpart = fields.Boolean(
         store=False,
     )
@@ -109,8 +115,16 @@ class AccountBankStatementLine(models.Model):
     manual_currency_id = fields.Many2one(
         "res.currency", readonly=True, store=False, prefetch=False
     )
-    manual_original_amount = fields.Monetary(
-        default=False, store=False, prefetch=False, readonly=True
+    manual_original_amount_in_currency = fields.Monetary(
+        default=False,
+        store=False,
+        prefetch=False,
+        readonly=True,
+        currency_field="manual_in_currency_id",
+    )
+    manual_amount_message = fields.Char(compute="_compute_manual_amount_message")
+    show_full_reconcile_button = fields.Boolean(
+        compute="_compute_manual_amount_message"
     )
     manual_move_type = fields.Selection(
         lambda r: r.env["account.move"]._fields["move_type"].selection,
@@ -139,6 +153,34 @@ class AccountBankStatementLine(models.Model):
     reconcile_aggregate = fields.Char(compute="_compute_reconcile_aggregate")
     aggregate_id = fields.Integer(compute="_compute_reconcile_aggregate")
     aggregate_name = fields.Char(compute="_compute_reconcile_aggregate")
+
+    @api.depends(
+        "manual_original_amount_in_currency",
+        "manual_currency_id",
+        "manual_amount_in_currency",
+        "manual_move_id",
+    )
+    def _compute_manual_amount_message(self):
+        for rec in self:
+            rec.show_full_reconcile_button = True
+            rec.manual_amount_message = ""
+            if not rec.manual_currency_id:
+                continue
+            resulting_amt = (
+                rec.manual_original_amount_in_currency - rec.manual_amount_in_currency
+            )
+            if rec.manual_currency_id.is_zero(resulting_amt):
+                msg = _("will be fully paid.")
+                rec.show_full_reconcile_button = False
+            else:
+                msg = _("will be reduced by %s") % (
+                    formatLang(
+                        self.env,
+                        rec.manual_amount_in_currency,
+                        currency_obj=rec.manual_currency_id,
+                    )
+                )
+            rec.manual_amount_message = msg
 
     @api.model
     def _reconcile_aggregate_map(self):
@@ -390,7 +432,7 @@ class AccountBankStatementLine(models.Model):
             "manual_move_id": False,
             "manual_move_type": False,
             "manual_kind": False,
-            "manual_original_amount": False,
+            "manual_original_amount_in_currency": False,
             "manual_currency_id": False,
             "analytic_distribution": False,
         }
@@ -415,7 +457,9 @@ class AccountBankStatementLine(models.Model):
             self.manual_move_id = self.manual_line_id.move_id
             self.manual_move_type = self.manual_line_id.move_id.move_type
         self.manual_kind = line["kind"]
-        self.manual_original_amount = line.get("original_amount", 0.0)
+        self.manual_original_amount_in_currency = line.get(
+            "original_amount_currency", 0.0
+        )
 
     @api.onchange("manual_reference", "manual_delete")
     def _onchange_manual_reconcile_reference(self):
@@ -446,6 +490,39 @@ class AccountBankStatementLine(models.Model):
         )
         self.can_reconcile = self.reconcile_data_info.get("can_reconcile", False)
 
+    @api.onchange("manual_amount_in_currency")
+    def _onchange_manual_amount_in_currency(self):
+        if (
+            self.manual_line_id.exists()
+            and self.manual_line_id
+            and self.manual_kind != "liquidity"
+        ):
+            self.manual_amount = self.manual_in_currency_id._convert(
+                self.manual_amount_in_currency,
+                self.company_id.currency_id,
+                self.company_id,
+                self.manual_line_id.date,
+            )
+        self.changed_manual_amount_in_currency = True
+        self._onchange_manual_reconcile_vals()
+
+    @api.onchange("manual_amount")
+    def _onchange_manual_amount(self):
+        if (
+            self.manual_line_id.exists()
+            and self.manual_line_id
+            and self.manual_kind != "liquidity"
+            and not self.changed_manual_amount_in_currency
+        ):
+            self.manual_amount_in_currency = self.company_id.currency_id._convert(
+                self.manual_amount,
+                self.manual_in_currency_id,
+                self.company_id,
+                self.manual_line_id.date,
+            )
+        self.changed_manual_amount_in_currency = False
+        self._onchange_manual_reconcile_vals()
+
     def _get_manual_reconcile_vals(self):
         vals = {
             "name": self.manual_name,
@@ -463,16 +540,19 @@ class AccountBankStatementLine(models.Model):
         }
         liquidity_lines, _suspense_lines, _other_lines = self._seek_for_lines()
         if self.manual_line_id and self.manual_line_id.id not in liquidity_lines.ids:
-            vals.update(
-                {
-                    "currency_amount": self.manual_currency_id._convert(
-                        self.manual_amount,
-                        self.manual_in_currency_id,
-                        self.company_id,
-                        self.manual_line_id.date,
-                    ),
-                }
-            )
+            if self.manual_in_currency_id and self.manual_amount_in_currency:
+                vals.update({"currency_amount": self.manual_amount_in_currency})
+            else:
+                vals.update(
+                    {
+                        "currency_amount": self.manual_currency_id._convert(
+                            self.manual_amount,
+                            self.manual_in_currency_id,
+                            self.company_id,
+                            self.manual_line_id.date,
+                        ),
+                    }
+                )
         return vals
 
     @api.onchange(

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -49,8 +49,11 @@ class AccountReconcileAbstract(models.AbstractModel):
         date = self.date if "date" in self._fields else line.date
         original_amount = amount = net_amount = line.debit - line.credit
         line_currency = line.currency_id
+        original_amount_currency = line.amount_currency
         if is_counterpart:
-            currency_amount = -line.amount_residual_currency or line.amount_residual
+            currency_amount = original_amount_currency = (
+                -line.amount_residual_currency or line.amount_residual
+            )
             amount = -line.amount_residual
             currency = line.currency_id or line.company_id.currency_id
             original_amount = net_amount = -line.amount_residual
@@ -87,6 +90,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             currency_amount = line.amount_currency
         else:
             currency_amount = self.amount_currency or self.amount
+            original_amount_currency = self.amount_currency
             line_currency = self._get_reconcile_currency()
         vals = {
             "move_id": move and line.move_id.id,
@@ -106,6 +110,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             "currency_amount": currency_amount,
             "analytic_distribution": line.analytic_distribution,
             "kind": kind,
+            "original_amount_currency": original_amount_currency,
         }
         if from_unreconcile:
             vals.update(

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -255,6 +255,105 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             f.manual_reference = "account.move.line;%s" % receivable1.id
             self.assertEqual(-100, f.manual_amount)
 
+    def test_reconcile_invoice_reconcile_with_currency(self):
+        """
+        We want to test the reconcile widget for bank statements on invoices
+        with a different currency. We want to indicate manually in the bank
+        statement line the amount that we want to reconcile, expressed in
+        the invoice currency.
+        """
+        new_rate = 1.6299
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-07-01"),
+                "rate": new_rate,
+                "currency_id": self.currency_usd_id,
+                "company_id": self.bank_journal_euro.company_id.id,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable1 = inv1.line_ids.filtered(
+            lambda l: l.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.add_account_move_line_id = receivable1
+            self.assertFalse(f.add_account_move_line_id)
+            self.assertTrue(f.can_reconcile)
+            f.manual_reference = "account.move.line;%s" % receivable1.id
+            f.manual_amount_in_currency = -100
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(inv1.amount_residual_signed, 0)
+        self.assertEqual(inv1.payment_state, "paid")
+
+    def test_reconcile_invoice_reconcile_full_with_currency(self):
+        """
+        We want to test the reconcile widget for bank statements on invoices
+        with a different currency. We want to press the button on the statement
+        line to force the full reconciliation.
+        """
+        new_rate = 1.6299
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-07-01"),
+                "rate": new_rate,
+                "currency_id": self.currency_usd_id,
+                "company_id": self.bank_journal_euro.company_id.id,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable1 = inv1.line_ids.filtered(
+            lambda l: l.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.add_account_move_line_id = receivable1
+            self.assertFalse(f.add_account_move_line_id)
+            self.assertTrue(f.can_reconcile)
+            f.manual_reference = "account.move.line;%s" % receivable1.id
+        bank_stmt_line.button_manual_reference_full_paid()
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(inv1.amount_residual_signed, 0)
+        self.assertEqual(inv1.payment_state, "paid")
+
     def test_reconcile_invoice_unreconcile(self):
         """
         We want to test the reconcile widget for bank statements on invoices.

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -287,15 +287,22 @@
                                     attrs="{'readonly': ['|', '|', ('manual_exchange_counterpart', '=', True), ('manual_reference', '=', False), ('is_reconciled', '=', True)]}"
                                 />
                                 <field name="manual_currency_id" invisible="1" />
-                                <field name="manual_original_amount" invisible="1" />
+                                <field
+                                    name="manual_original_amount_in_currency"
+                                    invisible="1"
+                                />
                                 <field name="manual_move_type" invisible="1" />
+                                <field
+                                    name="show_full_reconcile_button"
+                                    invisible="1"
+                                />
                                 <label
                                     for="manual_move_id"
                                     string=""
-                                    attrs="{'invisible': ['|', ('manual_move_type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund']), ('manual_original_amount', '=', 0)]}"
+                                    attrs="{'invisible': ['|', ('manual_move_type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund']), ('manual_original_amount_in_currency', '=', 0)]}"
                                 />
                                 <div
-                                    attrs="{'invisible': ['|', ('manual_move_type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund']), ('manual_original_amount', '=', 0)]}"
+                                    attrs="{'invisible': ['|', ('manual_move_type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund']), ('manual_original_amount_in_currency', '=', 0)]}"
                                 >
                                     Invoice <field
                                         class="oe_inline"
@@ -303,18 +310,19 @@
                                     />
                                     with an open amount <field
                                         class="oe_inline"
-                                        name="manual_original_amount"
-                                    /> will be reduced by <field
-                                        class="oe_inline"
-                                        name="manual_amount"
-                                        readonly="1"
-                                    />.
-                                    <br />
-                                You might want to set the invoice as <button
-                                        name="button_manual_reference_full_paid"
-                                        type="object"
-                                        method_args="[1]"
-                                    >fully paid</button>.
+                                        name="manual_original_amount_in_currency"
+                                    />
+                                    <field name="manual_amount_message" />
+                                    <div
+                                        attrs="{'invisible': [('show_full_reconcile_button', '=', False)]}"
+                                    >
+                                        <br />
+                                        You might want to set the invoice as <button
+                                            name="button_manual_reference_full_paid"
+                                            type="object"
+                                            method_args="[1]"
+                                        >fully paid</button>.
+                                    </div>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
Before this fix, when attempting to reconcile a statement line in EUR with an invoice in USD, upon indicating the amount to reconcile in the currency invoice the results would be incorrect. 

This fix also includes an improvement on the message shown in the bank statement line on the effect of the reconciliation to the invoice.

cc @etobella @pedrobaeza 