### PR TITLE
[FIX] `account_move_base_import`: replace `analytic_account_id` with `analytic_distribution` for move line values

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -76,7 +76,8 @@ class AccountJournal(models.Model):
     commission_analytic_account_id = fields.Many2one(
         comodel_name="account.analytic.account",
         string="Commission Analytic Account",
-        help="Choose an analytic account to be used on the commission line.",
+        help="Choose an analytic account to be used on the commission "
+        "line analytic distribution.",
     )
     autovalidate_completed_move = fields.Boolean(
         string="Validate fully completed moves",
@@ -206,7 +207,11 @@ class AccountJournal(models.Model):
                     comm_values["currency_id"] = currency.id
                 if self.commission_analytic_account_id:
                     comm_values.update(
-                        {"analytic_account_id": self.commission_analytic_account_id.id}
+                        {
+                            "analytic_distribution": {
+                                self.commission_analytic_account_id.id: 100
+                            }
+                        }
                     )
                 vals_list.append(comm_values)
         return vals_list

--- a/account_move_base_import/tests/test_base_import.py
+++ b/account_move_base_import/tests/test_base_import.py
@@ -19,8 +19,17 @@ class TestCodaImport(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.analytic_account_obj = cls.env["account.analytic.account"]
+        cls.analytic_plan_obj = cls.env["account.analytic.plan"]
         cls.account_move_obj = cls.env["account.move"]
         cls.account_move_line_obj = cls.env["account.move.line"]
+        cls.plan_a = cls.analytic_plan_obj.create({"name": "Plan A"})
+        cls.analytic_account_a = cls.analytic_account_obj.create(
+            {
+                "name": "analytic_account_a",
+                "plan_id": cls.plan_a.id,
+            }
+        )
         cls.journal = cls.company_data["default_journal_bank"]
         cls.partner = cls.env.ref("base.res_partner_12")
         cls.account_id = cls.journal.default_account_id.id
@@ -31,6 +40,7 @@ class TestCodaImport(AccountTestInvoicingCommon):
                 "import_type": "generic_csvxls_so",
                 "partner_id": cls.partner.id,
                 "commission_account_id": cls.account_id,
+                "commission_analytic_account_id": cls.analytic_account_a.id,
                 "receivable_account_id": cls.account_id,
                 "create_counterpart": True,
             }
@@ -76,3 +86,10 @@ class TestCodaImport(AccountTestInvoicingCommon):
         self.assertEqual(move_line.date_maturity, fields.Date.from_string("2011-03-07"))
         self.assertEqual(move_line.credit, 118.4)
         self.assertEqual(move_line.name, "label a")
+        commission_line = move.line_ids.filtered(
+            lambda line: line.name == "Commission line"
+        )
+        self.assertEqual(
+            commission_line.analytic_distribution,
+            {str(self.analytic_account_a.id): 100},
+        )


### PR DESCRIPTION
There is no field `analytic_account_id` on the `account.move.line` model, so of course it can't be used for the values to create