### PR TITLE
[18.0][FIX] account_reconcile_*_oca: Allow to use regex filtering

### DIFF
--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -116,7 +116,7 @@ class AccountReconcileModel(models.Model):
         base_line_dict["tax_tag_ids"] = [(6, 0, res["base_tags"])]
         return new_aml_dicts
 
-    def _get_write_off_move_lines_dict(self, residual_balance, partner_id):
+    def _get_write_off_move_lines_dict(self, residual_balance, partner_id, label=None):
         """Get move.lines dict corresponding to the reconciliation model's write-off
         lines.
         :param residual_balance: The residual balance of the account on the manual
@@ -142,6 +142,15 @@ class AccountReconcileModel(models.Model):
                 balance = currency.round(
                     line.amount * (1 if residual_balance > 0.0 else -1)
                 )
+            elif line.amount_type == "regex":
+                m = re.findall(line.amount_string, label or "")
+                if m:
+                    extracted_amount = float(m[0])
+                    balance = currency.round(
+                        extracted_amount * (1 if residual_balance > 0.0 else -1)
+                    )
+                else:
+                    balance = 0.0
             else:
                 balance = 0.0
 

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -589,7 +589,7 @@ class AccountBankStatementLine(models.Model):
             reconcile_model._get_partner_from_mapping(self) or self._retrieve_partner()
         )
         for line in reconcile_model._get_write_off_move_lines_dict(
-            -liquidity_amount, partner.id
+            -liquidity_amount, partner.id, label=self.payment_ref
         ):
             new_line = line.copy()
             new_line["partner_id"] = (


### PR DESCRIPTION
I found that the standard odoo configuration was not working when searching by regex.

For example, demo data includes a mapping for Bank fees that should create but just one was created, with the new one, it works as expected and it gets the data from the label

<img width="1326" height="307" alt="image" src="https://github.com/user-attachments/assets/093268d9-3d5e-4502-8904-c83fdde8114d" />
