### PR TITLE
[18.0][IMP] account_reconcile_oca: onchange manual_partner_id

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -508,6 +508,7 @@ class AccountBankStatementLine(models.Model):
                 in_currency_date,
             )
         self.previous_manual_amount_in_currency = self.manual_amount_in_currency
+        edited_is_liquidity = False
         for line in data:
             if line["reference"] == self.manual_reference:
                 if self._check_line_changed(line):
@@ -516,7 +517,8 @@ class AccountBankStatementLine(models.Model):
                         line["kind"] if line["kind"] != "suspense" else "other"
                     )
                     line.update(line_vals)
-                    if line["kind"] == "liquidity":
+                    edited_is_liquidity = line.get("kind") == "liquidity"
+                    if edited_is_liquidity:
                         self._update_move_partner()
             if self.manual_line_id and self.manual_line_id.id == line.get(
                 "original_exchange_line_id"
@@ -543,6 +545,30 @@ class AccountBankStatementLine(models.Model):
             self.manual_reference,
         )
         self.can_reconcile = self.reconcile_data_info.get("can_reconcile", False)
+
+        # Ensure the UI shows consistent partner across all displayed lines:
+        # only when editing liquidity line
+        if not edited_is_liquidity:
+            return
+        partner_value = (
+            [self.manual_partner_id.id, self.manual_partner_id.display_name]
+            if self.manual_partner_id
+            else False
+        )
+        info = dict(self.reconcile_data_info or {})
+        reconcile_lines = list(info.get("data") or [])
+        if not reconcile_lines:
+            self.reconcile_data_info = info
+            return
+        updated_lines = []
+        for line in reconcile_lines:
+            new_line = dict(line)
+            # Update only the "other" displayed line(s)
+            if new_line.get("kind") != "liquidity":
+                new_line["partner_id"] = partner_value
+            updated_lines.append(new_line)
+        info["data"] = updated_lines
+        self.reconcile_data_info = info
 
     def _update_move_partner(self):
         if self.partner_id == self.manual_partner_id:

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1473,3 +1473,63 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertEqual(3, len(f.reconcile_data_info["data"]))
             self.assertTrue(f.can_reconcile)
             self.assertEqual(f.reconcile_data_info["data"][-1]["amount"], 3.63)
+
+    def test_manual_partner_on_liquidity_propagates_to_other_line(self):
+        # GIVEN
+        partner = self.env["res.partner"].create({"name": "Widget Partner Propagate"})
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            widget_lines = f.reconcile_data_info["data"]
+            liquidity_line = None
+            for line_data in widget_lines:
+                if line_data.get("kind") == "liquidity" and line_data.get("id"):
+                    liquidity_line = line_data
+                    break
+            self.assertTrue(liquidity_line)
+            non_liquidity_line = None
+            for line_data in widget_lines:
+                if line_data.get("kind") != "liquidity":
+                    non_liquidity_line = line_data
+                    break
+            self.assertTrue(non_liquidity_line)
+            partner_display_format = [partner.id, partner.display_name]
+            initial_partner = non_liquidity_line.get("partner_id")
+            self.assertNotEqual(
+                initial_partner,
+                partner_display_format,
+            )
+            # WHEN
+            f.manual_reference = f"account.move.line;{liquidity_line['id']}"
+            f.manual_partner_id = partner
+            # THEN
+            updated_widget_lines = f.reconcile_data_info["data"]
+            updated_non_liquidity_line = None
+            for line_data in updated_widget_lines:
+                if line_data.get("kind") != "liquidity":
+                    updated_non_liquidity_line = line_data
+                    break
+            self.assertTrue(
+                updated_non_liquidity_line,
+            )
+            self.assertEqual(
+                updated_non_liquidity_line.get("partner_id"),
+                partner_display_format,
+            )


### PR DESCRIPTION
Manual partner change on liquidity line updates other lines and ensures the consistent partner across all displayed reconcile lines (like in enterprise).
Updating partner on other lines does not propagate.


