### PR TITLE
[18.0][FIX] account_reconcile_model_oca: partner matching - fix migration v18.0

### DIFF
--- a/account_reconcile_model_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_model_oca/models/account_bank_statement_line.py
@@ -88,14 +88,14 @@ class AccountBankStatementLine(models.Model):
                     aml.partner_id = partner.id
                     AND partner.name IS NOT NULL
                     AND partner.active
-                    AND (
+                    AND ((
             """)
             query_parts = SQL(") OR (").join(sub_queries)
             final_query = SQL(
                 """
                 %s
                     %s
-                )
+                ))
                 WHERE aml.company_id = %s
                 LIMIT 1
             """,


### PR DESCRIPTION
Fix lost parenthesis in migration to v18.0 causing matching any aml when one partner is matched

Use case: I have some partners having `communication` in their name. When reconciling a bank statement line from a customer payment, the bank put as narration `Communication: xyz`. This causes those partners to match. As the query `OR` is applied on the `JOIN` between `res_partner.id` and `aml.partner_id`, this join is not respected anymore causing to return the first aml partner. 

@victoralmau @pedrobaeza @mmequignon @JordiBForgeFlow 