### PR TITLE
[18.0][FIX] account_reconcile_oca: Account move smartbutton missing context

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -409,7 +409,9 @@
     >
         <field name="name">Reconcile bank statement lines</field>
         <field name="res_model">account.bank.statement.line</field>
-        <field name="context">{'search_default_move_id': active_id}</field>
+        <field
+            name="context"
+        >{'search_default_move_id': active_id, 'view_ref': 'account_reconcile_oca.bank_statement_line_form_reconcile_view'}</field>
         <field name="view_mode">kanban</field>
         <field
             name="view_ids"


### PR DESCRIPTION
When opening the "Bank reconcile" on an account move, the reconciliation view is not loaded correctly.

Fixed by adding the reconcile form view in context.

<img width="1673" height="886" alt="smartbutton" src="https://github.com/user-attachments/assets/e9e42bf5-9fc3-4884-bcf1-efde04ed4fcf" />
<img width="2197" height="1166" alt="reconcile_view" src="https://github.com/user-attachments/assets/ff51184a-b460-4d2b-b59b-830d58d0395f" />
