### PR TITLE
[18.0][IMP] account_reconcile_oca: Defining the appropriate views in the fiscalyear_lock action

### DIFF
--- a/account_reconcile_oca/models/res_company.py
+++ b/account_reconcile_oca/models/res_company.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Dixmit
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -12,3 +13,27 @@ class ResCompany(models.Model):
         ._fields["reconcile_aggregate"]
         .selection
     )
+
+    def _get_unreconciled_statement_lines_redirect_action(
+        self, unreconciled_statement_lines
+    ):
+        """Define the appropriate views that this method will have, by default the
+        account module does not add any.
+        """
+        action = super()._get_unreconciled_statement_lines_redirect_action(
+            unreconciled_statement_lines
+        )
+        if len(unreconciled_statement_lines) == 1:
+            custom_action = self.env["ir.actions.actions"]._for_xml_id(
+                "account_reconcile_oca.action_bank_statement_line_create"
+            )
+            action.update(views=custom_action["views"])
+        else:
+            custom_action = self.env["ir.actions.actions"]._for_xml_id(
+                "account_reconcile_oca.action_bank_statement_line_reconcile_all"
+            )
+            action.update(
+                view_mode=custom_action["view_mode"],
+                views=custom_action["views"],
+            )
+        return action


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-reconcile/pull/866

Defining the appropriate views in the fiscalyear_lock action

Example use case:
- Install the account_lock_date_update module.
- Go to Invoicing > Accounting > Accounting > Actions > Update lock dates
- Create a bank statement line (unreconciled) with today's date
- Define "Lock Date for All Users with today's date

**Before (multi statement line)**
![antes](https://github.com/user-attachments/assets/ab36dbe0-6e2c-4a57-ad24-176b6e3fea32)

**After (multi statement line)**
![despues](https://github.com/user-attachments/assets/a204b15b-7b01-48e2-b0d0-99418b1e684f)

Please @pedrobaeza can you review it?

@Tecnativa TT56805