### PR TITLE
[18.0][IMP] account_reconcile_oca: Multiple fixes

### DIFF
--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
@@ -4,14 +4,22 @@ import {KanbanController} from "@web/views/kanban/kanban_controller";
 import {View} from "@web/views/view";
 import {formatMonetary} from "@web/views/fields/formatters";
 import {router} from "@web/core/browser/router";
+import {useSetupAction} from "@web/search/action_hook";
 
 export class ReconcileController extends KanbanController {
     async setup() {
         super.setup();
         this.state = useState({
-            selectedRecordId: null,
+            selectedRecordId: this.props.state?.selectedRecordId,
             journalBalance: 0,
             currency: false,
+        });
+        useSetupAction({
+            getLocalState: () => {
+                return {
+                    selectedRecordId: this.state.selectedRecordId,
+                };
+            },
         });
         useSubEnv({
             parentController: this,
@@ -97,6 +105,8 @@ export class ReconcileController extends KanbanController {
         var resId = false;
         if (record === undefined && this.props.resId) {
             resId = this.props.resId;
+        } else if (record === undefined && this.state.selectedRecordId) {
+            resId = this.state.selectedRecordId;
         } else if (record === undefined) {
             var records = this.model.root.records.filter(
                 (modelRecord) =>

--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
@@ -124,7 +124,7 @@ export class ReconcileController extends KanbanController {
             resId = record.resId;
         }
         if (this.state.selectedRecordId && this.state.selectedRecordId !== resId) {
-            if (this.form_controller && this.form_controller.model.root.isDirty) {
+            if (this.form_controller && this.form_controller?.model?.root?.isDirty) {
                 await this.form_controller.model.root.save({
                     noReload: true,
                     stayInEdition: true,


### PR DESCRIPTION
We have detected that when the user goes to another record, like view move, when they return, they are not in the same reconciliation, making it harder to handle.

With this change, this is solved