### PR TITLE
[17.0][IMP] account_reconcile_oca: Display the correct name (display_name) of the move in the reconciliation

### DIFF
--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -90,7 +90,7 @@ class AccountReconcileAbstract(models.AbstractModel):
             line_currency = self._get_reconcile_currency()
         vals = {
             "move_id": move and line.move_id.id,
-            "move": move and line.move_id.name,
+            "move": move and line.move_id.display_name,
             "reference": "account.move.line;%s" % line.id,
             "id": line.id,
             "account_id": [line.account_id.id, line.account_id.display_name],


### PR DESCRIPTION
Display the correct name (`display_name`) of the move in the reconciliation

<img width="517" height="320" alt="invoice" src="https://github.com/user-attachments/assets/63e47c87-5666-4584-bbff-2db6171a6ac0" />

**Before**
<img width="695" height="267" alt="antes" src="https://github.com/user-attachments/assets/3f65c279-88fa-4056-ad74-0bb9f8415d6e" />

**After**
<img width="718" height="256" alt="despues" src="https://github.com/user-attachments/assets/655ba24d-5809-452a-ad66-3b4c2eab7955" />

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT57785