### PR TITLE
[17.0][FIX] account_reconcile_oca: display foreign currency symbol in reconciliation widget

### DIFF
--- a/account_reconcile_oca/static/src/js/widgets/reconcile_data_widget.esm.js
+++ b/account_reconcile_oca/static/src/js/widgets/reconcile_data_widget.esm.js
@@ -35,7 +35,6 @@ export class AccountReconcileDataWidget extends Component {
             });
             data[line].amount_currency_format = formatMonetary(
                 data[line].currency_amount,
-                undefined,
                 {
                     currencyId: data[line].line_currency_id,
                 }


### PR DESCRIPTION
When available, the "_Amount in currency_" column displayed in the reconciliation widget only displays the amount, without the currency symbol.

Seems like the call made to `formatMonetary` which should format this amount is currently incorrectly passed 3 args (probably because the method in previous Odoo versions used to be called `formatCurrency` and indeed used to have 3 arguments)

**Currently:**
![before](https://github.com/user-attachments/assets/ee680819-fb43-4024-ba4a-53a5c40b60ae)

**With this fix:**
![after](https://github.com/user-attachments/assets/6cbb1d85-f4e6-4ffa-bf77-6ab46ce200fe)
