### PR TITLE
[18.0][FIX] account_reconcile_oca: Don't apply max_amount on intermediate counterparts

### DIFF
--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -170,11 +170,12 @@ class AccountAccountReconcile(models.Model):
         counterparts = data["counterparts"]
         amount = 0.0
         for line_id in counterparts:
+            max_amount = amount if line_id == counterparts[-1] else 0
             lines = self._get_reconcile_line(
                 self.env["account.move.line"].browse(line_id),
                 "other",
                 is_counterpart=True,
-                max_amount=amount,
+                max_amount=max_amount,
                 move=True,
             )
             new_data["data"] += lines


### PR DESCRIPTION
Forward-port of #703 and #705

Steps to reproduce:

- Have 3 or more items to reconcile. Example: 200, -350, 150.
- One of the intermediate items should be higher than the current running balance.
- Select all the items, and click on Action > Reconcile.

Current behavior:

The second item appears with its amount strike-throughed (and putting the current runnning balance as the amount to reconcile).

Expected behavior:

Only strike-through the amount if the last balance is not matching the amount.

The solution to this is to only put a maximum amount when checking the reconciliability of the last line of the counterparts.

@Tecnativa TT50888