### PR TITLE
[18.0][IMP] account_statement_base: Add kanban view to bank statement line action

### DIFF
--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -180,7 +180,7 @@
     <record id="account_bank_statement_line_action" model="ir.actions.act_window">
         <field name="name">Bank Statement Lines</field>
         <field name="res_model">account.bank.statement.line</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">list,form,kanban</field>
         <field name="context">{'account_bank_statement_line_main_view': True}</field>
     </record>
 </odoo>


### PR DESCRIPTION
This change adds the kanban view mode to the 'account_bank_statement_line_action' to allow users to visualize bank statement lines in a kanban format, in addition to list and form views.