### PR TITLE
[18.0][FIX] account_move_base_import: file_name field invisible 

### DIFF
--- a/account_move_base_import/wizard/import_statement_view.xml
+++ b/account_move_base_import/wizard/import_statement_view.xml
@@ -11,6 +11,7 @@
                         domain="[('used_for_import', '=', True)]"
                     />
                     <field name="input_statement" filename="file_name" />
+                    <field name="file_name" invisible="1" />
                 </group>
                 <group string="Import Parameters Summary" name="params">
                     <field name="partner_id" />


### PR DESCRIPTION
Bug introduced in https://github.com/OCA/account-reconcile/pull/797

account_move_base_import: ensure the filename is captured properly when a file is uploaded

It was causing the error below:

File "/odoo/external-src/account-reconcile/account_move_base_import/wizard/import_statement.py", line 53, in _check_extension (__, ftype) = os.path.splitext(self.file_name)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<frozen posixpath>", line 118, in splitext
TypeError: expected str, bytes or os.PathLike object, not bool