### PR TITLE
[16.0][FIX] account_reconcile_oca: Correct open action for Journal Items

### DIFF
--- a/account_reconcile_oca/models/account_journal.py
+++ b/account_reconcile_oca/models/account_journal.py
@@ -33,10 +33,13 @@ class AccountJournal(models.Model):
         return _("Well done! Everything has been reconciled")
 
     def open_action(self):
-        self.ensure_one()
-        if self.type not in ["bank", "cash"]:
-            return super().open_action()
-        action = self.env["ir.actions.actions"]._for_xml_id(
-            "account_reconcile_oca.action_bank_statement_line_reconcile_all"
-        )
+        """
+        Return OCA *Reconcile All* when core *Bank Statements* tree is requested;
+        leave other actions unchanged.
+        """
+        action = super().open_action()
+        if action.get("xml_id") == "account.action_bank_statement_tree":
+            action = self.env["ir.actions.actions"]._for_xml_id(
+                "account_reconcile_oca.action_bank_statement_line_reconcile_all"
+            )
         return action


### PR DESCRIPTION
When clicking "Journal Items" on a Bank journal in dashboard, the system incorrectly launched the OCA reconciliation view  instead of displaying the regular Journal Items. See:

https://github.com/user-attachments/assets/693a170e-00e6-44a3-83b9-e77443863380

This patch removes/adjusts the override that hijacked the action and re-establishes the expected account move line tree 


Note: Clicking the journal name continues to open the OCA Reconcile All view, per PR #763. This PR only restores the proper Journal Items (account.move.line) action and ensures no regressions in the remaining action views.


cc @chienandalu @pedrobaeza 