### PR TITLE
[17.0][IMP] account_statement_base: Add statement_id field to statement lines tree view

### DIFF
--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -6,180 +6,179 @@
   Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 -->
 <odoo>
-
-<record id="account_bank_statement_line_form" model="ir.ui.view">
-    <field name="model">account.bank.statement.line</field>
-    <field name="arch" type="xml">
-        <form>
-            <group name="main">
-                <field name="company_id" invisible="1" />
-                <field name="currency_id" invisible="1" />
-                <field name="country_code" invisible="1" />
-                <field name="state" invisible="1" />
-                <field name="suitable_journal_ids" invisible="1" />
-                <field name="date" />
-                <field name="payment_ref" required="1" />
-                <field name="partner_id" />
-                <field name="amount" />
-                <field
+    <record id="account_bank_statement_line_form" model="ir.ui.view">
+        <field name="model">account.bank.statement.line</field>
+        <field name="arch" type="xml">
+            <form>
+                <group name="main">
+                    <field name="company_id" invisible="1" />
+                    <field name="currency_id" invisible="1" />
+                    <field name="country_code" invisible="1" />
+                    <field name="state" invisible="1" />
+                    <field name="suitable_journal_ids" invisible="1" />
+                    <field name="date" />
+                    <field name="payment_ref" required="1" />
+                    <field name="partner_id" />
+                    <field name="amount" />
+                    <field
                         name="foreign_currency_id"
                         domain="[('id', '!=', currency_id)]"
                         groups="base.group_multi_currency"
                     />
-                <field name="amount_currency" groups="base.group_multi_currency" />
-                <field name="partner_bank_id" />
-                <field
+                    <field name="amount_currency" groups="base.group_multi_currency" />
+                    <field name="partner_bank_id" />
+                    <field
                         name="journal_id"
                         invisible="context.get('default_journal_id')"
                     />
-                <field name="move_id" />
-                <field
+                    <field name="move_id" />
+                    <field
                         name="statement_id"
                         domain="[('journal_id', '=', journal_id)]"
                         invisible="not context.get('account_bank_statement_line_main_view')"
                     />
-            </group>
-            <notebook>
-                <page name="narration" string="Notes">
-                    <field name="narration" nolabel="1" colspan="2" />
-                </page>
-                <page name="technical" string="Technical Information">
-                    <group name="tech-fields">
-                        <field name="transaction_type" />
-                        <field name="partner_name" />
-                        <field name="account_number" />
-                        <field name="is_reconciled" />
-                        <field name="payment_ids" widget="many2many_tags" />
-                    </group>
-                </page>
-            </notebook>
-        </form>
-    </field>
-</record>
-
-<record id="account_bank_statement_line_tree" model="ir.ui.view">
-    <field name="model">account.bank.statement.line</field>
-    <field name="arch" type="xml">
-        <tree editable="top" multi_edit="1" decoration-muted="is_reconciled">
-            <field name="sequence" />
-            <field name="date" readonly="is_reconciled" />
-            <field name="move_id" optional="hide" required="0" />
-            <field name="payment_ref" readonly="is_reconciled" />
-            <field name="ref" optional="hide" readonly="is_reconciled" />
-            <field name="transaction_type" optional="hide" />
-            <field name="account_number" optional="hide" />
-            <field name="partner_id" readonly="is_reconciled" />
-            <field name="amount" readonly="is_reconciled" />
-            <field
+                </group>
+                <notebook>
+                    <page name="narration" string="Notes">
+                        <field name="narration" nolabel="1" colspan="2" />
+                    </page>
+                    <page name="technical" string="Technical Information">
+                        <group name="tech-fields">
+                            <field name="transaction_type" />
+                            <field name="partner_name" />
+                            <field name="account_number" />
+                            <field name="is_reconciled" />
+                            <field name="payment_ids" widget="many2many_tags" />
+                        </group>
+                    </page>
+                </notebook>
+            </form>
+        </field>
+    </record>
+    <record id="account_bank_statement_line_tree" model="ir.ui.view">
+        <field name="model">account.bank.statement.line</field>
+        <field name="arch" type="xml">
+            <tree editable="top" multi_edit="1" decoration-muted="is_reconciled">
+                <field name="sequence" />
+                <field name="date" readonly="is_reconciled" />
+                <field name="move_id" optional="hide" required="0" />
+                <field name="payment_ref" readonly="is_reconciled" />
+                <field name="ref" optional="hide" readonly="is_reconciled" />
+                <field name="transaction_type" optional="hide" />
+                <field name="account_number" optional="hide" />
+                <field name="partner_id" readonly="is_reconciled" />
+                <field name="amount" readonly="is_reconciled" />
+                <field
                     name="foreign_currency_id"
                     optional="hide"
                     groups="base.group_multi_currency"
                     readonly="is_reconciled"
                 />
-            <field
+                <field
                     name="amount_currency"
                     optional="hide"
                     groups="base.group_multi_currency"
                     readonly="is_reconciled"
                 />
-            <field name="running_balance" />
-            <field
+                <field name="running_balance" />
+                <field
                     name="narration"
                     optional="hide"
                     string="Notes"
                     readonly="is_reconciled"
                 />
-            <field name="journal_id" optional="hide" readonly="is_reconciled" />
-            <field name="partner_bank_id" optional="hide" readonly="is_reconciled" />
-            <button
+                <field name="journal_id" optional="hide" readonly="is_reconciled" />
+                <field
+                    name="partner_bank_id"
+                    optional="hide"
+                    readonly="is_reconciled"
+                />
+                <button
                     name="action_undo_reconciliation"
                     type="object"
                     string="Revert reconciliation"
                     icon="fa-undo"
                     invisible="not is_reconciled"
                 />
-            <button
+                <button
                     name="action_open_journal_entry"
                     type="object"
                     title="Open Journal Entry"
                     icon="fa-folder-open-o"
                 />
-            <field name="company_id" column_invisible="True" />
-            <field name="is_reconciled" column_invisible="True" />
-            <field name="currency_id" column_invisible="True" />
-            <field name="foreign_currency_id" column_invisible="True" />
-            <field name="country_code" column_invisible="True" />
-            <field name="state" column_invisible="True" />
-            <field name="suitable_journal_ids" column_invisible="True" />
+                <field name="company_id" column_invisible="True" />
+                <field name="is_reconciled" column_invisible="True" />
+                <field name="currency_id" column_invisible="True" />
+                <field name="foreign_currency_id" column_invisible="True" />
+                <field name="country_code" column_invisible="True" />
+                <field name="state" column_invisible="True" />
+                <field name="suitable_journal_ids" column_invisible="True" />
 
-        </tree>
-    </field>
-</record>
-
-<record id="account_bank_statement_line_search" model="ir.ui.view">
-    <field name="model">account.bank.statement.line</field>
-    <field name="arch" type="xml">
-        <search>
-            <field
+            </tree>
+        </field>
+    </record>
+    <record id="account_bank_statement_line_search" model="ir.ui.view">
+        <field name="model">account.bank.statement.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <field
                     name="payment_ref"
                     filter_domain="['|', '|', ('payment_ref', 'ilike', self), ('ref', 'ilike', self), ('narration', 'ilike', self)]"
                     string="Label, Ref or Notes"
                 />
-            <field name="partner_id" />
-            <field name="date" />
-            <field name="statement_id" />
-            <field name="journal_id" domain="[('type', 'in', ('bank', 'cash'))]" />
-            <field name="amount" />
-            <separator />
-            <filter
+                <field name="partner_id" />
+                <field name="date" />
+                <field name="statement_id" />
+                <field name="journal_id" domain="[('type', 'in', ('bank', 'cash'))]" />
+                <field name="amount" />
+                <separator />
+                <filter
                     name="reconciled"
                     string="Reconciled"
                     domain="[('is_reconciled', '=', True)]"
                 />
-            <filter
+                <filter
                     name="not_reconciled"
                     string="Not Reconciled"
                     domain="[('is_reconciled', '=', False)]"
                 />
-            <separator />
-            <filter
+                <separator />
+                <filter
                     name="to_check"
                     string="To check"
                     domain="[('to_check', '=', True)]"
                 />
-            <separator />
-            <filter name="date" string="Date" date="date" />
-            <group name="groupby">
-                <filter
+                <separator />
+                <filter name="date" string="Date" date="date" />
+                <group name="groupby">
+                    <filter
                         name="partner_groupby"
                         string="Partner"
                         context="{'group_by': 'partner_id'}"
                     />
-                <filter
+                    <filter
                         name="journal_groupby"
                         string="Journal"
                         context="{'group_by': 'journal_id'}"
                     />
-                <filter
+                    <filter
                         name="transaction_type_groupby"
                         string="Transaction Type"
                         context="{'group_by': 'transaction_type'}"
                     />
-                <filter
+                    <filter
                         name="date_groupby"
                         string="Date"
                         context="{'group_by': 'date'}"
                     />
-            </group>
-        </search>
-    </field>
-</record>
-
-<record id="account_bank_statement_line_action" model="ir.actions.act_window">
-    <field name="name">Bank Statement Lines</field>
-    <field name="res_model">account.bank.statement.line</field>
-    <field name="view_mode">tree,form</field>
-    <field name="context">{'account_bank_statement_line_main_view': True}</field>
-</record>
-
+                </group>
+            </search>
+        </field>
+    </record>
+    <record id="account_bank_statement_line_action" model="ir.actions.act_window">
+        <field name="name">Bank Statement Lines</field>
+        <field name="res_model">account.bank.statement.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'account_bank_statement_line_main_view': True}</field>
+    </record>
 </odoo>

--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -61,6 +61,11 @@
             <tree editable="top" multi_edit="1" decoration-muted="is_reconciled">
                 <field name="sequence" />
                 <field name="date" readonly="is_reconciled" />
+                <field
+                    name="statement_id"
+                    optional="hide"
+                    domain="[('journal_id', '=', journal_id)]"
+                />
                 <field name="move_id" optional="hide" required="0" />
                 <field name="payment_ref" readonly="is_reconciled" />
                 <field name="ref" optional="hide" readonly="is_reconciled" />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-reconcile/pull/871

Add `statement_id` field to statement lines tree view

![ejemplo](https://github.com/user-attachments/assets/5d07a323-85d3-4dc0-9b1c-73aba11eb6f5)

Please @pedrobaeza can you review it?

@Tecnativa TT56879