### PR TITLE
[18.0][FIX] account_move_base_import: Use dedicated partner to fix test failure

### DIFF
--- a/account_move_base_import/tests/test_invoice.py
+++ b/account_move_base_import/tests/test_invoice.py
@@ -26,6 +26,13 @@ class TestInvoice(AccountTestInvoicingCommon):
         )
         cls.partner_agrolait_id = cls.partner_agrolait.id
 
+        cls.partner_autocomplete = cls.env["res.partner"].create(
+            {
+                "name": "TestPartner",
+                "is_company": True,
+            }
+        )
+
     def _create_invoice(
         self,
         move_type="out_invoice",
@@ -192,7 +199,7 @@ class TestInvoice(AccountTestInvoicingCommon):
             .with_context(check_move_validity=False)
             .create(
                 {
-                    "name": "Test autocompletion based on Partner Name Deco Addict",
+                    "name": "Test autocompletion based on Partner Name TestPartner",
                     "account_id": self.company_data["default_account_receivable"].id,
                     "move_id": move_test1.id,
                     "date_maturity": fields.Date.from_string("2013-12-17"),
@@ -259,7 +266,7 @@ class TestInvoice(AccountTestInvoicingCommon):
         # Line 4. I check that the partner name has been recognised.
         self.assertEqual(
             move_line_partner_name.partner_id.name,
-            "Deco Addict",
+            "TestPartner",
             msg="Check completion by partner name",
         )
         # Line 5. I check that the partner special label has been recognised.


### PR DESCRIPTION
This issue was also observed in: https://github.com/OCA/account-reconcile/pull/889

This PR fixes a test failure in account_move_base_import caused by a change in Odoo 18 demo data.

Issue: The test TestInvoice.test_all_completion_rules relied on the partner "Deco Addict" from the base demo data. In Odoo 18, this partner was renamed, causing the test to fail. Initially, we considered updating the name to "Acme Corporation", but relying on unstable demo data makes the test fragile to future changes.

Solution: Refactored tests/test_invoice.py to create a dedicated partner "TestPartner" in setUpClass. The test now uses this specific partner for the completion rule test, removing dependency on demo data and ensuring robustness.