### PR TITLE
[18.0][IMP] account_reconcile_oca: Add multi-company rule to account.account.reconcile

### DIFF
--- a/account_reconcile_oca/README.rst
+++ b/account_reconcile_oca/README.rst
@@ -57,7 +57,7 @@ Known issues / Roadmap
 
 The following bugs are already detected:
 
-- Creation of activities on the chatter do show automatically
+-  Creation of activities on the chatter do show automatically
 
 Bug Tracker
 ===========
@@ -81,7 +81,7 @@ Authors
 Contributors
 ------------
 
-- Enric Tobella
+-  Enric Tobella
 
 Maintainers
 -----------

--- a/account_reconcile_oca/__manifest__.py
+++ b/account_reconcile_oca/__manifest__.py
@@ -18,6 +18,7 @@
     "data": [
         "views/res_config_settings.xml",
         "security/ir.model.access.csv",
+        "security/security.xml",
         "views/account_account_reconcile.xml",
         "views/account_bank_statement_line.xml",
         "views/account_move_line.xml",

--- a/account_reconcile_oca/security/security.xml
+++ b/account_reconcile_oca/security/security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="rule_account_account_reconcile_multi_company" model="ir.rule">
+        <field name="name">account.account.reconcile multi-company</field>
+        <field name="model_id" ref="model_account_account_reconcile" />
+        <field name="domain_force">[('company_id','in',company_ids)]</field>
+    </record>
+</odoo>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-reconcile/pull/850

Add multi-company rule to account.account.reconcile

In a multi-company context, when working with only one company and accessing the Reconcile menu, we want to see only the data of the selected companies, not all of them.

Please @pedrobaeza and  @etobella can you review it?

@Tecnativa TT56510