### PR TITLE
[16.0][FIX] account_reconcile_oca: Correct filtering in the manual_model_id field by the appropriate allowed journals

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -89,7 +89,12 @@ class AccountBankStatementLine(models.Model):
         store=False,
         default=False,
         prefetch=False,
-        domain="[('rule_type', '=', 'writeoff_button'), ('company_id', '=', company_id)]",
+        domain="""
+        [('rule_type', '=', 'writeoff_button'),
+        ('company_id', '=', company_id),
+        '|',
+        ('match_journal_ids', '=', False), ('match_journal_ids', '=', journal_id)]
+        """,
     )
     manual_name = fields.Char(store=False, default=False, prefetch=False)
     manual_amount = fields.Monetary(


### PR DESCRIPTION
Backport from 17.0: https://github.com/OCA/account-reconcile/pull/870

Correct filtering in the `manual_model_id` field by the appropriate allowed journals

**Before**
![antes](https://github.com/user-attachments/assets/3bb32469-49e0-43fd-95d7-81650559605e)

**After**
![despues](https://github.com/user-attachments/assets/2d43f911-1b53-4fc1-bab8-fc43ac30a1f9)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56841