### PR TITLE
[16.0][FIX] account_reconcile_oca: keep statement rate for manual counterparts

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -1184,6 +1184,19 @@ class AccountBankStatementLine(models.Model):
         self.ensure_one()
         self.move_id.to_check = False
 
+    def _convert_reconcile_counterpart_max_amount(self, max_amount, currency, date):
+        reconcile_currency = self._get_reconcile_currency()
+        if currency not in (self.company_id.currency_id, reconcile_currency):
+            return super()._convert_reconcile_counterpart_max_amount(
+                max_amount, currency, date
+            )
+        amounts = self._prepare_counterpart_amounts_using_st_line_rate(
+            reconcile_currency, 0.0, max_amount
+        )
+        if currency == self.company_id.currency_id:
+            return amounts["balance"]
+        return amounts["amount_currency"]
+
     def _get_reconcile_line(
         self,
         line,

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -36,6 +36,11 @@ class AccountReconcileAbstract(models.AbstractModel):
     def _get_reconcile_currency(self):
         return self.currency_id or self.company_id._currency_id
 
+    def _convert_reconcile_counterpart_max_amount(self, max_amount, currency, date):
+        return self._get_reconcile_currency()._convert(
+            max_amount, currency, self.company_id, date
+        )
+
     def _get_reconcile_line(
         self,
         line,
@@ -71,8 +76,10 @@ class AccountReconcileAbstract(models.AbstractModel):
                     -real_currency_amount > max_amount > 0
                     or -real_currency_amount < max_amount < 0
                 ):
-                    currency_max_amount = self._get_reconcile_currency()._convert(
-                        max_amount, currency, self.company_id, date
+                    currency_max_amount = (
+                        self._convert_reconcile_counterpart_max_amount(
+                            max_amount, currency, date
+                        )
                     )
                     amount = currency_max_amount
                     net_amount = -max_amount

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1464,6 +1464,140 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertTrue(f.can_reconcile)
             self.assertEqual(f.reconcile_data_info["data"][-1]["amount"], 3.63)
 
+    def test_manual_counterpart_uses_statement_rate_after_late_rate_update(self):
+        chf = self.env.ref("base.CHF")
+        chf.active = True
+        rate = self.env["res.currency.rate"].create(
+            {
+                "currency_id": chf.id,
+                "name": time.strftime("%Y-01-13"),
+                "inverse_company_rate": 1.07,
+            }
+        )
+        chf_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank CHF",
+                "type": "bank",
+                "code": "BCHF",
+                "currency_id": chf.id,
+                "suspense_account_id": self.company.account_journal_suspense_account_id.id,
+            }
+        )
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            currency_id=self.currency_euro_id,
+            invoice_amount=1261.31,
+            date_invoice=time.strftime("%Y-02-01"),
+            auto_validate=True,
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": chf_journal.id,
+                "date": time.strftime("%Y-01-13"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": chf_journal.id,
+                "statement_id": bank_stmt.id,
+                "amount": -250,
+                "date": time.strftime("%Y-01-13"),
+            }
+        )
+        (
+            liquidity_lines,
+            _suspense_lines,
+            _other_lines,
+        ) = bank_stmt_line._seek_for_lines()
+        self.assertEqual(liquidity_lines.credit, 267.5)
+
+        rate.inverse_company_rate = 1.09004
+        payable = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == "liability_payable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = payable
+            counterpart = next(
+                line
+                for line in f.reconcile_data_info["data"]
+                if line["reference"] == "account.move.line;%s" % payable.id
+            )
+            self.assertEqual(counterpart["amount"], 267.5)
+            self.assertTrue(f.can_reconcile)
+
+    def test_manual_receivable_counterpart_uses_statement_rate_after_late_rate_update(
+        self,
+    ):
+        chf = self.env.ref("base.CHF")
+        chf.active = True
+        rate = self.env["res.currency.rate"].create(
+            {
+                "currency_id": chf.id,
+                "name": time.strftime("%Y-01-13"),
+                "inverse_company_rate": 1.07,
+            }
+        )
+        chf_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank CHF Receivable",
+                "type": "bank",
+                "code": "BCHR",
+                "currency_id": chf.id,
+                "suspense_account_id": self.company.account_journal_suspense_account_id.id,
+            }
+        )
+        invoice = self._create_invoice(
+            move_type="out_invoice",
+            currency_id=self.currency_euro_id,
+            invoice_amount=1261.31,
+            date_invoice=time.strftime("%Y-02-01"),
+            auto_validate=True,
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": chf_journal.id,
+                "date": time.strftime("%Y-01-13"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": chf_journal.id,
+                "statement_id": bank_stmt.id,
+                "amount": 250,
+                "date": time.strftime("%Y-01-13"),
+            }
+        )
+        (
+            liquidity_lines,
+            _suspense_lines,
+            _other_lines,
+        ) = bank_stmt_line._seek_for_lines()
+        self.assertEqual(liquidity_lines.debit, 267.5)
+
+        rate.inverse_company_rate = 1.09004
+        receivable = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = receivable
+            counterpart = next(
+                line
+                for line in f.reconcile_data_info["data"]
+                if line["reference"] == "account.move.line;%s" % receivable.id
+            )
+            self.assertEqual(counterpart["amount"], -267.5)
+            self.assertTrue(f.can_reconcile)
+
     def test_foreign_currency_reconcile_model_differing_rate_exchange_gain(self):
         """
         Test that when the bank uses a different exchange rate than Odoo, but foreign


### PR DESCRIPTION
Fixes #993.

## Description

When a bank statement line is created in a foreign-currency journal before a late currency rate update, the reconciliation widget must keep using the rate stored on the statement line.

Before this fix, manually adding a counterpart line could recompute the counterpart amount using the updated global currency rate instead of the original statement line rate.

This PR keeps the default conversion behavior in the abstract reconciliation model, but lets `account.bank.statement.line` convert limited counterpart amounts through Odoo's statement-line-rate helper.

## Changes

- Add `_convert_reconcile_counterpart_max_amount()` as a small hook in `account.reconcile.abstract`.
- Override that hook in `account.bank.statement.line`.
- Use `_prepare_counterpart_amounts_using_st_line_rate()` for company/reconcile currency amounts on bank statement lines.
- Keep the previous generic conversion behavior for other currency cases.
- Add regression tests for both payable and receivable manual counterpart flows.

## Chronology

1. Reproduced the issue with a CHF bank statement line created with an original rate of `1.07`.
2. Updated the same day's rate afterwards to `1.09004`, simulating a late rate import.
3. Confirmed the bug: when adding a payable counterpart manually, the widget proposed `272.51` instead of keeping the statement-line amount `267.5`.
4. Traced the recomputation to the generic `max_amount` conversion path in `account.reconcile.abstract`.
5. Added a hook to preserve the generic behavior by default.
6. Specialized the bank statement line implementation to reuse Odoo's existing statement-line-rate helper.
7. Added a symmetric receivable test to cover the positive-amount sign case as well.

## Testing

Before the fix, the payable regression test failed with:

```text
AssertionError: 272.51 != 267.5
```

After the fix:

```text
account_reconcile_oca: 40 tests
0 failed, 0 errors
```

Also run successfully:

```text
pre-commit run --files \
  account_reconcile_oca/models/account_reconcile_abstract.py \
  account_reconcile_oca/models/account_bank_statement_line.py \
  account_reconcile_oca/tests/test_bank_account_reconcile.py
```

All selected pre-commit hooks passed, including black, flake8, and pylint-odoo.
