### PR TITLE
[16.0][IMP] account_reconcile_oca: Improve usability when using Reconcile Mode = 'Keep suspense accounts' 

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -139,6 +139,30 @@ class AccountBankStatementLine(models.Model):
     reconcile_aggregate = fields.Char(compute="_compute_reconcile_aggregate")
     aggregate_id = fields.Integer(compute="_compute_reconcile_aggregate")
     aggregate_name = fields.Char(compute="_compute_reconcile_aggregate")
+    reconciled_move_id = fields.Many2one(
+        "account.move",
+        string="Reconciled Move",
+        readonly=True,
+        compute="_compute_reconciled_move_id",
+    )
+    reconciled_line_ids = fields.Many2many(
+        "account.move.line",
+        string="Reconciled Move Lines",
+        readonly=True,
+        compute="_compute_reconciled_move_id",
+    )
+
+    def _compute_reconciled_move_id(self):
+        for line in self:
+            line.reconciled_move_id = (
+                self.line_ids._all_reconciled_lines()
+                .filtered(
+                    lambda line: line.move_id != self.move_id
+                    and (line.matched_debit_ids or line.matched_credit_ids)
+                )
+                .mapped("move_id")
+            )
+            line.reconciled_line_ids = line.reconciled_move_id.line_ids
 
     @api.model
     def _reconcile_aggregate_map(self):
@@ -572,6 +596,16 @@ class AccountBankStatementLine(models.Model):
         action.update(
             {"res_id": self.move_id.id, "views": [[False, "form"]], "view_mode": "form"}
         )
+        return action
+
+    def action_show_moves(self):
+        """Open the action to show the moves related to the bank statement line."""
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account.action_move_journal_line"
+        )
+        moves = self.move_id + self.reconciled_move_id
+        action.update({"domain": [("id", "in", moves.ids)], "view_mode": "tree,form"})
         return action
 
     def _inverse_reconcile_data_info(self):

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -196,6 +196,15 @@
                             accesskey="m"
                             string="View move"
                             class="btn btn-info"
+                            attrs="{'invisible': [('reconciled_line_ids', '!=', [])]}"
+                        />
+                        <button
+                            name="action_show_moves"
+                            type="object"
+                            accesskey="m"
+                            string="View moves"
+                            class="btn btn-info"
+                            attrs="{'invisible': [('reconciled_line_ids', '=', [])]}"
                         />
                     </div>
                 </div>
@@ -214,12 +223,42 @@
                 <field name="company_currency_id" invisible="1" />
                 <field name="previous_manual_amount_in_currency" invisible="1" />
                 <field name="currency_id" invisible="1" />
+                <field name="reconcile_mode" invisible="1" />
                 <field
                     name="reconcile_data_info"
                     nolabel="1"
                     widget="account_reconcile_oca_data"
                     class="w-100"
                 />
+                <field
+                    name="reconciled_line_ids"
+                    nolabel="1"
+                    attrs="{'invisible': ['|', ('reconcile_mode', '!=', 'keep'), ('reconciled_line_ids', '=', [])]}"
+                >
+                    <tree>
+                        <field name="company_currency_id" invisible="1" />
+                        <field name="currency_id" invisible="1" />
+                        <field name="account_id" />
+                        <field name="partner_id" />
+                        <field name="date" />
+                        <field name="name" />
+                        <field
+                            name="amount_currency"
+                            widget="monetary"
+                            options="{'currency_field': 'currency_id'}"
+                        />
+                        <field
+                            name="debit"
+                            widget="monetary"
+                            options="{'currency_field': 'company_currency_id'}"
+                        />
+                        <field
+                            name="credit"
+                            widget="monetary"
+                            options="{'currency_field': 'company_currency_id'}"
+                        />
+                    </tree>
+                </field>
                 <div>
                     <field
                         name="manual_model_id"


### PR DESCRIPTION
When using Reconcile Mode = 'Keep suspense accounts' do show the reconciled move lines in the reconciliation screen, and show a button 'View moves' instead of 'View move'.

This change makes it much easier for the user to review what accounts did the user choose to reconcile the statement line with.

<img width="1367" height="523" alt="image" src="https://github.com/user-attachments/assets/e2fbac97-d550-40a4-a67b-7c30d65f786a" />


@etobella @JordiMForgeFlow 