### PR TITLE
[16.0][IMP] account_reconcile_oca: replace Narration tab with Statement Details

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -319,9 +319,43 @@
                             </group>
                         </group>
                     </page>
-                    <page name="narration" string="Narration">
-                        <field name="payment_ref" />
-                        <field name="narration" />
+                    <page name="narration" string="Statement Details">
+                        <group>
+                            <group string="Transaction">
+                                <field
+                                    name="payment_ref"
+                                    string="Label"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                                <field
+                                    name="transaction_type"
+                                    string="Type"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                                <field
+                                    name="ref"
+                                    string="Reference"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                                <field
+                                    name="narration"
+                                    string="Note"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                            </group>
+                            <group string="Source">
+                                <field
+                                    name="partner_name"
+                                    string="Partner Name (raw)"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                                <field
+                                    name="account_number"
+                                    string="Account Number"
+                                    attrs="{'readonly': [('is_reconciled', '=', True)]}"
+                                />
+                            </group>
+                        </group>
                     </page>
                     <page name="chatter" string="Chatter">
                         <field name="move_id" widget="account_reconcile_oca_chatter" />


### PR DESCRIPTION
The Narration tab in the reconciliation view shows payment_ref and narration fields without labels, and omits transaction_type, ref, partner_name, account_number and unique_import_id.

Replace with a Statement Details tab showing all statement line fields with labels matching reconciliation model terminology: Label, Type, Reference, Note in the Transaction group, and Partner Name, Account Number, Import ID in the Source group.