### PR TITLE
[18.0][FIX] account_reconcile_oca: Dates of new move when using Reconcile Mode = 'Keep suspense accounts'

### DIFF
--- a/account_reconcile_oca/models/__init__.py
+++ b/account_reconcile_oca/models/__init__.py
@@ -3,6 +3,7 @@ from . import account_journal
 from . import account_bank_statement_line
 from . import account_bank_statement
 from . import account_account_reconcile
+from . import account_move
 from . import account_move_line
 from . import res_company
 from . import res_config_settings

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Dixmit
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from collections import defaultdict
 
 from dateutil import rrule
@@ -850,6 +849,7 @@ class AccountBankStatementLine(models.Model):
     def _reconcile_bank_line_keep_move_vals(self):
         return {
             "journal_id": self.journal_id.id,
+            "date": self.date,
         }
 
     def _reconcile_bank_line_keep(self, data):
@@ -911,7 +911,8 @@ class AccountBankStatementLine(models.Model):
                         | line
                     )
             move.invalidate_recordset()
-        move._post()
+        move.date = move._get_first_non_locked_date()
+        move._post(soft=False)
         for _account, lines in to_reconcile.items():
             lines.reconcile()
 

--- a/account_reconcile_oca/models/account_move.py
+++ b/account_reconcile_oca/models/account_move.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Dixmit
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import timedelta
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_first_non_locked_date(self):
+        """Get the date of the move to reconcile, considering the lock
+        dates defined in the company (user defined and tax dates).
+        so that the date proposed is the lock date +1 day if there's a lock date,
+        and the move date otherwise."""
+        locks = []
+        user_lock_date = self.company_id._get_user_fiscal_lock_date(self.journal_id)
+        if user_lock_date:
+            locks.append(user_lock_date)
+        if self._affect_tax_report() and self.company_id.tax_lock_date:
+            locks.append(self.company_id.tax_lock_date)
+        lock_date = max(locks)
+        if lock_date and self.date <= lock_date:
+            return lock_date + timedelta(days=1)
+        else:
+            return self.date

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -675,14 +675,71 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.bank_journal_euro.suspense_account_id,
             bank_stmt_line.mapped("move_id.line_ids.account_id"),
         )
-        # Reset reconciliation
         reconcile_move = (
             bank_stmt_line.line_ids._all_reconciled_lines()
             .filtered(lambda line: line.move_id != bank_stmt_line.move_id)
             .move_id
         )
+        self.assertEqual(reconcile_move.date, bank_stmt_line.date)
+        # Reset reconciliation
         bank_stmt_line.unreconcile_bank_line()
         self.assertTrue(reconcile_move.reversal_move_ids)
+        reversal_move_id = reconcile_move.reversal_move_ids[0]
+        self.assertEqual(reversal_move_id.date, bank_stmt_line.date)
+        self.assertFalse(bank_stmt_line.is_reconciled)
+
+    def test_reconcile_invoice_keep_with_lock_date(self):
+        """
+        We want to test how the keep mode works, keeping the original move lines,
+        and now considering that we have set a lock date.
+        """
+        self.rule.line_ids.write(
+            {"tax_ids": [Command.link(self.tax_10.id)], "force_tax_included": True}
+        )
+        self.bank_journal_euro.reconcile_mode = "keep"
+        self.bank_journal_euro.suspense_account_id.reconcile = True
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        # Set a period lock date in the company
+        self.env.user.groups_id -= self.env.ref("account.group_account_manager")
+        self.bank_journal_euro.company_id.tax_lock_date = time.strftime("%Y-07-16")
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_model_id = self.rule
+        bank_stmt_line.reconcile_bank_line()
+        self.assertIn(
+            self.bank_journal_euro.suspense_account_id,
+            bank_stmt_line.mapped("move_id.line_ids.account_id"),
+        )
+        reconcile_move = (
+            bank_stmt_line.line_ids._all_reconciled_lines()
+            .filtered(lambda line: line.move_id != bank_stmt_line.move_id)
+            .move_id
+        )
+        self.assertEqual(str(reconcile_move.date), time.strftime("%Y-07-17"))
+        # Reset reconciliation
+        bank_stmt_line.unreconcile_bank_line()
+        self.assertTrue(reconcile_move.reversal_move_ids)
+        self.assertEqual(
+            str(reconcile_move.reversal_move_ids[0].date), time.strftime("%Y-07-17")
+        )
         self.assertFalse(bank_stmt_line.is_reconciled)
 
     def test_reconcile_model_with_foreign_currency(self):


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-reconcile/pull/887