### PR TITLE
[16.0][FIX] account_reconcile_oca: Preserve bank line currency rate

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -594,6 +594,10 @@ class AccountBankStatementLine(models.Model):
         partner = (
             reconcile_model._get_partner_from_mapping(self) or self._retrieve_partner()
         )
+        # Propagate the bank line implicit rate to keep the move consistent.
+        line_rate = None
+        if self.foreign_currency_id and self.amount and self.amount_currency:
+            line_rate = self.amount_currency / self.amount
         for line in reconcile_model._get_write_off_move_lines_dict(
             -liquidity_amount, partner.id
         ):
@@ -601,17 +605,16 @@ class AccountBankStatementLine(models.Model):
             new_line["name"] = new_line.get("name") or default_name
             new_line["partner_id"] = partner and partner.name_get()[0] or False
             amount = line.get("balance")
-            if self.foreign_currency_id:
-                amount = self.foreign_currency_id.compute(
-                    amount, self.journal_id.currency_id or self.company_currency_id
-                )
             if currency != self.company_id.currency_id:
-                currency_amount = self.company_id.currency_id._convert(
-                    amount,
-                    currency,
-                    self.company_id,
-                    self.date,
-                )
+                if line_rate is not None:
+                    currency_amount = currency.round(amount * line_rate)
+                else:
+                    currency_amount = self.company_id.currency_id._convert(
+                        amount,
+                        currency,
+                        self.company_id,
+                        self.date,
+                    )
             new_line.update(
                 {
                     "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -789,6 +789,41 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         self.assertEqual(bank_stmt_line.move_id.line_ids[0].debit, expected_amount)
         self.assertEqual(bank_stmt_line.move_id.line_ids[1].credit, expected_amount)
 
+    def test_reconcile_model_writeoff_keeps_bank_line_rate(self):
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "amount_currency": 120,
+                "foreign_currency_id": self.currency_usd_id,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            self.assertFalse(f.can_reconcile)
+            f.manual_model_id = self.rule
+            self.assertTrue(f.can_reconcile)
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(2, len(bank_stmt_line.move_id.line_ids))
+        writeoff_line = bank_stmt_line.move_id.line_ids.filtered(
+            lambda r: r.account_id == self.current_assets_account
+        )
+        self.assertEqual(len(writeoff_line), 1)
+        self.assertEqual(writeoff_line.credit, 100)
+        self.assertEqual(writeoff_line.amount_currency, -120)
+
     # Testing to check functionality
 
     def test_reconcile_invoice_to_check_reconciled(self):


### PR DESCRIPTION
Termina de corregir https://github.com/OCA/account-reconcile/pull/792

En casos de que el extracto se cargue con otro tipo de conversión de monedas el proceso de conciliación no es correcto.