### PR TITLE
[17.0][FIX] account_reconcile_oca: incorrect amounts when reconciling with a model and a foreign currency

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -595,14 +595,11 @@ class AccountBankStatementLine(models.Model):
                 (partner.id, partner.display_name) if partner else False
             )
             amount = line.get("balance")
-            if self.foreign_currency_id:
-                amount = self.foreign_currency_id._convert(
-                    amount,
-                    self.journal_id.currency_id or self.company_currency_id,
-                    self.company_id,
-                    self.date,
+            if self.foreign_currency_id and self.amount:
+                currency_amount = currency.round(
+                    amount * self.amount_currency / self.amount
                 )
-            if currency != self.company_id.currency_id:
+            elif currency != self.company_id.currency_id:
                 currency_amount = self.company_id.currency_id._convert(
                     amount,
                     currency,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -796,6 +796,82 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         self.assertEqual(bank_stmt_line.move_id.line_ids[0].debit, expected_amount)
         self.assertEqual(bank_stmt_line.move_id.line_ids[1].credit, expected_amount)
 
+    def test_reconcile_model_with_statement_line_foreign_currency(self):
+        """
+        Regression test for a bank statement line whose journal is in the
+        company currency but with a foreign-currency amount
+        """
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        # Implied rate of 2.0 USD/EUR is deliberately false from the
+        # active system rate (1.5289) so the test fails if the
+        # code falls back to `res.currency._convert()` at `self.date`.
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100.0,
+                "foreign_currency_id": self.currency_usd_id,
+                "amount_currency": 200.0,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_model_id = self.rule
+            self.assertTrue(f.can_reconcile)
+
+        writeoff = next(
+            line
+            for line in bank_stmt_line.reconcile_data_info["data"]
+            if line["account_id"][0] == self.current_assets_account.id
+        )
+        self.assertEqual(writeoff["amount"], -100.0)
+        self.assertEqual(writeoff["credit"], 100.0)
+        self.assertEqual(writeoff["debit"], 0.0)
+        self.assertEqual(
+            writeoff["currency_amount"],
+            -200.0,
+            "Write-off must use the statement line's implied rate "
+            "(2.0 USD/EUR), not the available rate.",
+        )
+        self.assertEqual(writeoff["line_currency_id"], self.currency_usd_id)
+
+        self.assertEqual(bank_stmt_line.amount_currency, 200.0)
+
+        bank_stmt_line.reconcile_bank_line()
+        liquidity = bank_stmt_line.move_id.line_ids.filtered(
+            lambda ml: ml.account_id == self.bank_journal_euro.default_account_id
+        )
+        counterpart = bank_stmt_line.move_id.line_ids.filtered(
+            lambda ml: ml.account_id == self.current_assets_account
+        )
+        self.assertEqual(len(liquidity), 1)
+        self.assertEqual(len(counterpart), 1)
+        self.assertEqual(liquidity.debit, 100.0)
+        self.assertEqual(liquidity.balance, 100.0)
+        self.assertEqual(counterpart.credit, 100.0)
+        self.assertEqual(counterpart.balance, -100.0)
+        self.assertEqual(counterpart.currency_id.id, self.currency_usd_id)
+        self.assertEqual(
+            counterpart.amount_currency,
+            -200.0,
+            "The counterpart must carry -200 USD, matching the statement "
+            "line's implied rate (2.0 USD/EUR).",
+        )
+        self.assertAlmostEqual(
+            sum(bank_stmt_line.move_id.line_ids.mapped("balance")), 0.0
+        )
+
     # Testing to check functionality
 
     def test_reconcile_invoice_to_check_reconciled(self):


### PR DESCRIPTION
When reconciling a bank statement line with a foreign currency amount on a journal (in company currency) using a reconciliation model, the resulting write-off line has incorrect/unexpected amounts:

## Before
Starting from this state:
<img width="1766" height="476" alt="BEFORE_1" src="https://github.com/user-attachments/assets/f14d024b-bdd3-4941-a550-e9dfb138ac8d" />

Clicking on the reconciliation model button (which is defined to map 100% of the remaining balance) gives out this:
<img width="1764" height="428" alt="BEFORE_2" src="https://github.com/user-attachments/assets/950dd87a-0a5f-4e34-976e-804a7642cc9a" />

which is not what one would expect as it does not reconcile the full balance - a double conversion lands the bank statement line balance onto the `amount_currency` field and then reconverts this for the writeoff balance.

## After
This PR changes the result obtained after clicking on the reconciliation model button to this state of things:
<img width="1764" height="396" alt="AFTER" src="https://github.com/user-attachments/assets/866c8903-736f-4c82-be17-dc37a9000513" />

We also add a test case for this scenario.