### PR TITLE
[16.0][FIX] account_reconcile_oca: isolate searchModel state in match widget

### DIFF
--- a/account_reconcile_oca/static/src/js/widgets/reconcile_move_line_widget.esm.js
+++ b/account_reconcile_oca/static/src/js/widgets/reconcile_move_line_widget.esm.js
@@ -2,6 +2,7 @@
 
 import {View} from "@web/views/view";
 import {registry} from "@web/core/registry";
+import {CallbackRecorder} from "@web/webclient/actions/action_hook";
 
 const {Component, useSubEnv} = owl;
 
@@ -9,9 +10,26 @@ export class AccountReconcileMatchWidget extends Component {
     setup() {
         // Necessary in order to avoid a loop
         super.setup(...arguments);
+        // Isolate this embedded View from the parent action's state
+        // recorders by giving it its own local CallbackRecorders, the
+        // same way action_service.js does for each ControllerComponent.
+        // Without this, the inner WithSearch registers its searchModel
+        // state on the parent action's __getGlobalState__ recorder. On
+        // breadcrumb back, action_service merges every recorded
+        // getGlobalState() under the same `searchModel` key (last write
+        // wins), so the inner account.move.line searchModel state
+        // overwrites the outer account.bank.statement.line one. The
+        // outer kanban then restores with a domain referencing
+        // account.move.line-only fields (e.g. `account_id.non_trade`
+        // from the Trade Receivable/Payable filters of
+        // `account_move_line_search_reconcile_view`) and crashes
+        // `web_search_read` on `account.bank.statement.line`.
         useSubEnv({
             config: {},
             parentController: this.env.parentController,
+            __beforeLeave__: new CallbackRecorder(),
+            __getGlobalState__: new CallbackRecorder(),
+            __getLocalState__: new CallbackRecorder(),
         });
     }
     get listViewProperties() {


### PR DESCRIPTION
The `account_reconcile_oca_match` widget mounts an inner `View` for account.move.line inside the bank statement line reconcile form. Without isolation, the inner `WithSearch` registers its searchModel state on the parent action's `__getGlobalState__` / `__getLocalState__` / `__beforeLeave__` CallbackRecorders. When the user backtracks via the breadcrumb, action_service merges every recorded `getGlobalState()` under the same `searchModel` key (last write wins), so the inner account.move.line state overwrites the outer
account.bank.statement.line one. The outer kanban then restores with a domain that references account.move.line-only fields (e.g. `account_id.non_trade` from the **Trade Receivable / Trade Payable** filters of `account_move_line_search_reconcile_view`) and crashes `web_search_read` on `account.bank.statement.line`:

    ValueError: Invalid field account.bank.statement.line.account_id
    in leaf ('account_id.non_trade', '=', False)

Fix: override `__beforeLeave__`, `__getGlobalState__` and `__getLocalState__` to `null` in the widget's `useSubEnv`. The inner WithSearch then skips registering its callbacks on the parent action's recorders, so the outer kanban's searchModel state is preserved on breadcrumb back.