### PR TITLE
[18.0][IMP] account_reconcile_oca: refresh screen, keep the url id

### DIFF
--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
@@ -27,6 +27,14 @@ export class ReconcileController extends KanbanController {
         onWillStart(() => {
             this.updateJournalInfo();
         });
+
+        // Get the ID from the URL
+        const id = router.current?.id || null;
+        if (id) {
+            const idInt = parseInt(id, 10);
+            this.props.resId = idInt;
+        }
+
         onMounted(() => {
             this.selectRecord();
         });


### PR DESCRIPTION
Menu: Accounting - Accounting - Reconcile

When I click on open items, they appear on the top, and I click on Reconcile. 
**Then**, when I click on open items, **nothing happens**.
When I refresh the screen, I always come to the **first** section to reconcile.

**Existing workaround**: On the left side, click on another section, then click on the section I want to work on.

**Preferred solution**: When I click on an open item, it should always appear on the top and be ready to Reconcile.

**Solution of this PR**: Refresh the screen, and keep the active section (keep the ID in the url).