### PR TITLE
[16.0][IMP] account_reconcile_oca: default filters on Reconcile tab

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -238,7 +238,7 @@
                             name="add_account_move_line_id"
                             widget="account_reconcile_oca_match"
                             domain="[('parent_state', '=', 'posted'),('amount_residual', '!=', 0),('account_id.reconcile', '=', True), ('company_id', '=', company_id), ('statement_line_id', '!=', id)]"
-                            context="{'search_default_partner_id': partner_id, 'tree_view_ref': 'account_reconcile_oca.account_move_line_tree_reconcile_view', 'search_view_ref': 'account_reconcile_oca.account_move_line_search_reconcile_view'}"
+                            context="{'search_default_partner_id': partner_id, 'search_default_trade_payable': partner_id, 'search_default_trade_receivable': partner_id, 'search_default_payment_asset_current': partner_id, 'tree_view_ref': 'account_reconcile_oca.account_move_line_tree_reconcile_view', 'search_view_ref': 'account_reconcile_oca.account_move_line_search_reconcile_view'}"
                         />
                     </page>
                     <page name="manual" string="Manual operation">

--- a/account_reconcile_oca/views/account_move_line.xml
+++ b/account_reconcile_oca/views/account_move_line.xml
@@ -99,6 +99,11 @@
                     help="From Trade Receivable accounts"
                     name="trade_receivable"
                 />
+                    <filter
+                    string="Outstanding Payments/Receipts"
+                    name="payment_asset_current"
+                    domain="[('payment_id', '!=', False), ('account_id.account_type', '=', 'asset_current')]"
+                />
                 </search>
         </field>
     </record>


### PR DESCRIPTION
New behavior in the bank statement reconcile interface: when the bank statement line has a partner, the "Reconcile" tab has 2 filters:
- filter "partner_id"
- filter "Payable or Receivable" (added)

That way, you do not see the VAT lines by default in the "Reconcile" tab when the bank statement line has a partner, but only the receivable/payable accounts.

When there is no partner on the bank statement line, the behavior is unchanged (there are no filters in the "Reconcile" tab)

BEFORE:
<img width="1439" height="841" alt="account_reconcile_oca-before" src="https://github.com/user-attachments/assets/90bddccd-9e34-414c-9cfc-aeb8a7d76c9c" />


AFTER:
<img width="1439" height="687" alt="account_reconcile_oca-after" src="https://github.com/user-attachments/assets/4cc74f03-e122-4353-87c4-22e8eb73532a" />
