### PR TITLE
[17.0][FIX] account_reconcile_oca: Show the name of the move if reconciliation model apply

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -669,6 +669,7 @@ class AccountBankStatementLine(models.Model):
                         is_counterpart=True,
                         max_amount=amount,
                         reconcile_auxiliary_id=reconcile_auxiliary_id,
+                        move=True,
                     )
                     amount -= sum(line.get("amount") for line in line_data)
                     data += line_data


### PR DESCRIPTION
Show the name of the move if reconciliation model apply

Consistent with existing: https://github.com/OCA/account-reconcile/blob/bb97b2a2d122c4f99b98e93724b5b2c2647e786d/account_reconcile_oca/models/account_bank_statement_line.py#L983

Example use case:
- Invoice reconciliation model without self-validation.
- Create an invoice to a customer with an amount
- Create a bank statement line with the corresponding amount
- Click on Reset reconciliation
- The name of the invoice against which it has been linked will be displayed

**Before**
![antes](https://github.com/user-attachments/assets/64f0ec4c-0a5d-450a-aae2-a06cceac4796)

**After**
![despues](https://github.com/user-attachments/assets/5aff786f-a78b-4514-ac1e-b86b91cf3a01)

Please @pedrobaeza and @etobella can you review it?

@Tecnativa TT56294 TT56157