### PR TITLE
[18.0][FIX] account_reconcile_oca: Can't fetch record error to reconcile

### DIFF
--- a/account_reconcile_oca/static/src/js/widgets/reconcile_data_widget.esm.js
+++ b/account_reconcile_oca/static/src/js/widgets/reconcile_data_widget.esm.js
@@ -3,10 +3,15 @@ import {formatDate, parseDate} from "@web/core/l10n/dates";
 import {formatMonetary} from "@web/views/fields/formatters";
 import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";
+import {standardFieldProps} from "@web/views/fields/standard_field_props";
 
 const {Component} = owl;
 
 export class AccountReconcileDataWidget extends Component {
+    static props = {
+        ...standardFieldProps,
+    };
+    static template = "account_reconcile_oca.ReconcileDataWidget";
     setup() {
         super.setup(...arguments);
         this.orm = useService("orm");
@@ -84,7 +89,6 @@ export class AccountReconcileDataWidget extends Component {
         this.action.doAction(action);
     }
 }
-AccountReconcileDataWidget.template = "account_reconcile_oca.ReconcileDataWidget";
 
 export const AccountReconcileDataWidgetField = {
     component: AccountReconcileDataWidget,


### PR DESCRIPTION
Before this fix using the account_reconcile_oca module in Odoo 18.0, opening the widget cause a loading module warning.

In the reconcile_data_widget.esm.js file where the widget wasn't being loaded correctly due to improper props definition.
This fix properly defines the widget props using standardFieldProps and moves the template definition to the class declaration,
ensuring the widget is loaded correctly and preventing the FetchRecordError after reconciliation.

This seems to be partially related #813 in a way it does not toast error message of deleted IDs not found in all cases, which I'm not sure why.


I signed OCA CLA.