### PR TITLE
[18.0][FIX] account_reconcile_oca: keep candidates list page/scroll when selecting a counterpart

### DIFF
--- a/account_reconcile_oca/models/account_move_line.py
+++ b/account_reconcile_oca/models/account_move_line.py
@@ -3,10 +3,44 @@
 
 from odoo import _, models
 from odoo.exceptions import ValidationError
+from odoo.tools.sql import create_index
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
+
+    def init(self):
+        """Index the candidate counterparts of the reconcile widget.
+
+        The `add_account_move_line_id` field of the reconcile view searches the
+        counterparts with the domain::
+
+            [("parent_state", "=", "posted"), ("amount_residual", "!=", 0),
+             ("account_id.reconcile", "=", True), ("company_id", "=", company_id),
+             ("statement_line_id", "!=", id)]
+
+        No index of the ``account`` module supports it: the standard
+        ``account_move_line__unreconciled_index`` is built on ``reconciled``,
+        not on ``amount_residual``. On big databases that means a full scan of
+        ``account_move_line`` on every single interaction with the widget,
+        because ``web_search_read`` also runs a ``search_count`` for the pager.
+        """
+        res = super().init()
+        create_index(
+            self.env.cr,
+            "account_move_line_reconcile_widget_idx",
+            self._table,
+            ["company_id", "account_id", "partner_id", "statement_line_id"],
+            where="parent_state = 'posted' AND amount_residual <> 0",
+        )
+        create_index(
+            self.env.cr,
+            "account_move_line_reconcile_order_idx",
+            self._table,
+            ["date DESC", "move_name DESC", "id"],
+            where="parent_state = 'posted' AND amount_residual <> 0",
+        )
+        return res
 
     def action_reconcile_manually(self):
         if not self:

--- a/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile/reconcile_controller.esm.js
@@ -130,7 +130,8 @@ export class ReconcileController extends KanbanController {
         }
         this.initialLoad = false;
         if (this.state.selectedRecordId && this.state.selectedRecordId !== resId) {
-            if (this.form_controller && this.form_controller?.model?.root?.isDirty) {
+            const formRecord = this.form_controller?.model?.root;
+            if (formRecord && (await formRecord.isDirty())) {
                 await this.form_controller.model.root.save({
                     noReload: true,
                     stayInEdition: true,

--- a/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_controller.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_controller.esm.js
@@ -2,9 +2,28 @@ import {ListController} from "@web/views/list/list_controller";
 
 export class ReconcileMoveLineController extends ListController {
     async openRecord(record) {
+        // Selecting a counterpart updates the parent record, which re-renders
+        // the whole reconcile form and reloads this list. Keep the scroll
+        // position of the right panel so the user stays where they were (the
+        // current page is preserved by ReconcileMoveLineModel).
+        const scroller = document.querySelector(".o_account_reconcile_oca_info");
+        const scrollTop = scroller ? scroller.scrollTop : null;
         var data = {};
         data[this.props.parentField] = [record.resId, record.display_name];
-        this.props.parentRecord.update(data);
+        await this.props.parentRecord.update(data);
+        if (scroller && scrollTop !== null) {
+            // The update re-renders the form asynchronously, so restore the
+            // scroll across the next couple of frames to make sure it sticks
+            // once the DOM has been patched.
+            const restore = () => {
+                scroller.scrollTop = scrollTop;
+            };
+            restore();
+            requestAnimationFrame(() => {
+                restore();
+                requestAnimationFrame(restore);
+            });
+        }
     }
     async clickAddAll() {
         await this.props.parentRecord.save();

--- a/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_model.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_model.esm.js
@@ -1,0 +1,27 @@
+import {RelationalModel} from "@web/model/relational_model/relational_model";
+
+export class ReconcileMoveLineModel extends RelationalModel {
+    /**
+     * The candidates list lives inside the reconcile form. Every time the user
+     * selects a counterpart the parent record is updated, the whole form
+     * re-renders and passes a brand new (but value-wise identical) domain to
+     * this list. RelationalModel resets the pagination offset to 0 whenever it
+     * is reloaded "from above with a domain", which sent the user back to the
+     * first page of candidates on every click.
+     *
+     * We drop the domain from the reload params when it didn't actually change,
+     * so the offset (current page) is preserved. A real search change still
+     * carries a different domain value and resets the page as expected.
+     */
+    _getNextConfig(currentConfig, params) {
+        if (
+            params.domain &&
+            currentConfig.domain &&
+            JSON.stringify(params.domain) === JSON.stringify(currentConfig.domain)
+        ) {
+            params = {...params};
+            delete params.domain;
+        }
+        return super._getNextConfig(currentConfig, params);
+    }
+}

--- a/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_model.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_model.esm.js
@@ -1,4 +1,17 @@
 import {RelationalModel} from "@web/model/relational_model/relational_model";
+import {deepEqual} from "@web/core/utils/objects";
+
+// Keys of the model config that change what is actually fetched from the
+// server. If none of them changes, a reload is a pure round trip.
+const QUERY_KEYS = [
+    "domain",
+    "context",
+    "groupBy",
+    "orderBy",
+    "offset",
+    "limit",
+    "comparison",
+];
 
 export class ReconcileMoveLineModel extends RelationalModel {
     /**
@@ -23,5 +36,31 @@ export class ReconcileMoveLineModel extends RelationalModel {
             delete params.domain;
         }
         return super._getNextConfig(currentConfig, params);
+    }
+
+    /**
+     * `useModel` reloads the list on every `onWillUpdateProps`, and this list is
+     * a child of the reconcile form: selecting another statement line re-renders
+     * the form *before* the new record is read, so the list is asked to reload
+     * with the domain and the context of the line we are leaving. That request
+     * fetches exactly what is already displayed and is thrown away ~150 ms
+     * later, when the new record arrives and the real reload happens.
+     *
+     * So we skip the reload when the resulting config would fetch the very same
+     * data. Only the props driven reloads are candidates to be skipped: an
+     * explicit `model.load()` (the reload after an unlink, a multi edit, ...)
+     * carries no domain and always goes through.
+     */
+    async load(params = {}) {
+        if (this.root && "domain" in params) {
+            const nextConfig = this._getNextConfig(this.config, params);
+            const sameQuery = QUERY_KEYS.every((key) =>
+                deepEqual(this.config[key], nextConfig[key])
+            );
+            if (sameQuery) {
+                return;
+            }
+        }
+        return super.load(params);
     }
 }

--- a/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_view.esm.js
+++ b/account_reconcile_oca/static/src/js/reconcile_move_line/reconcile_move_line_view.esm.js
@@ -1,4 +1,5 @@
 import {ReconcileMoveLineController} from "./reconcile_move_line_controller.esm.js";
+import {ReconcileMoveLineModel} from "./reconcile_move_line_model.esm.js";
 import {ReconcileMoveLineRenderer} from "./reconcile_move_line_renderer.esm.js";
 
 import {listView} from "@web/views/list/list_view";
@@ -7,6 +8,7 @@ import {registry} from "@web/core/registry";
 export const ReconcileMoveLineView = {
     ...listView,
     Controller: ReconcileMoveLineController,
+    Model: ReconcileMoveLineModel,
     Renderer: ReconcileMoveLineRenderer,
     buttonTemplate: "reconcile_move_line.ListView.Buttons",
 };


### PR DESCRIPTION
The candidates list is rendered inside the reconcile form. Selecting a counterpart updates the parent record, which re-renders the form and passes a new (but value-wise identical) domain to the list. RelationalModel resets the pagination offset to 0 whenever it is reloaded "from above with a domain", so the user was sent back to the first page of candidates (and the right panel scrolled away) on every click.

  - Add ReconcileMoveLineModel, which drops the domain from the reload params when its value hasn't changed, preserving the current page. A real search change still carries a different domain and resets the page as expected.
  - Wire the new model into ReconcileMoveLineView.
  - Preserve the scroll position of the reconcile panel in ReconcileMoveLineController.openRecord.

cc @Tecnativa TT63153

ping @sergio-teruel @carlosdauden 