### PR TITLE
[16.0][IMP] account_reconcile_oca: Fix the amount in currency once we reconcile. Add tests

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -752,7 +752,7 @@ class AccountBankStatementLine(models.Model):
                     data += lines
             else:
                 reconcile_auxiliary_id, lines = self._get_reconcile_line(
-                    line, "other", from_unreconcile=False
+                    line, "other", from_unreconcile=False, is_reconciled=True
                 )
                 data += lines
 
@@ -1162,6 +1162,7 @@ class AccountBankStatementLine(models.Model):
         from_unreconcile=False,
         reconcile_auxiliary_id=False,
         move=False,
+        is_reconciled=False,
     ):
         new_vals = super()._get_reconcile_line(
             line,
@@ -1170,6 +1171,7 @@ class AccountBankStatementLine(models.Model):
             max_amount=max_amount,
             from_unreconcile=from_unreconcile,
             move=move,
+            is_reconciled=is_reconciled,
         )
         rates = []
         for vals in new_vals:

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -44,6 +44,7 @@ class AccountReconcileAbstract(models.AbstractModel):
         max_amount=False,
         from_unreconcile=False,
         move=False,
+        is_reconciled=False,
     ):
         date = self.date if "date" in self._fields else line.date
         original_amount = amount = net_amount = line.debit - line.credit
@@ -82,6 +83,8 @@ class AccountReconcileAbstract(models.AbstractModel):
                         self.company_id,
                         date,
                     )
+        elif is_reconciled:
+            currency_amount = line.amount_residual_currency or -line.amount_residual
         else:
             currency_amount = self.amount_currency or self.amount
             line_currency = self._get_reconcile_currency()

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -147,6 +147,66 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         self.assertEqual(receivable_line.amount_currency, -100)
         self.assertEqual(receivable_line.balance, -50)
 
+    def test_two_manual_lines_with_currency(self):
+        """We want to test the reconcile widget for bank statements
+        on manual lines with foreign currency.
+        We enforce the currency rate to be sure that the amounts are correct
+        """
+        self.env["res.currency.rate"].create(
+            {
+                "currency_id": self.env.ref("base.USD").id,
+                "name": time.strftime("%Y-07-15"),
+                "rate": 2,
+            }
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "amount_currency": 100,
+                "foreign_currency_id": self.currency_usd_id,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable_acc = self.company_data["default_account_receivable"]
+        expense_acc = self.company_data["default_account_expense"]
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_reference = "reconcile_auxiliary;1"
+            f.manual_account_id = receivable_acc
+            f.manual_amount_in_currency = -40
+            self.assertFalse(f.can_reconcile)
+            f.manual_reference = "reconcile_auxiliary;2"
+            f.manual_account_id = expense_acc
+            self.assertTrue(f.can_reconcile)
+        bank_stmt_line.reconcile_bank_line()
+        receivable_line = bank_stmt_line.line_ids.filtered(
+            lambda line: line.account_id == receivable_acc
+        )
+        self.assertEqual(receivable_line.currency_id.id, self.currency_usd_id)
+        self.assertEqual(receivable_line.amount_currency, -40)
+        self.assertEqual(receivable_line.balance, -20)
+        matched_line = False
+        for line in bank_stmt_line.reconcile_data_info["data"]:
+            if line["id"] == receivable_line.id:
+                matched_line = True
+                self.assertEqual(line["currency_amount"], -40)
+                self.assertEqual(line["amount"], -20)
+                break
+        self.assertEqual(matched_line, True)
+
     def test_reconcile_invoice_reconcile_full(self):
         """
         We want to test the reconcile widget for bank statements on invoices.


### PR DESCRIPTION
We found that before this change, the widget was showing the full currency amount.

Without the changes we have:

<img width="968" height="729" alt="image" src="https://github.com/user-attachments/assets/912676fc-9808-4847-b9d6-fb00f5e11330" />

Now we have the right amount

[Grabación de pantalla desde 2025-07-23 06-23-44.webm](https://github.com/user-attachments/assets/c67ec8e6-25da-4ffe-9ebd-fc5f9538aebe)

@HaraldPanten @ValentinVinagre Thanks for finding this :wink: 