### PR TITLE
[IMP] account_statement_base: Added internal_index in tree view for sorting

### DIFF
--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -59,6 +59,7 @@
         <field name="model">account.bank.statement.line</field>
         <field name="arch" type="xml">
             <tree editable="top" multi_edit="1" decoration-muted="is_reconciled">
+                <field name="internal_index" optional="hide" />
                 <field name="sequence" />
                 <field
                     name="date"


### PR DESCRIPTION
The internal_index field is added to correctly sort the statement lines, because if we sort by date or sequence, the running_balance field will be incorrect.