### PR TITLE
[18.0][FIX] account_reconcile_oca: Define the display_name of the appropriate account based on the company

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -622,6 +622,7 @@ class AccountBankStatementLine(models.Model):
                     "account_id": [
                         line["account_id"],
                         self.env["account.account"]
+                        .with_company(self.company_id)
                         .browse(line["account_id"])
                         .display_name,
                     ],

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -46,6 +46,7 @@ class AccountReconcileAbstract(models.AbstractModel):
         move=False,
         is_reconciled=False,
     ):
+        line = line.with_company(line.company_id)
         date = self.date if "date" in self._fields else line.date
         original_amount = amount = net_amount = line.debit - line.credit
         line_currency = line.currency_id


### PR DESCRIPTION
Define the `display_name` of the appropriate account based on the company

Example use case:
- Company A + Company B
- Create a bank statement line in Company A
- Select Company A + Company B; Company B is selected
- When you click "Reset reconciliation" on the bank statement line, the account name will not contain the correct code

Please @pedrobaeza can you review it?

@Tecnativa TT63117