### PR TITLE
[18.0][FIX] account_reconcile_oca: prevent duplicate aggregates in reconcile kanban renderer

### DIFF
--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_renderer.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_renderer.esm.js
@@ -17,21 +17,21 @@ export class ReconcileRenderer extends KanbanRenderer {
         }
         const {list} = this.props;
         const aggregates = [];
+        const seen = new Set();
         for (const record of list.records) {
-            const aggregateId = record.data.aggregate_id && record.data.aggregate_id;
-            if (
-                aggregateId &&
-                (!aggregates.length || aggregates[0].id !== aggregateId)
-            ) {
-                aggregates.push({
-                    id: aggregateId,
-                    name: record.data.aggregate_name,
-                    balance: record.data.statement_balance_end_real,
-                    balanceStr: formatMonetary(record.data.statement_balance_end_real, {
-                        currencyId: record.data.currency_id[0],
-                    }),
-                });
+            const aggregateId = record.data.aggregate_id;
+            if (!aggregateId || seen.has(aggregateId)) {
+                continue;
             }
+            seen.add(aggregateId);
+            aggregates.push({
+                id: aggregateId,
+                name: record.data.aggregate_name,
+                balance: record.data.statement_balance_end_real,
+                balanceStr: formatMonetary(record.data.statement_balance_end_real, {
+                    currencyId: record.data.currency_id[0],
+                }),
+            });
         }
         return aggregates;
     }


### PR DESCRIPTION
Ensure aggregates are computed only once per aggregate_id by tracking processed IDs with a Set. This avoids repeating the same aggregate when records are not ordered or grouped by aggregate_id.

Previously, only the first aggregate was checked, causing duplicate entries when different aggregate_ids appeared later in the list.

@etobella 