### PR TITLE
[16.0][FIX] account_reconcile_oca: move smartbutton and missing search view

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -399,7 +399,9 @@
     >
         <field name="name">Reconcile bank statement lines</field>
         <field name="res_model">account.bank.statement.line</field>
-        <field name="context">{'search_default_move_id': active_id}</field>
+        <field
+            name="context"
+        >{'search_default_move_id': active_id, 'view_ref': 'account_reconcile_oca.bank_statement_line_form_reconcile_view'}</field>
         <field name="view_mode">tree</field>
         <field
             name="view_ids"

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -136,6 +136,20 @@
         </field>
     </record>
 
+        <record id="account_bank_statement_line_search" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.search</field>
+        <field name="model">account.bank.statement.line</field>
+        <field
+            name="inherit_id"
+            ref="account_statement_base.account_bank_statement_line_search"
+        />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="move_id" />
+            </field>
+        </field>
+    </record>
+
     <record id="bank_statement_line_form_reconcile_view" model="ir.ui.view">
         <field name="name">account.bank.statement.line.reconcile</field>
         <field name="model">account.bank.statement.line</field>


### PR DESCRIPTION
backport of #962 

Also backport the search view that is missing (new commit because backporting https://github.com/OCA/account-reconcile/commit/502cd2b22cd51d6db7e147cb7c04cbebb6fba68e seems not a good idea?)