### PR TITLE
[18.0][FIX] [FIX] account_reconcile_oca: When doing manual reconciliations, allowto set the amount to reconcile in the invoice currency.

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -11,6 +11,7 @@ from odoo import Command, _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.fields import first
 from odoo.tools import LazyTranslate, float_compare, float_is_zero, groupby
+from odoo.tools.misc import formatLang
 
 _lt = LazyTranslate(__name__, default_lang="en_US")
 
@@ -105,11 +106,22 @@ class AccountBankStatementLine(models.Model):
     manual_amount = fields.Monetary(
         store=False, default=False, prefetch=False, currency_field="manual_currency_id"
     )
+    previous_manual_amount = fields.Monetary(
+        store=False, default=False, prefetch=False, currency_field="manual_currency_id"
+    )
     manual_currency_id = fields.Many2one(
         "res.currency", readonly=True, store=False, prefetch=False
     )
-    manual_original_amount = fields.Monetary(
-        default=False, store=False, prefetch=False, readonly=True
+    manual_original_amount_in_currency = fields.Monetary(
+        default=False,
+        store=False,
+        prefetch=False,
+        readonly=True,
+        currency_field="manual_in_currency_id",
+    )
+    manual_amount_message = fields.Char(compute="_compute_manual_amount_message")
+    show_full_reconcile_button = fields.Boolean(
+        compute="_compute_manual_amount_message"
     )
     manual_move_type = fields.Selection(
         lambda r: r.env["account.move"]._fields["move_type"].selection,
@@ -125,6 +137,52 @@ class AccountBankStatementLine(models.Model):
     reconcile_aggregate = fields.Char(compute="_compute_reconcile_aggregate")
     aggregate_id = fields.Integer(compute="_compute_reconcile_aggregate")
     aggregate_name = fields.Char(compute="_compute_reconcile_aggregate")
+
+    @api.depends(
+        "manual_original_amount_in_currency",
+        "manual_currency_id",
+        "manual_in_currency_id",
+        "manual_amount_in_currency",
+        "manual_move_id",
+    )
+    def _compute_manual_amount_message(self):
+        for rec in self:
+            rec.show_full_reconcile_button = True
+            rec.manual_amount_message = ""
+            if not rec.manual_currency_id:
+                continue
+            # Both amounts are expressed in the counterpart line currency, so
+            # they must be rounded and rendered with that currency, not with
+            # the company one (manual_currency_id).
+            currency = rec.manual_in_currency_id or rec.manual_currency_id
+            resulting_amt = (
+                rec.manual_original_amount_in_currency - rec.manual_amount_in_currency
+            )
+            open_amount = formatLang(
+                self.env,
+                abs(rec.manual_original_amount_in_currency),
+                currency_obj=currency,
+            )
+            # One whole clause per message: a translator needs to be able to
+            # reorder the amounts, which is impossible when the sentence is
+            # split between the view and a fragment built here.
+            if currency.is_zero(resulting_amt):
+                msg = _("with an open amount of %(open)s will be fully paid.") % {
+                    "open": open_amount,
+                }
+                rec.show_full_reconcile_button = False
+            else:
+                msg = _(
+                    "with an open amount of %(open)s will be reduced by %(amount)s"
+                ) % {
+                    "open": open_amount,
+                    "amount": formatLang(
+                        self.env,
+                        abs(rec.manual_amount_in_currency),
+                        currency_obj=currency,
+                    ),
+                }
+            rec.manual_amount_message = msg
 
     @api.model
     def _reconcile_aggregate_map(self):
@@ -383,7 +441,7 @@ class AccountBankStatementLine(models.Model):
             "manual_move_id": False,
             "manual_move_type": False,
             "manual_kind": False,
-            "manual_original_amount": False,
+            "manual_original_amount_in_currency": False,
             "manual_currency_id": False,
             "analytic_distribution": False,
         }
@@ -391,6 +449,7 @@ class AccountBankStatementLine(models.Model):
     def _process_manual_reconcile_from_line(self, line):
         self.manual_account_id = line["account_id"][0]
         self.manual_amount = line["amount"]
+        self.previous_manual_amount = line["amount"]
         self.manual_currency_id = line["currency_id"]
         self.manual_in_currency_id = line.get("line_currency_id")
         self.manual_in_currency = line.get("line_currency_id") and line[
@@ -408,7 +467,9 @@ class AccountBankStatementLine(models.Model):
             self.manual_move_id = self.manual_line_id.move_id
             self.manual_move_type = self.manual_line_id.move_id.move_type
         self.manual_kind = line["kind"]
-        self.manual_original_amount = line.get("original_amount", 0.0)
+        self.manual_original_amount_in_currency = line.get(
+            "original_amount_currency", 0.0
+        )
 
     @api.onchange("manual_reference", "manual_delete")
     def _onchange_manual_reconcile_reference(self):
@@ -457,21 +518,60 @@ class AccountBankStatementLine(models.Model):
             "credit": -self.manual_amount if self.manual_amount < 0 else 0.0,
             "debit": self.manual_amount if self.manual_amount > 0 else 0.0,
             "analytic_distribution": self.analytic_distribution,
+            # `_sync_manual_amounts` keeps this consistent with `manual_amount`,
+            # so converting here would round-trip the amount and silently change
+            # whichever of the two the user typed.
             "currency_amount": self.manual_amount_in_currency,
         }
-        liquidity_lines, _suspense_lines, _other_lines = self._seek_for_lines()
-        if self.manual_line_id and self.manual_line_id.id not in liquidity_lines.ids:
-            vals.update(
-                {
-                    "currency_amount": self.manual_currency_id._convert(
-                        self.manual_amount,
-                        self.manual_in_currency_id,
-                        self.company_id,
-                        self.manual_line_id.date,
-                    ),
-                }
-            )
         return vals
+
+    def _sync_manual_amounts(self):
+        """Keep the company-currency and counterpart-currency amounts consistent.
+
+        Whichever of the two the user edited is authoritative and the other one is
+        derived from it. The `previous_*` snapshots tell which one that was, so no
+        extra flag is needed and an explicit 0.00 is treated like any other amount.
+        """
+        if not self.manual_in_currency_id:
+            return
+        company_currency = self.company_id.currency_id
+        in_currency_date = self.date
+        if (
+            self.manual_line_id.exists()
+            and self.manual_line_id
+            and self.manual_kind != "liquidity"
+        ):
+            in_currency_date = self.manual_line_id.date
+        if (
+            float_compare(
+                self.manual_amount_in_currency,
+                self.previous_manual_amount_in_currency,
+                precision_rounding=self.manual_in_currency_id.rounding,
+            )
+            != 0
+        ):
+            self.manual_amount = self.manual_in_currency_id._convert(
+                self.manual_amount_in_currency,
+                company_currency,
+                self.company_id,
+                in_currency_date,
+            )
+        elif (
+            float_compare(
+                self.manual_amount,
+                self.previous_manual_amount,
+                precision_rounding=company_currency.rounding,
+            )
+            != 0
+        ):
+            self.manual_amount_in_currency = company_currency._convert(
+                self.manual_amount,
+                self.manual_in_currency_id,
+                self.company_id,
+                in_currency_date,
+            )
+        self.previous_manual_amount_in_currency = self.manual_amount_in_currency
+        self.previous_manual_amount = self.manual_amount
 
     @api.onchange(
         "manual_account_id",
@@ -485,29 +585,7 @@ class AccountBankStatementLine(models.Model):
         self.ensure_one()
         data = self.reconcile_data_info.get("data", [])
         new_data = []
-        if (
-            self.manual_in_currency_id
-            and float_compare(
-                self.manual_amount_in_currency,
-                self.previous_manual_amount_in_currency,
-                precision_rounding=self.manual_in_currency_id.rounding,
-            )
-            != 0
-        ):
-            in_currency_date = self.date
-            if (
-                self.manual_line_id.exists()
-                and self.manual_line_id
-                and self.manual_kind != "liquidity"
-            ):
-                in_currency_date = self.manual_line_id.date
-            self.manual_amount = self.manual_in_currency_id._convert(
-                self.manual_amount_in_currency,
-                self.manual_currency_id,
-                self.company_id,
-                in_currency_date,
-            )
-        self.previous_manual_amount_in_currency = self.manual_amount_in_currency
+        self._sync_manual_amounts()
         for line in data:
             if line["reference"] == self.manual_reference:
                 if self._check_line_changed(line):

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -50,8 +50,11 @@ class AccountReconcileAbstract(models.AbstractModel):
         date = self.date if "date" in self._fields else line.date
         original_amount = amount = net_amount = line.debit - line.credit
         line_currency = line.currency_id
+        original_amount_currency = line.amount_currency
         if is_counterpart:
-            currency_amount = -line.amount_residual_currency or line.amount_residual
+            currency_amount = original_amount_currency = (
+                -line.amount_residual_currency or line.amount_residual
+            )
             amount = -line.amount_residual
             currency = line.currency_id or line.company_id.currency_id
             original_amount = net_amount = -line.amount_residual
@@ -88,6 +91,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             currency_amount = line.amount_currency
         else:
             currency_amount = self.amount_currency or self.amount
+            original_amount_currency = self.amount_currency
             line_currency = self._get_reconcile_currency()
         vals = {
             "move_id": move and line.move_id.id,
@@ -109,6 +113,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             "currency_amount": currency_amount,
             "analytic_distribution": line.analytic_distribution,
             "kind": kind,
+            "original_amount_currency": original_amount_currency,
         }
         if from_unreconcile:
             vals.update(

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -270,6 +270,175 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             f.manual_reference = f"account.move.line;{receivable1.id}"
             self.assertEqual(-100, f.manual_amount)
 
+    def test_reconcile_invoice_reconcile_with_currency(self):
+        """
+        We want to test the reconcile widget for bank statements on invoices
+        with a different currency. We want to indicate manually in the bank
+        statement line the amount that we want to reconcile, expressed in
+        the invoice currency.
+        """
+        new_rate = 1.6299
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-07-01"),
+                "rate": new_rate,
+                "currency_id": self.currency_usd_id,
+                "company_id": self.bank_journal_euro.company_id.id,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable1 = inv1.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.add_account_move_line_id = receivable1
+            self.assertFalse(f.add_account_move_line_id)
+            self.assertTrue(f.can_reconcile)
+            f.manual_reference = f"account.move.line;{receivable1.id}"
+            f.manual_amount_in_currency = -100
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(inv1.amount_residual_signed, 0)
+        self.assertEqual(inv1.payment_state, "paid")
+
+    def test_reconcile_amounts_kept_in_sync_both_ways(self):
+        """Editing either amount derives the other one, and only that one.
+
+        The company-currency amount and the counterpart-currency amount must stay
+        consistent whichever of the two the user types, and a value typed in the
+        counterpart currency must not be re-derived (and thus rounded away) by a
+        later onchange on an unrelated field.
+        """
+        new_rate = 1.6299
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-07-01"),
+                "rate": new_rate,
+                "currency_id": self.currency_usd_id,
+                "company_id": self.bank_journal_euro.company_id.id,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable1 = inv1.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        usd = self.env["res.currency"].browse(self.currency_usd_id)
+        company_currency = self.bank_journal_euro.company_id.currency_id
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = receivable1
+            f.manual_reference = f"account.move.line;{receivable1.id}"
+
+            # Typing the counterpart-currency amount derives the company one.
+            f.manual_amount_in_currency = -50
+            self.assertEqual(-50, f.manual_amount_in_currency)
+            self.assertEqual(
+                usd._convert(
+                    -50, company_currency, bank_stmt_line.company_id, receivable1.date
+                ),
+                f.manual_amount,
+            )
+
+            # An onchange on an unrelated field must not re-derive it.
+            f.manual_name = "Partial payment"
+            self.assertEqual(-50, f.manual_amount_in_currency)
+
+            # Typing the company-currency amount derives the counterpart one.
+            f.manual_amount = -20
+            self.assertEqual(-20, f.manual_amount)
+            self.assertEqual(
+                company_currency._convert(
+                    -20, usd, bank_stmt_line.company_id, receivable1.date
+                ),
+                f.manual_amount_in_currency,
+            )
+
+    def test_reconcile_invoice_reconcile_full_with_currency(self):
+        """
+        We want to test the reconcile widget for bank statements on invoices
+        with a different currency. We want to press the button on the statement
+        line to force the full reconciliation.
+        """
+        new_rate = 1.6299
+        self.env["res.currency.rate"].create(
+            {
+                "name": time.strftime("%Y-07-01"),
+                "rate": new_rate,
+                "currency_id": self.currency_usd_id,
+                "company_id": self.bank_journal_euro.company_id.id,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 50,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        receivable1 = inv1.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.add_account_move_line_id = receivable1
+            self.assertFalse(f.add_account_move_line_id)
+            self.assertTrue(f.can_reconcile)
+            f.manual_reference = f"account.move.line;{receivable1.id}"
+        bank_stmt_line.button_manual_reference_full_paid()
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(inv1.amount_residual_signed, 0)
+        self.assertEqual(inv1.payment_state, "paid")
+
     @mute_logger("odoo.models.unlink")
     def test_reconcile_invoice_unreconcile(self):
         """

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -220,6 +220,7 @@
                 <field name="foreign_currency_id" invisible="1" />
                 <field name="company_currency_id" invisible="1" />
                 <field name="previous_manual_amount_in_currency" invisible="1" />
+                <field name="previous_manual_amount" invisible="1" />
                 <field name="currency_id" invisible="1" />
                 <field
                     name="reconcile_data_info"
@@ -295,34 +296,40 @@
                                     modifiers="{'readonly': ['|', '|', ('manual_exchange_counterpart', '=', True), ('manual_reference', '=', False), ('is_reconciled', '=', True)]}"
                                 />
                                 <field name="manual_currency_id" invisible="1" />
-                                <field name="manual_original_amount" invisible="1" />
+                                <field
+                                    name="manual_original_amount_in_currency"
+                                    invisible="1"
+                                />
                                 <field name="manual_move_type" invisible="1" />
+                                <field
+                                    name="show_full_reconcile_button"
+                                    invisible="1"
+                                />
                                 <label
                                     for="manual_move_id"
                                     string=""
-                                    insible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount == 0"
+                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount_in_currency == 0"
                                 />
+
                                 <div
-                                    insible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount == 0"
+                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount_in_currency == 0"
                                 >
                                     Invoice <field
                                     class="oe_inline"
                                     name="manual_move_id"
                                 />
-                                    with an open amount <field
+                                    <field
                                     class="oe_inline"
-                                    name="manual_original_amount"
-                                /> will be reduced by <field
-                                    class="oe_inline"
-                                    name="manual_amount"
-                                    readonly="1"
-                                />.
-                                    <br />
-                                You might want to set the invoice as <button
+                                    name="manual_amount_message"
+                                />
+                                    <div invisible="not show_full_reconcile_button">
+                                        <br />
+                                        You might want to set the invoice as <button
                                     name="button_manual_reference_full_paid"
                                     type="object"
                                     method_args="[1]"
                                 >fully paid</button>.
+                                    </div>
                                 </div>
                             </group>
                         </group>

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -220,6 +220,7 @@
                 <field name="foreign_currency_id" invisible="1" />
                 <field name="company_currency_id" invisible="1" />
                 <field name="previous_manual_amount_in_currency" invisible="1" />
+                <field name="previous_manual_amount" invisible="1" />
                 <field name="currency_id" invisible="1" />
                 <field
                     name="reconcile_data_info"
@@ -295,34 +296,40 @@
                                     modifiers="{'readonly': ['|', '|', ('manual_exchange_counterpart', '=', True), ('manual_reference', '=', False), ('is_reconciled', '=', True)]}"
                                 />
                                 <field name="manual_currency_id" invisible="1" />
-                                <field name="manual_original_amount" invisible="1" />
+                                <field
+                                    name="manual_original_amount_in_currency"
+                                    invisible="1"
+                                />
                                 <field name="manual_move_type" invisible="1" />
+                                <field
+                                    name="show_full_reconcile_button"
+                                    invisible="1"
+                                />
                                 <label
                                     for="manual_move_id"
                                     string=""
-                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount == 0"
+                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount_in_currency == 0"
                                 />
+
                                 <div
-                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount == 0"
+                                    invisible="manual_move_type not in ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'] or manual_original_amount_in_currency == 0"
                                 >
                                     Invoice <field
                                     class="oe_inline"
                                     name="manual_move_id"
                                 />
-                                    with an open amount <field
+                                    <field
                                     class="oe_inline"
-                                    name="manual_original_amount"
-                                /> will be reduced by <field
-                                    class="oe_inline"
-                                    name="manual_amount"
-                                    readonly="1"
-                                />.
-                                    <br />
-                                You might want to set the invoice as <button
+                                    name="manual_amount_message"
+                                />
+                                    <div invisible="not show_full_reconcile_button">
+                                        <br />
+                                        You might want to set the invoice as <button
                                     name="button_manual_reference_full_paid"
                                     type="object"
                                     method_args="[1]"
                                 >fully paid</button>.
+                                    </div>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
## What this fixes

When a bank statement line in the company currency is reconciled against an invoice
issued in another currency, the reconciliation widget lets you edit two amounts: the
one in company currency and the one in the counterpart's currency ("Amount in
Currency"). Only the first of them actually drove the result: whatever you typed in
the counterpart currency was thrown away and recomputed by converting the company
amount back at the exchange rate. Since a conversion and its inverse do not round
trip, the amount applied to the invoice was never quite the amount you asked for, and
for a partial payment it was simply the wrong figure.

That matters because in a foreign-currency payment the number you actually know is the
one in the invoice currency — it is what the customer's remittance advice says and what
their ledger will show. The company-currency amount is a consequence of it, not the
other way round.

## The case, with numbers

The company books in USD, the rate is 1 USD = 0.80 EUR, and a customer is invoiced
240.00 € (300.00 $). The customer pays 80.00 € of it; their bank converts at its own
rate and credits 105.00 $, keeping 5.00 $ as a charge.

Selecting the invoice in the widget proposes 84.00 € — the whole $105.00  converted —
which would leave the invoice owing 156.00 €. That figure appears nowhere: not on the
remittance advice, not in the customer's books. With this PR you type the 80.00 € that
was really paid, Odoo derives the 100.00 $ that corresponds to it, the remaining 5.00 $
is posted to bank charges like any other write-off, and the invoice is left owing
exactly 160.00 €.

## What you see

"Amount in Currency" is now authoritative when you edit it, and the company amount
follows; edit the company amount instead and the counterpart amount follows. Whichever
one you typed is the one that is kept.

The invoice information under the amounts also became useful. For an invoice or refund
counterpart it now states the effect of the reconciliation in the invoice currency —
"Invoice INV/2026/00001 with an open amount of 240.00 € will be reduced by 80.00 €",
or "… will be fully paid." when nothing would be left — and offers a button to settle
the invoice in full. Previously that block was rendered with an inverted condition and
a misspelled attribute, so in practice it never appeared, and the amount inside it was
formatted with the company currency although it is expressed in the invoice's.

## Implementation notes for reviewers

The two amounts are kept consistent in a single place, `_sync_manual_amounts`. Which of
them the user edited is determined by comparing each against its `previous_*` snapshot
with `float_compare` and the currency's own rounding — the idiom the module already used
for this — so there is no state flag, no pair of onchanges writing each other's field,
and correctness does not depend on onchange ordering. An amount of 0.00 is treated like
any other value. `_get_manual_reconcile_vals` no longer re-converts anything; it reports
the synchronised values, which also removes a `_seek_for_lines()` call from the onchange
path.

The message is built as one complete translatable clause with named placeholders, rather
than a sentence split between static text in the view and a fragment assembled in
Python, so it can be translated and reordered.

## Tests

Three tests cover the behaviour: reconciling a partial amount typed in the counterpart
currency, settling an invoice in full through the "fully paid" button, and a test
asserting that editing either amount derives the other while an onchange on an
unrelated field does not silently re-derive what was typed. 

Find attached a video with an actual demo:
https://github.com/user-attachments/assets/f2694620-5ae5-43ea-8e0f-b10879221dd7




