### PR TITLE
[19.0][FIX] account_reconcile_oca: create partner bank with sudo in test

### DIFF
--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1371,19 +1371,27 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
 
     def test_bank_partner_match_account(self):
         account_number = "GB33BUKB20201555555555"
-        partner = self.env["res.partner"].create(
-            {
-                "name": "Test Partner",
-                "bank_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "acc_number": account_number,
-                        },
-                    )
-                ],
-            }
+        # Use sudo to create the bank account: when account_payment_order is
+        # installed alongside, creating res.partner.bank requires its payment
+        # group, which the accounting test user doesn't have. This test only
+        # needs the bank account to check partner matching, not ACLs.
+        partner = (
+            self.env["res.partner"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test Partner",
+                    "bank_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "acc_number": account_number,
+                            },
+                        )
+                    ],
+                }
+            )
         )
         bank_stmt = self.acc_bank_stmt_model.create(
             {


### PR DESCRIPTION
cc @Tecnativa

`account_payment_order` (in the bank-payment repo) overrides the base ACL by reusing the same external id.
Because it reuses `base.access_res_partner_bank_group_account_payment,` it replaces the base rule, so in any DB where `account_payment_order` is installed only `group_account_payment` can create `res.partner.bank`. The `account_reconcile_oca` test user has accounting/manager groups but not that payment group, so the nested `bank_ids` create fails

ping @pedrobaeza @etobella