### PR TITLE
[18.0][IMP] account_reconcile_model_oca: Get write off line balance from note via regex

### DIFF
--- a/account_reconcile_model_oca/__manifest__.py
+++ b/account_reconcile_model_oca/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2024 Dixmit
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 
 {
     "name": "Account Reconcile Model Oca",

--- a/account_reconcile_model_oca/models/__init__.py
+++ b/account_reconcile_model_oca/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_reconcile_model
+from . import account_reconcile_model_line
 from . import account_bank_statement_line

--- a/account_reconcile_model_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_model_oca/models/account_bank_statement_line.py
@@ -1,5 +1,7 @@
 # Copyright 2023 Dixmit
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# Copyright 2025 Victor M.M. Torres, Tecnativa SL
+# Copyright 2025 Jacques-Etienne Baudoux (BICM) <je@bcim.be>
+# Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 
 from odoo import models
 from odoo.tools import SQL, html2plaintext

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -1,3 +1,7 @@
+# Copyright 2024 Dixmit
+# Copyright 2025 Victor M.M. Torres, Tecnativa SL
+# Copyright 2026 Jacques-Etienne Baudoux (BICM) <je@bcim.be>
+# Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 import re
 from collections import defaultdict
 

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -138,7 +138,9 @@ class AccountReconcileModel(models.Model):
             return 0.0
         return self._str2float(m[0])
 
-    def _get_write_off_move_lines_dict(self, residual_balance, partner_id, label=None):
+    def _get_write_off_move_lines_dict(
+        self, residual_balance, partner_id, label=None, note=None
+    ):
         """Get move.lines dict corresponding to the reconciliation model's write-off
         lines.
         :param residual_balance: The residual balance of the account on the manual
@@ -166,6 +168,11 @@ class AccountReconcileModel(models.Model):
                 balance = self._get_write_off_amount_from_string(
                     line.amount_string, label
                 )
+                if not balance:
+                    balance = self._get_write_off_amount_from_string(
+                        line.amount_string, note
+                    )
+
             balance = currency.round(balance * (1 if residual_balance > 0.0 else -1))
 
             if currency.is_zero(balance):

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -839,22 +839,3 @@ class AccountReconcileModel(models.Model):
             return {"allow_write_off", "allow_auto_reconcile"}
 
         return {"rejected"}
-
-
-class AccountReconcileModelLine(models.Model):
-    _inherit = "account.reconcile.model.line"
-
-    def _get_write_off_move_line_dict(self, balance, currency):
-        self.ensure_one()
-        return {
-            "name": self.label,
-            "balance": balance,
-            "debit": balance > 0 and balance or 0,
-            "credit": balance < 0 and -balance or 0,
-            "account_id": self.account_id.id,
-            "currency_id": currency.id,
-            "analytic_distribution": self.analytic_distribution,
-            "reconcile_model_id": self.model_id.id,
-            "journal_id": self.journal_id.id,
-            "tax_ids": [],
-        }

--- a/account_reconcile_model_oca/models/account_reconcile_model.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Dixmit
 # Copyright 2025 Victor M.M. Torres, Tecnativa SL
 # Copyright 2026 Jacques-Etienne Baudoux (BICM) <je@bcim.be>
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 import re
 from collections import defaultdict
@@ -131,6 +132,12 @@ class AccountReconcileModel(models.Model):
         amount_string = amount_string.replace(",", ".")
         return float(amount_string)
 
+    def _get_write_off_amount_from_string(self, regex, text=None):
+        m = re.findall(regex, text or "")
+        if not m:
+            return 0.0
+        return self._str2float(m[0])
+
     def _get_write_off_move_lines_dict(self, residual_balance, partner_id, label=None):
         """Get move.lines dict corresponding to the reconciliation model's write-off
         lines.
@@ -150,24 +157,16 @@ class AccountReconcileModel(models.Model):
 
         lines_vals_list = []
         for line in self.line_ids:
-            balance = 0
+            balance = 0.0
             if line.amount_type == "percentage":
-                balance = currency.round(residual_balance * (line.amount / 100.0))
+                balance = abs(residual_balance) * (line.amount / 100.0)
             elif line.amount_type == "fixed":
-                balance = currency.round(
-                    line.amount * (1 if residual_balance > 0.0 else -1)
-                )
+                balance = line.amount
             elif line.amount_type == "regex":
-                m = re.findall(line.amount_string, label or "")
-                if m:
-                    extracted_amount = self._str2float(m[0])
-                    balance = currency.round(
-                        extracted_amount * (1 if residual_balance > 0.0 else -1)
-                    )
-                else:
-                    balance = 0.0
-            else:
-                balance = 0.0
+                balance = self._get_write_off_amount_from_string(
+                    line.amount_string, label
+                )
+            balance = currency.round(balance * (1 if residual_balance > 0.0 else -1))
 
             if currency.is_zero(balance):
                 continue

--- a/account_reconcile_model_oca/models/account_reconcile_model_line.py
+++ b/account_reconcile_model_oca/models/account_reconcile_model_line.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Victor M.M. Torres, Tecnativa SL
+# Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+from odoo import models
+
+
+class AccountReconcileModelLine(models.Model):
+    _inherit = "account.reconcile.model.line"
+
+    def _get_write_off_move_line_dict(self, balance, currency):
+        self.ensure_one()
+        return {
+            "name": self.label,
+            "balance": balance,
+            "debit": balance > 0 and balance or 0,
+            "credit": balance < 0 and -balance or 0,
+            "account_id": self.account_id.id,
+            "currency_id": currency.id,
+            "analytic_distribution": self.analytic_distribution,
+            "reconcile_model_id": self.model_id.id,
+            "journal_id": self.journal_id.id,
+            "tax_ids": [],
+        }

--- a/account_reconcile_model_oca/tests/test_reconciliation_match.py
+++ b/account_reconcile_model_oca/tests/test_reconciliation_match.py
@@ -1694,6 +1694,30 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.assertEqual(due_line["debit"], 100.0)
         self.assertEqual(tax_line["credit"], 10.0)
 
+    def test_regex_matching_simple_note(self):
+        lines = self.rule_3._get_write_off_move_lines_dict(
+            90.0,
+            False,
+            label="R:9772938 10/07 AX 9415116318 T:5 C/ croip",
+            note="R:9772938 10/07 AX 9415116318 T:5 BRT: 100.00 C/ croip",
+        )
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            if (
+                line["account_id"]
+                == self.company_data["default_account_deferred_expense"].id
+            ):
+                due_line = line
+            elif (
+                line["account_id"]
+                == self.company_data["default_tax_account_receivable"].id
+            ):
+                tax_line = line
+        self.assertTrue(due_line)
+        self.assertTrue(tax_line)
+        self.assertEqual(due_line["debit"], 100.0)
+        self.assertEqual(tax_line["credit"], 10.0)
+
     def test_regex_matching_thousand_sep(self):
         lines = self.rule_3._get_write_off_move_lines_dict(
             90.0,

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Dixmit
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from collections import defaultdict
@@ -590,7 +591,7 @@ class AccountBankStatementLine(models.Model):
             reconcile_model._get_partner_from_mapping(self) or self._retrieve_partner()
         )
         for line in reconcile_model._get_write_off_move_lines_dict(
-            -liquidity_amount, partner.id, label=self.payment_ref
+            -liquidity_amount, partner.id, label=self.payment_ref, note=self.narration
         ):
             new_line = line.copy()
             new_line["partner_id"] = (

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1473,3 +1473,67 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertEqual(3, len(f.reconcile_data_info["data"]))
             self.assertTrue(f.can_reconcile)
             self.assertEqual(f.reconcile_data_info["data"][-1]["amount"], 3.63)
+
+    def test_write_off_lines_from_note(self):
+        """
+        Testing the fill of the bank statment line with
+        writeoff suggestion reconcile model with auto_reconcile
+        """
+        rule = self.env["account.reconcile.model"].create(
+            {
+                "name": "Line with Bank Fees",
+                "rule_type": "writeoff_suggestion",
+                "match_label": "contains",
+                "match_label_param": "TEST BANK FEES",
+                "auto_reconcile": True,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "label": "Due amount",
+                            "account_id": self.company_data[
+                                "default_account_deferred_expense"
+                            ].id,
+                            "amount_type": "regex",
+                            "amount_string": r"BRT: ([\d,.]+)",
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "label": "Bank Fees",
+                            "account_id": self.company_data[
+                                "default_tax_account_receivable"
+                            ].id,
+                            "amount_type": "percentage",
+                            "amount_string": "100",
+                        }
+                    ),
+                ],
+            }
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "TEST BANK FEES",
+                "payment_ref": "TEST BANK FEES",
+                "narration": "R:9772938 10/07 AX 9415116318 T:5 BRT: 100.00 C/ croip",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 1000.0,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertTrue(bank_stmt_line.is_reconciled)
+        regex_line = bank_stmt_line.move_id.line_ids.filtered(
+            lambda line: line.account_id == rule.line_ids[0].account_id
+        )
+        percentage_line = bank_stmt_line.move_id.line_ids.filtered(
+            lambda line: line.account_id == rule.line_ids[1].account_id
+        )
+        self.assertEqual(regex_line.balance, -100.0)
+        self.assertEqual(percentage_line.balance, -900.0)


### PR DESCRIPTION
Previously, it was only possible to extract the amount of an automatic counterparty line from the payment reference. With this change, the regular expression will also be applied to the note.

@jbaudoux @etobella @victoralmau Could you review this?