### PR TITLE
[18.0][FIX] account_reconcile_oca: Show the name of the move if reconciliation model apply

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -670,6 +670,7 @@ class AccountBankStatementLine(models.Model):
                         is_counterpart=True,
                         max_amount=amount,
                         reconcile_auxiliary_id=reconcile_auxiliary_id,
+                        move=True,
                     )
                     amount -= sum(line.get("amount") for line in line_data)
                     data += line_data


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-reconcile/pull/842

Show the name of the move if reconciliation model apply

Consistent with existing: https://github.com/OCA/account-reconcile/blob/dcfebe9feb7896e569d9f2a1371566e803616ea9/account_reconcile_oca/models/account_bank_statement_line.py#L987

Example use case:
- Invoice reconciliation model without self-validation.
- Create an invoice to a customer with an amount
- Create a bank statement line with the corresponding amount
- Click on Reset reconciliation
- The name of the invoice against which it has been linked will be displayed

**Before**
![antes](https://github.com/user-attachments/assets/64f0ec4c-0a5d-450a-aae2-a06cceac4796)

**After**
![despues](https://github.com/user-attachments/assets/5aff786f-a78b-4514-ac1e-b86b91cf3a01)

Please @pedrobaeza and @etobella can you review it?

@Tecnativa TT56294 TT56157