### PR TITLE
[19.0][FIX] account_reconcile_oca: use valid user groups field in demo

### DIFF
--- a/account_reconcile_oca/demo/demo.xml
+++ b/account_reconcile_oca/demo/demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <record id="base.user_admin" model="res.users">
-        <field name="groups_id" eval="[(4,ref('account.group_account_user'))]" />
+        <field name="group_ids" eval="[(4,ref('account.group_account_user'))]" />
     </record>
 </odoo>


### PR DESCRIPTION
```
2026-06-16 12:59:14,436 39 WARNING prod odoo.modules.loading: Module account_reconcile_oca demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 4381, in write
    self._check_field_access(self._fields[field_name], 'write')
                             ~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'groups_id'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 605, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 460, in _tag_record
    record = model._load_records([data], self.mode == 'update')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 5171, in _load_records
    data['record']._load_records_write(data['values'])
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 5092, in _load_records_write
    self.write(values)
  File "/opt/odoo/auto/addons/calendar/models/res_users.py", line 71, in write
    return super().write(vals)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/auto/addons/auth_totp_mail/models/res_users.py", line 22, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/auto/addons/auth_signup/models/res_users.py", line 282, in write
    return super().write(vals)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/auto/addons/mail/models/discuss/res_users.py", line 19, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/auto/addons/mail/models/res_users.py", line 214, in write
    write_res = super().write(vals)
                ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/auto/addons/resource/models/res_users.py", line 17, in write
    rslt = super().write(vals)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/res_users.py", line 1370, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/res_users.py", line 617, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/custom/src/odoo/odoo/orm/models.py", line 4383, in write
    raise ValueError(f"Invalid field {field_name!r} in {self._name!r}") from e
ValueError: Invalid field 'groups_id' in 'res.users'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 73, in load_demo
    load_data(env(su=True, context=dict(env.context, install_demo=True)), idref, mode, kind='demo', package=package)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 59, in load_data
    convert_file(env, package.name, filename, idref, mode, noupdate=kind == 'demo')
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 693, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 792, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 663, in parse
    self._tag_root(de)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 618, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/account_reconcile_oca/demo/demo.xml:3, somewhere inside
<record id="base.user_admin" model="res.users">
        <field name="groups_id" eval="[(4,ref('account.group_account_user'))]"/>
    </record>
```
@Tecnativa

@victoralmau @pedrobaeza please review