### PR TITLE
[16.][FIX] account_reconcile_oca: Dates of new move when using Reconcile Mode = 'Keep suspense accounts'

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Dixmit
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from collections import defaultdict
+from datetime import timedelta
 
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
@@ -822,6 +822,7 @@ class AccountBankStatementLine(models.Model):
     def _reconcile_bank_line_keep_move_vals(self):
         return {
             "journal_id": self.journal_id.id,
+            "date": self._get_reconciled_move_date(),
         }
 
     def _reconcile_bank_line_keep(self, data):
@@ -883,7 +884,7 @@ class AccountBankStatementLine(models.Model):
                         | line
                     )
             move.invalidate_recordset()
-        move._post()
+        move._post(soft=False)
         for _account, lines in to_reconcile.items():
             lines.reconcile()
 
@@ -917,6 +918,23 @@ class AccountBankStatementLine(models.Model):
                 for move in to_reverse
             ]
             to_reverse._reverse_moves(default_values_list, cancel=True)
+
+    def _get_reconciled_move_date(self):
+        """Get the date of the move to reconcile, considering the lock
+        dates defined in the company (user defined and tax dates).
+        so that the date proposed is the lock date +1 day if there's a lock date,
+        and the move date otherwise."""
+        locks = []
+        user_lock_date = self.move_id.company_id._get_user_fiscal_lock_date()
+        if user_lock_date:
+            locks.append(user_lock_date)
+        if self.move_id._affect_tax_report() and self.move_id.company_id.tax_lock_date:
+            locks.append(self.tax_lock_date)
+        lock_date = max(locks)
+        if lock_date and self.move_id.date <= lock_date:
+            return lock_date + timedelta(days=1)
+        else:
+            return self.move_id.date
 
     def _reconcile_move_line_vals(self, line, move_id=False):
         vals = {

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -603,14 +603,76 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.bank_journal_euro.suspense_account_id,
             bank_stmt_line.mapped("move_id.line_ids.account_id"),
         )
-        # Reset reconciliation
         reconcile_move = (
             bank_stmt_line.line_ids._all_reconciled_lines()
             .filtered(lambda line: line.move_id != bank_stmt_line.move_id)
             .move_id
         )
+        self.assertEqual(reconcile_move.date, bank_stmt_line.date)
+        # Reset reconciliation
         bank_stmt_line.unreconcile_bank_line()
         self.assertTrue(reconcile_move.reversal_move_id)
+        self.assertEqual(reconcile_move.reversal_move_id, bank_stmt_line.date)
+        self.assertFalse(bank_stmt_line.is_reconciled)
+
+    def test_reconcile_invoice_keep_with_lock_date(self):
+        """
+        We want to test how the keep mode works, keeping the original move lines,
+        and now considering that we have set a lock date.
+        """
+        self.bank_journal_euro.reconcile_mode = "keep"
+        self.bank_journal_euro.suspense_account_id.reconcile = True
+        inv1 = self.create_invoice(
+            currency_id=self.currency_euro_id, invoice_amount=100
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        # Set a lock date in the company
+        self.bank_journal_euro.company_id.period_lock_date = time.strftime("%Y-07-16")
+        receivable1 = inv1.line_ids.filtered(
+            lambda l: l.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.add_account_move_line_id = receivable1
+            self.assertFalse(f.add_account_move_line_id)
+        self.assertTrue(bank_stmt_line.can_reconcile)
+        number_of_lines = len(bank_stmt_line.reconcile_data_info["data"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(
+            number_of_lines, len(bank_stmt_line.reconcile_data_info["data"])
+        )
+        self.assertIn(
+            self.bank_journal_euro.suspense_account_id,
+            bank_stmt_line.mapped("move_id.line_ids.account_id"),
+        )
+        reconcile_move = (
+            bank_stmt_line.line_ids._all_reconciled_lines()
+            .filtered(lambda line: line.move_id != bank_stmt_line.move_id)
+            .move_id
+        )
+        self.assertEqual(reconcile_move.date, time.strftime("%Y-07-17"))
+        # Reset reconciliation
+        bank_stmt_line.unreconcile_bank_line()
+        self.assertTrue(reconcile_move.reversal_move_id)
+        self.assertEqual(reconcile_move.reversal_move_id, time.strftime("%Y-07-17"))
         self.assertFalse(bank_stmt_line.is_reconciled)
 
     def test_reconcile_model_with_foreign_currency(self):


### PR DESCRIPTION
When using Reconcile Mode = 'Keep suspense accounts' the new move created after the reconciliation should by respect the lock dates, if set.

cc @etobella @JordiMForgeFlow 