### PR TITLE
[18.0] account_reconcile_oca: hide deprecated accounts in Manual Operation field

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -43,6 +43,7 @@ class AccountBankStatementLine(models.Model):
         store=False,
         default=False,
         prefetch=False,
+        domain=[("deprecated", "=", False)],
     )
     manual_partner_id = fields.Many2one(
         "res.partner",


### PR DESCRIPTION
fw-ported from the 17.0 PR #950 