### PR TITLE
[18.0][IMP] account_statement_base: Add statement_id field to statement lines tree view

### DIFF
--- a/account_statement_base/views/account_bank_statement_line.xml
+++ b/account_statement_base/views/account_bank_statement_line.xml
@@ -62,6 +62,11 @@
             <list editable="top" multi_edit="1" decoration-muted="is_reconciled">
                 <field name="sequence" />
                 <field name="date" readonly="is_reconciled" />
+                <field
+                    name="statement_id"
+                    optional="hide"
+                    domain="[('journal_id', '=', journal_id)]"
+                />
                 <field name="move_id" optional="hide" required="0" />
                 <field name="payment_ref" readonly="is_reconciled" />
                 <field name="ref" optional="hide" readonly="is_reconciled" />


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-reconcile/pull/873

Add `statement_id` field to statement lines tree view

![ejemplo](https://github.com/user-attachments/assets/5d07a323-85d3-4dc0-9b1c-73aba11eb6f5)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56879