### PR TITLE
[18.0][FIX] account_reconcile_model_oca: string to float

### DIFF
--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -116,6 +116,17 @@ class AccountReconcileModel(models.Model):
         base_line_dict["tax_tag_ids"] = [(6, 0, res["base_tags"])]
         return new_aml_dicts
 
+    @api.model
+    def _str2float(self, amount_string):
+        """Convert a string to float"""
+        # Remove thousands separator
+        seps = [" ", ",", "."]
+        for sep in seps:
+            amount_string = amount_string[:-3].replace(sep, "") + amount_string[-3:]
+        # Use dot as decimal separator
+        amount_string = amount_string.replace(",", ".")
+        return float(amount_string)
+
     def _get_write_off_move_lines_dict(self, residual_balance, partner_id, label=None):
         """Get move.lines dict corresponding to the reconciliation model's write-off
         lines.
@@ -145,7 +156,7 @@ class AccountReconcileModel(models.Model):
             elif line.amount_type == "regex":
                 m = re.findall(line.amount_string, label or "")
                 if m:
-                    extracted_amount = float(m[0])
+                    extracted_amount = self._str2float(m[0])
                     balance = currency.round(
                         extracted_amount * (1 if residual_balance > 0.0 else -1)
                     )

--- a/account_reconcile_model_oca/readme/CONTRIBUTORS.md
+++ b/account_reconcile_model_oca/readme/CONTRIBUTORS.md
@@ -7,3 +7,5 @@
 
 - [Tecnativa](https://www.tecnativa.com):
   - Víctor Martínez
+
+- Jacques-Etienne Baudoux (BCIM) \<<je@bcim.be>\>

--- a/account_reconcile_model_oca/tests/test_reconciliation_match.py
+++ b/account_reconcile_model_oca/tests/test_reconciliation_match.py
@@ -1671,7 +1671,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 },
             )
 
-    def test_regex_matching(self):
+    def test_regex_matching_simple(self):
         lines = self.rule_3._get_write_off_move_lines_dict(
             90.0,
             False,
@@ -1693,6 +1693,36 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.assertTrue(tax_line)
         self.assertEqual(due_line["debit"], 100.0)
         self.assertEqual(tax_line["credit"], 10.0)
+
+    def test_regex_matching_thousand_sep(self):
+        lines = self.rule_3._get_write_off_move_lines_dict(
+            90.0,
+            False,
+            label="R:9772938 10/07 AX 9415116318 T:5 BRT: 1,234.56 C/ croip",
+        )
+        for line in lines:
+            if (
+                line["account_id"]
+                == self.company_data["default_account_deferred_expense"].id
+            ):
+                due_line = line
+        self.assertTrue(due_line)
+        self.assertEqual(due_line["debit"], 1234.56)
+
+    def test_regex_matching_comma_decimal(self):
+        lines = self.rule_3._get_write_off_move_lines_dict(
+            90.0,
+            False,
+            label="R:9772938 10/07 AX 9415116318 T:5 BRT: 1234,56 C/ croip",
+        )
+        for line in lines:
+            if (
+                line["account_id"]
+                == self.company_data["default_account_deferred_expense"].id
+            ):
+                due_line = line
+        self.assertTrue(due_line)
+        self.assertEqual(due_line["debit"], 1234.56)
 
     def test_regex_not_matched(self):
         lines = self.rule_3._get_write_off_move_lines_dict(


### PR DESCRIPTION
Improve conversion of amount string to float.

Add support of a thousand separator or comma as decimal separator

Fixes:
```
account_reconcile_model_oca/models/account_reconcile_model.py", line 148, in _get_write_off_move_lines_dict
    extracted_amount = float(m[0])
                       ^^^^^^^^^^^
ValueError: could not convert string to float: '1,026.50'
```

cc @etobella @pedrobaeza