### PR TITLE
[18.0][FIX] account_reconcile_oca: Define the appropriate name in the suggested counterparts of transactions (similar to v15)

### DIFF
--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -95,7 +95,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             if line.partner_id
             else False,
             "date": fields.Date.to_string(line.date),
-            "name": line.name,
+            "name": line.name or line.move_id.name,
             "debit": amount if amount > 0 else 0.0,
             "credit": -amount if amount < 0 else 0.0,
             "amount": amount,


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-reconcile/pull/856

Define the appropriate name in the suggested counterparts of transactions (similar to v15)

Example use case:
- Create a vendor invoice + validate
- Create a bank statement line
- Add as a suggested reconciliation of the statement line the vendor invoice
- The label (name) to be displayed will be the name of the journal entry
- Make the reconciliation
- The journal entry of the generated entry will have the appropriate label

![ejemplo](https://github.com/user-attachments/assets/87abb27b-1eed-4551-a6e8-341556b85cd3)

Please @pedrobaeza can you review it?

@Tecnativa TT56592