### PR TITLE
[18.0][IMP] account_reconcile_sale_order: payment transaction & downpayment

### DIFF
--- a/account_reconcile_sale_order/__manifest__.py
+++ b/account_reconcile_sale_order/__manifest__.py
@@ -9,10 +9,10 @@
     "category": "Accounting",
     "website": "https://github.com/OCA/account-reconcile",
     "author": "Hunki Enterprises BV, Odoo Community Association (OCA)",
-    "maintainers": ["hbrunn"],
+    "maintainers": ["hbrunn", "jbaudoux"],
     "license": "AGPL-3",
     "depends": [
-        "sale",
+        "sale_action_paid",  # OCA/sale-workflow
         "account_reconcile_oca",
     ],
     "data": [

--- a/account_reconcile_sale_order/models/account_bank_statement_line.py
+++ b/account_reconcile_sale_order/models/account_bank_statement_line.py
@@ -87,6 +87,7 @@ class AccountBankStatementLine(models.Model):
         Return dict to be added to reconcile_data_info["data"] for sale order
         """
         account = sale_order.partner_id.property_account_receivable_id
+        amount = sale_order.amount_total - sale_order.amount_invoiced
         return {
             "id": False,
             "reference": f"reconcile_auxiliary;{reconcile_auxiliary_id}",
@@ -97,12 +98,12 @@ class AccountBankStatementLine(models.Model):
             ),
             "date": fields.Date.to_string(sale_order.date_order),
             "name": sale_order.name,
-            "amount": -sale_order.amount_total,
-            "credit": sale_order.amount_total,
+            "amount": -amount,
+            "credit": amount,
             "debit": 0,
             "kind": kind,
             "currency_id": sale_order.currency_id.id,
-            "currency_amount": -sale_order.amount_total,
+            "currency_amount": -amount,
             "line_currency_id": sale_order.currency_id.id,
             "sale_order_id": sale_order.id,
         }

--- a/account_reconcile_sale_order/models/account_bank_statement_line.py
+++ b/account_reconcile_sale_order/models/account_bank_statement_line.py
@@ -1,8 +1,10 @@
 # Copyright 2024 Hunki Enterprises BV
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountBankStatementLine(models.Model):
@@ -120,10 +122,13 @@ class AccountBankStatementLine(models.Model):
         """
         Invoice selected sale orders and post the invoices
         """
-        if order.state in ("draft", "sent"):
-            order.action_confirm()
-        invoices = order._create_invoices()
-        invoices.action_post()
+        order.ensure_one()
+        invoices = order._action_paid(force_invoice=True)
+        invoices = invoices.filtered(lambda inv: inv.state == "posted")
+        if not invoices:
+            raise UserError(
+                self.env._("The reconciliation could not create a posted invoice")
+            )
         return invoices.line_ids.filtered(
             lambda x: x.account_id.account_type == "asset_receivable"
         )

--- a/account_reconcile_sale_order/readme/CONTRIBUTORS.md
+++ b/account_reconcile_sale_order/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
--   Holger Brunn \<mail@hunki-enterprises.com> (https://hunki-enterprises.com)
+- Holger Brunn \<mail@hunki-enterprises.com\> (https://hunki-enterprises.com)
+- Jacques-Etienne Baudoux (BCIM) \<je@bcim.be\>

--- a/account_reconcile_sale_order/readme/DESCRIPTION.md
+++ b/account_reconcile_sale_order/readme/DESCRIPTION.md
@@ -1,3 +1,4 @@
 This module allows a workflow where you don't invoice sale orders until you've received a payment.
 
 That's useful ie for webshops with non-instant payment like wire transfer, where you might have a lot of customers not doing the payment after all, which results in extra work for cancellation of the invoices/orders involved.
+It also applies to manual made quotations.

--- a/account_reconcile_sale_order/readme/USAGE.md
+++ b/account_reconcile_sale_order/readme/USAGE.md
@@ -1,8 +1,6 @@
 To use this module, you need to:
 
-1. Have a payment on a bank statement matching the amount of an *invoicable* sale order
+1. Have a payment on a bank statement matching the amount of one or multiple *invoicable* sale order
 2. Enter the reconciliation screen
 3. Observe that the sale order is offered as reconciliation counterpart
 4. You can manually select and deselect sale orders in the *sale orders* tab of the reconciliation widget
-
-Note the reconciliation only works if fully invoicing the sale order yields an invoice over the order's total amount. Usually this means that all products in the sale order must have invoicing policy *Ordered quantities*.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-addon-sale_action_paid @ git+https://github.com/OCA/sale-workflow.git@refs/pull/3779/head#subdirectory=sale_action_paid


### PR DESCRIPTION
Properly mark SO as paid by managing the payment transaction for webshop SO or SO for which you sent a payment link.

This will also:
* send email for payment confirmation to the customer if enabled it in the odoo standard settings
* send the invoice  if enabled it in the odoo standard settings

For manually created quotation, a transaction will also be created.

In case of downpayment on the SO, the reconciliation counterpart is for the open amount on the SO.

Depends on:
* https://github.com/OCA/sale-workflow/pull/3779

cc @hbrunn @pedrobaeza 