### PR TITLE
[17.0] account_reconcile_oca: hide deprecated accounts in Manual Operation field

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -41,6 +41,7 @@ class AccountBankStatementLine(models.Model):
         store=False,
         default=False,
         prefetch=False,
+        domain=[("deprecated", "=", False)],
     )
     manual_partner_id = fields.Many2one(
         "res.partner",


### PR DESCRIPTION
By default, accounts marked with `deprecated` are shown in the `manual_account_id` dropdown:
<img width="2083" height="1040" alt="before" src="https://github.com/user-attachments/assets/278a8a89-1948-48a6-8a6f-06ba9c35b094" />

this fix just adds a domain on the field, excluding those accounts so they are not selected by mistake:
<img width="2230" height="1104" alt="after" src="https://github.com/user-attachments/assets/a1dab7a5-4332-472e-b2f1-84f80ae2a51b" />
