### PR TITLE
[18.0] [FIX] account_reconcile_oca: wrong inheritance

### DIFF
--- a/account_reconcile_oca/static/src/scss/reconcile.scss
+++ b/account_reconcile_oca/static/src/scss/reconcile.scss
@@ -30,7 +30,7 @@
         > div {
             border-right: thick solid rgba(0, 0, 0, 0);
         }
-        &.o_kanban_record_reconcile_oca_selected > div {
+        &.o_kanban_record_reconcile_oca_selected {
             border-right: thick solid $o-brand-primary;
         }
     }

--- a/account_reconcile_oca/static/src/xml/reconcile.xml
+++ b/account_reconcile_oca/static/src/xml/reconcile.xml
@@ -61,7 +61,7 @@
         t-inherit-mode="primary"
     >
         <!-- we pass to the component the selected record -->
-        <xpath expr="//Layout/t[2]" position="attributes">
+        <xpath expr="//Layout/t[7]" position="attributes">
             <attribute name="selectedRecordId">state.selectedRecordId</attribute>
         </xpath>
         <xpath expr="//Layout" position="attributes">


### PR DESCRIPTION
With this change, we restore the functionality to see which record is selected.

Before:
<img width="596" height="769" alt="image" src="https://github.com/user-attachments/assets/092f9db4-29e4-426a-899a-9f44a921850d" />

After:
<img width="596" height="769" alt="image" src="https://github.com/user-attachments/assets/b5edd4ba-ce1a-4624-ba25-e1a0afd43e5c" />
