### PR TITLE
[19.0][FIX] account_reconcile_oca: test setup for res.partner.bank permissions

### DIFF
--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -17,6 +17,12 @@ class TestAccountReconciliationCommon(TestAccountReconciliationModelCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        bank_account_access = cls.env.ref(
+            "base.access_res_partner_bank_group_partner_manager"
+        )
+        cls.env.user.write(
+            {"group_ids": [Command.link(bank_account_access.group_id.id)]}
+        )
         cls.env = cls.env(context=cls._setup_context())
         # Auto-disable reconciliation model created automatically with
         # generate_account_reconcile_model() to avoid side effects in tests


### PR DESCRIPTION
The test creates partner bank accounts, but the group allowed to do so can very depending on installed modules that extend or update the base ACL. Instead of hardcoding a specific group or bypassing access rights, the test now grants the user the group configured on the actual res.partner.bank access rule.
For example, when `account_payment_order` is installed, it reassigns the existing `base.access_res_partner_bank_group_partner_manager` ACL to its own “Accounting / Payments” group. 
@pedrobaeza ping

@Tecnativa