### PR TITLE
[16.0][IMP] account_reconcile_oca: Defining the appropriate views in the fiscalyear_lock action

### DIFF
--- a/account_reconcile_oca/models/res_company.py
+++ b/account_reconcile_oca/models/res_company.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Dixmit
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -12,3 +13,27 @@ class ResCompany(models.Model):
         ._fields["reconcile_aggregate"]
         .selection
     )
+
+    def _get_fiscalyear_lock_statement_lines_redirect_action(
+        self, unreconciled_statement_lines
+    ):
+        """Define the appropriate views that this method will have, by default the
+        account module does not add any.
+        """
+        action = super()._get_fiscalyear_lock_statement_lines_redirect_action(
+            unreconciled_statement_lines
+        )
+        if len(unreconciled_statement_lines) == 1:
+            custom_action = self.env["ir.actions.actions"]._for_xml_id(
+                "account_reconcile_oca.action_bank_statement_line_create"
+            )
+            action.update(views=custom_action["views"])
+        else:
+            custom_action = self.env["ir.actions.actions"]._for_xml_id(
+                "account_reconcile_oca.action_bank_statement_line_reconcile_all"
+            )
+            action.update(
+                view_mode=custom_action["view_mode"],
+                views=custom_action["views"],
+            )
+        return action


### PR DESCRIPTION
Defining the appropriate views in the fiscalyear_lock action

Example use case:
- Install the account_lock_date_update module.
- Go to Invoicing > Accounting > Accounting > Actions > Update lock dates
- Create a bank statement line (unreconciled) with today's date
- Define "Lock Date for All Users with today's date

**Before (1 statement line)**
![antes-1](https://github.com/user-attachments/assets/b6a4f613-eb5e-4980-8b47-37f971434d43)

**After (1 statement line)**
![despues-1](https://github.com/user-attachments/assets/155c7043-90d8-4f9e-aab4-d9eb5c7c0476)

**Before (multi statement line)**
![antes-multi](https://github.com/user-attachments/assets/1e7ba665-35cf-41d0-994c-937089540a30)

**After (multi statement line)**
![despues-multi](https://github.com/user-attachments/assets/a41549ee-7d44-4def-9407-b5036bc69433)

Please @pedrobaeza can you review it?

@Tecnativa TT56805