### PR TITLE
[16.0][FIX] account_reconcile_oca: use the statement-booked rate for foreign-currency reconciliation

### DIFF
--- a/account_reconcile_oca/__manifest__.py
+++ b/account_reconcile_oca/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Reconcile OCA",
     "summary": """
         Reconcile addons for Odoo CE accounting""",
-    "version": "16.0.2.5.1",
+    "version": "16.0.2.5.2",
     "license": "AGPL-3",
     "author": "CreuBlanca,Dixmit,Odoo Community Association (OCA)",
     "maintainers": ["etobella"],

--- a/account_reconcile_oca/models/account_account_reconcile.py
+++ b/account_reconcile_oca/models/account_account_reconcile.py
@@ -181,7 +181,7 @@ class AccountAccountReconcile(models.Model):
                 move=True,
             )
             new_data["data"] += lines
-            amount += sum(line["amount"] for line in lines)
+            amount += sum(line["currency_amount"] for line in lines)
         return new_data
 
     def clean_reconcile(self):

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -206,17 +206,136 @@ class AccountBankStatementLine(models.Model):
             )._default_reconcile_data()
         self.can_reconcile = self.reconcile_data_info.get("can_reconcile", False)
 
+    def _to_reconcile_currency_at_st_line_rate(self, amount_company):
+        """Convert ``amount_company`` (expressed in company currency) into
+        the reconcile currency using the rate booked on this statement
+        line's move, rather than ``res.currency.rate`` at ``self.date``.
+
+        The reconcile currency is ``self._get_reconcile_currency()`` (i.e.
+        ``foreign_currency_id or journal currency``), so this handles both
+        a foreign-currency journal and a company-currency journal carrying
+        a foreign-currency transaction via ``foreign_currency_id``. The
+        rate used is ``transaction_amount / company_amount`` taken from the
+        booked liquidity line.
+
+        Returns ``None`` when no statement-booked rate is usable
+        (statement in company currency, or booked amounts missing), so
+        callers can fall back to their original behaviour.
+        """
+        reconcile_currency = self._get_reconcile_currency()
+        if reconcile_currency == self.company_id.currency_id:
+            return None
+        (
+            transaction_amount,
+            _transaction_currency,
+            _journal_amount,
+            _journal_currency,
+            company_amount,
+            _company_currency,
+        ) = self._get_accounting_amounts_and_currencies()
+        if not transaction_amount or not company_amount:
+            return None
+        return reconcile_currency.round(
+            amount_company * abs(transaction_amount) / abs(company_amount)
+        )
+
+    def _get_reconcile_residual_in_reconcile_currency(
+        self,
+        amount,
+        currency_amount,
+        currency,
+        dest_currency,
+        date,
+    ):
+        """Override: when the statement is in a foreign currency and the
+        counterpart line is NOT in that same currency (company currency, or a
+        third currency), express the residual in the reconcile currency using
+        the rate booked on the statement move rather than ``res.currency.rate``
+        at ``date``. This keeps the ``max_amount`` capping decision consistent
+        with the booked amounts on the statement. A counterpart already in the
+        reconcile currency falls back to the default (its own exchange-rate
+        difference is handled separately).
+        """
+        reconcile_currency = self._get_reconcile_currency()
+        if (
+            reconcile_currency != self.company_id.currency_id
+            and currency != reconcile_currency
+        ):
+            converted = self._to_reconcile_currency_at_st_line_rate(amount)
+            if converted is not None:
+                return converted
+        return super()._get_reconcile_residual_in_reconcile_currency(
+            amount,
+            currency_amount,
+            currency,
+            dest_currency,
+            date,
+        )
+
+    def _get_reconcile_amounts_capped(
+        self,
+        max_amount,
+        currency,
+        dest_currency,
+        date,
+    ):
+        """Override: when the statement is in a foreign currency and the
+        counterpart line is NOT in that same currency, derive the capped
+        company-currency amount from the rate booked on the statement move (via
+        ``_prepare_counterpart_amounts_using_st_line_rate``) rather than from
+        ``res.currency.rate`` at ``date``. A counterpart already in the reconcile
+        currency falls back to the default, preserving its legitimate
+        exchange-rate difference.
+        """
+        reconcile_currency = self._get_reconcile_currency()
+        company_currency = self.company_id.currency_id
+        if reconcile_currency != company_currency and currency != reconcile_currency:
+            amounts = self._prepare_counterpart_amounts_using_st_line_rate(
+                dest_currency,
+                0.0,
+                -max_amount,
+            )
+            # Company-currency value of the capped capacity, at the booked rate.
+            amount_in_company = amounts["balance"]
+            if currency == company_currency:
+                # Counterpart in company currency: amount and currency_amount
+                # carry the same value.
+                return amount_in_company, amount_in_company
+            # Counterpart in a third currency: express the booked company amount
+            # in the counterpart currency; its own realised exchange difference
+            # is handled by the reconciliation engine at validation.
+            currency_amount = company_currency._convert(
+                amount_in_company,
+                currency,
+                self.company_id,
+                date,
+            )
+            return amount_in_company, currency_amount
+        return super()._get_reconcile_amounts_capped(
+            max_amount,
+            currency,
+            dest_currency,
+            date,
+        )
+
     def _get_amount_currency(self, line, dest_curr):
         if line["line_currency_id"] == dest_curr.id:
-            amount = line["currency_amount"]
-        else:
-            amount = self.company_id.currency_id._convert(
-                line["amount"],
-                dest_curr,
-                self.company_id,
-                self.date,
-            )
-        return amount
+            return line["currency_amount"]
+        if dest_curr == self._get_reconcile_currency():
+            # Express a company-currency counterpart in the reconcile currency
+            # at the statement-booked rate, so the remaining capacity stays
+            # consistent with how the next counterpart is imputed (otherwise a
+            # prior counterpart converted at the day rate leaves a residual
+            # when several counterparts are reconciled).
+            converted = self._to_reconcile_currency_at_st_line_rate(line["amount"])
+            if converted is not None:
+                return converted
+        return self.company_id.currency_id._convert(
+            line["amount"],
+            dest_curr,
+            self.company_id,
+            self.date,
+        )
 
     @api.onchange("add_account_move_line_id")
     def _onchange_add_account_move_line_id(self):
@@ -606,12 +725,20 @@ class AccountBankStatementLine(models.Model):
                     amount, self.journal_id.currency_id or self.company_currency_id
                 )
             if currency != self.company_id.currency_id:
-                currency_amount = self.company_id.currency_id._convert(
+                # Derive the currency amount from the rate booked on the
+                # statement when applicable, so that a rate change in
+                # res.currency.rate after the statement was posted does
+                # not introduce a discrepancy with the booked amounts.
+                currency_amount = self._to_reconcile_currency_at_st_line_rate(
                     amount,
-                    currency,
-                    self.company_id,
-                    self.date,
                 )
+                if currency_amount is None:
+                    currency_amount = self.company_id.currency_id._convert(
+                        amount,
+                        currency,
+                        self.company_id,
+                        self.date,
+                    )
             new_line.update(
                 {
                     "reference": "reconcile_auxiliary;%s" % reconcile_auxiliary_id,
@@ -678,15 +805,17 @@ class AccountBankStatementLine(models.Model):
                 amount = self.amount_total_signed
                 for line in res.get("amls", []):
                     max_amount = amount
-                    if (
-                        line.currency_id == self._get_reconcile_currency()
-                        and self.amount_currency
-                        and self.amount_total_signed
-                    ):
-                        # convert max amount with rate of statement, not Odoo's rate
-                        max_amount = line.currency_id.round(
-                            max_amount * self.amount_currency / self.amount_total_signed
-                        )
+                    # max_amount must be expressed in the reconcile
+                    # currency. When the statement is in a foreign
+                    # currency, convert via the rate booked on the
+                    # statement rather than res.currency.rate, so that
+                    # rates created after the statement was posted do not
+                    # shift the cap.
+                    converted = self._to_reconcile_currency_at_st_line_rate(
+                        max_amount,
+                    )
+                    if converted is not None:
+                        max_amount = converted
                     reconcile_auxiliary_id, line_data = self._get_reconcile_line(
                         line,
                         "other",
@@ -1138,6 +1267,14 @@ class AccountBankStatementLine(models.Model):
             if line["reference"] == manual_reference and line.get("id"):
                 total_amount = -line["amount"] + line["original_amount_unsigned"]
                 original_amount = line["original_amount_unsigned"]
+                # original_amount is in company currency but _get_reconcile_line
+                # expects max_amount in reconcile currency. Convert via the
+                # statement-booked rate when applicable.
+                converted = self._to_reconcile_currency_at_st_line_rate(
+                    original_amount,
+                )
+                if converted is not None:
+                    original_amount = converted
                 reconcile_auxiliary_id, lines = self._get_reconcile_line(
                     self.env["account.move.line"].browse(line["id"]),
                     "other",

--- a/account_reconcile_oca/models/account_reconcile_abstract.py
+++ b/account_reconcile_oca/models/account_reconcile_abstract.py
@@ -36,6 +36,70 @@ class AccountReconcileAbstract(models.AbstractModel):
     def _get_reconcile_currency(self):
         return self.currency_id or self.company_id._currency_id
 
+    def _get_reconcile_residual_in_reconcile_currency(
+        self,
+        amount,
+        currency_amount,
+        currency,
+        dest_currency,
+        date,
+    ):
+        """Express the residual amount of a counterpart line in the
+        reconcile currency, so it can be compared against ``max_amount``
+        in ``_get_reconcile_line``.
+
+        Default implementation goes through ``currency._convert`` at
+        ``date`` for the cross-currency case, which queries
+        ``res.currency.rate``. Subclasses with a more reliable rate
+        available (for instance the rate booked on a bank statement line)
+        should override this method.
+        """
+        if currency == dest_currency:
+            return currency_amount
+        if self.company_id.currency_id == dest_currency:
+            return amount
+        return self.company_id.currency_id._convert(
+            amount,
+            dest_currency,
+            self.company_id,
+            date,
+        )
+
+    def _get_reconcile_amounts_capped(
+        self,
+        max_amount,
+        currency,
+        dest_currency,
+        date,
+    ):
+        """Compute ``(amount, currency_amount)`` for a counterpart line
+        capped at ``max_amount`` (expressed in ``dest_currency``, i.e. the
+        reconcile currency). ``amount`` is in company currency,
+        ``currency_amount`` is in ``currency`` (the counterpart line
+        currency).
+
+        Default implementation goes through ``currency._convert`` at
+        ``date``, which queries ``res.currency.rate``. Subclasses with a
+        more reliable rate available (for instance the rate booked on a
+        bank statement line) should override this method to derive the
+        amounts from that rate, so that the reconciliation stays
+        consistent with what was actually posted.
+        """
+        currency_max_amount = dest_currency._convert(
+            max_amount,
+            currency,
+            self.company_id,
+            date,
+        )
+        currency_amount = -currency_max_amount
+        amount = currency._convert(
+            currency_amount,
+            self.company_id.currency_id,
+            self.company_id,
+            date,
+        )
+        return amount, currency_amount
+
     def _get_reconcile_line(
         self,
         line,
@@ -56,33 +120,26 @@ class AccountReconcileAbstract(models.AbstractModel):
             original_amount = net_amount = -line.amount_residual
             if max_amount:
                 dest_currency = self._get_reconcile_currency()
-                if currency == dest_currency:
-                    real_currency_amount = currency_amount
-                elif self.company_id.currency_id == dest_currency:
-                    real_currency_amount = amount
-                else:
-                    real_currency_amount = self.company_id.currency_id._convert(
+                real_currency_amount = (
+                    self._get_reconcile_residual_in_reconcile_currency(
                         amount,
+                        currency_amount,
+                        currency,
                         dest_currency,
-                        self.company_id,
                         date,
                     )
+                )
                 if (
                     -real_currency_amount > max_amount > 0
                     or -real_currency_amount < max_amount < 0
                 ):
-                    currency_max_amount = self._get_reconcile_currency()._convert(
-                        max_amount, currency, self.company_id, date
-                    )
-                    amount = currency_max_amount
-                    net_amount = -max_amount
-                    currency_amount = -amount
-                    amount = currency._convert(
-                        currency_amount,
-                        self.company_id.currency_id,
-                        self.company_id,
+                    amount, currency_amount = self._get_reconcile_amounts_capped(
+                        max_amount,
+                        currency,
+                        dest_currency,
                         date,
                     )
+                    net_amount = -max_amount
         elif is_reconciled:
             currency_amount = line.amount_currency
         else:

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1557,3 +1557,237 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             reconciled_exchange_line.balance,
             "Proposed reconciliation does not match auto reconciliation",
         )
+
+    def test_multi_counterpart_company_currency_booked_rate(self):
+        usd = self.env.ref("base.USD")
+        company_currency = self.env.company.currency_id
+        self.env["res.currency.rate"].search([("currency_id", "=", usd.id)]).unlink()
+        self.env["res.currency.rate"].create(
+            {
+                "currency_id": usd.id,
+                "name": time.strftime("%Y-01-01"),
+                "rate": 2.0,
+            }
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_usd.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "multi counterpart booked rate",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_usd.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100.0,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertEqual(bank_stmt_line.amount_total_signed, 50.0)
+        self.env["res.currency.rate"].create(
+            {
+                "currency_id": usd.id,
+                "name": time.strftime("%Y-07-15"),
+                "rate": 2.5,
+            }
+        )
+        inv1 = self.create_invoice(currency_id=company_currency.id, invoice_amount=10)
+        inv2 = self.create_invoice(currency_id=company_currency.id, invoice_amount=100)
+        rec1 = inv1.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        rec2 = inv2.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = rec1
+            f.add_account_move_line_id = rec2
+            self.assertTrue(f.can_reconcile)
+        data = bank_stmt_line.reconcile_data_info["data"]
+        others = [line for line in data if line["kind"] == "other"]
+        suspense = [line for line in data if line["kind"] == "suspense"]
+        self.assertEqual(len(others), 2)
+        self.assertFalse(suspense)
+        amounts = sorted(abs(line["amount"]) for line in others)
+        self.assertEqual(amounts, [10.0, 40.0])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertTrue(bank_stmt_line.is_reconciled)
+
+    def test_manual_counterpart_uses_statement_rate_after_late_rate_update(self):
+        chf = self.env.ref("base.CHF")
+        chf.active = True
+        rate = self.env["res.currency.rate"].create(
+            {
+                "currency_id": chf.id,
+                "name": time.strftime("%Y-01-13"),
+                "inverse_company_rate": 1.07,
+            }
+        )
+        chf_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank CHF",
+                "type": "bank",
+                "code": "BCHF",
+                "currency_id": chf.id,
+                "suspense_account_id": self.company.account_journal_suspense_account_id.id,
+            }
+        )
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            currency_id=self.currency_euro_id,
+            invoice_amount=1261.31,
+            date_invoice=time.strftime("%Y-02-01"),
+            auto_validate=True,
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": chf_journal.id,
+                "date": time.strftime("%Y-01-13"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": chf_journal.id,
+                "statement_id": bank_stmt.id,
+                "amount": -250,
+                "date": time.strftime("%Y-01-13"),
+            }
+        )
+        (
+            liquidity_lines,
+            _suspense_lines,
+            _other_lines,
+        ) = bank_stmt_line._seek_for_lines()
+        self.assertEqual(liquidity_lines.credit, 267.5)
+
+        rate.inverse_company_rate = 1.09004
+        payable = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == "liability_payable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = payable
+            counterpart = next(
+                line
+                for line in f.reconcile_data_info["data"]
+                if line["reference"] == "account.move.line;%s" % payable.id
+            )
+            self.assertEqual(counterpart["amount"], 267.5)
+            self.assertTrue(f.can_reconcile)
+
+    def test_manual_receivable_counterpart_uses_statement_rate_after_late_rate_update(
+        self,
+    ):
+        chf = self.env.ref("base.CHF")
+        chf.active = True
+        rate = self.env["res.currency.rate"].create(
+            {
+                "currency_id": chf.id,
+                "name": time.strftime("%Y-01-13"),
+                "inverse_company_rate": 1.07,
+            }
+        )
+        chf_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank CHF Receivable",
+                "type": "bank",
+                "code": "BCHR",
+                "currency_id": chf.id,
+                "suspense_account_id": self.company.account_journal_suspense_account_id.id,
+            }
+        )
+        invoice = self._create_invoice(
+            move_type="out_invoice",
+            currency_id=self.currency_euro_id,
+            invoice_amount=1261.31,
+            date_invoice=time.strftime("%Y-02-01"),
+            auto_validate=True,
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": chf_journal.id,
+                "date": time.strftime("%Y-01-13"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": chf_journal.id,
+                "statement_id": bank_stmt.id,
+                "amount": 250,
+                "date": time.strftime("%Y-01-13"),
+            }
+        )
+        (
+            liquidity_lines,
+            _suspense_lines,
+            _other_lines,
+        ) = bank_stmt_line._seek_for_lines()
+        self.assertEqual(liquidity_lines.debit, 267.5)
+
+        rate.inverse_company_rate = 1.09004
+        receivable = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.add_account_move_line_id = receivable
+            counterpart = next(
+                line
+                for line in f.reconcile_data_info["data"]
+                if line["reference"] == "account.move.line;%s" % receivable.id
+            )
+            self.assertEqual(counterpart["amount"], -267.5)
+            self.assertTrue(f.can_reconcile)
+
+    def test_writeoff_button_currency_amount_uses_statement_rate(self):
+        usd = self.env.ref("base.USD")
+        self.env["res.currency.rate"].search([("currency_id", "=", usd.id)]).unlink()
+        self.env["res.currency.rate"].create(
+            {"currency_id": usd.id, "name": time.strftime("%Y-01-01"), "rate": 2.0}
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_usd.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "writeoff",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_usd.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100.0,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.env["res.currency.rate"].create(
+            {"currency_id": usd.id, "name": time.strftime("%Y-07-15"), "rate": 2.5}
+        )
+        with Form(
+            bank_stmt_line,
+            view="account_reconcile_oca.bank_statement_line_form_reconcile_view",
+        ) as f:
+            f.manual_model_id = self.rule
+        writeoff = [
+            line
+            for line in bank_stmt_line.reconcile_data_info["data"]
+            if line["kind"] == "other"
+        ]
+        self.assertEqual(len(writeoff), 1)
+        self.assertEqual(writeoff[0]["amount"], -50.0)
+        self.assertEqual(writeoff[0]["currency_amount"], -100.0)
+        self.assertTrue(bank_stmt_line.reconcile_data_info.get("can_reconcile"))


### PR DESCRIPTION
## Problem

When a bank/cash statement line is in a foreign currency and is reconciled against a counterpart in the company currency, the widget converts the counterpart amounts through `res.currency.rate` at the statement date instead of the rate booked on the statement move. If a rate is imported *after* the statement was posted (a very common case: the daily rate for date D arrives on D+1), the imputed/capped amounts shift and an artificial residual is stranded on the bank suspense account.

Example: a `-250 CHF` cash line booked at `267.50 EUR` (rate 1.07), reconciled against a EUR vendor bill after a `1.09004` rate is imported, is imputed at `272.51 EUR` instead of `267.50 EUR`, leaving `5.01 EUR` stuck on the suspense account. The move balances in company currency, so `can_reconcile` stays true and nothing flags it.

Closes #993.

## Fix

The imputation and capping now derive the counterpart amounts from the rate booked on the statement move (`transaction_amount / company_amount`) instead of `res.currency.rate` at the statement date, at every conversion chokepoint:

- the residual used for the capping decision;
- the capped counterpart amounts;
- the running total of already-imputed counterparts (so multi-counterpart reconciliations stay consistent);
- the reconcile-model / write-off paths;
- the manual account reconciliation widget (`account.account.reconcile`).

Genuine exchange differences (counterpart in the *same* foreign currency as the statement) keep their `res.currency.rate` conversion, so realised currency gains/losses are preserved.

The change is fail-safe: the conversion hooks default to the stock behaviour, and the booked-rate helper falls back to `res.currency.rate` whenever no booked rate is available.

## Relationship to #1007

This addresses the same root cause as #1007 and produces the same result on the single-counterpart case it covers. It is intentionally a superset: it additionally fixes the multi-counterpart case (the running total in `_get_amount_currency`, otherwise a residual reappears on the 2nd counterpart), the capping decision at the booked threshold, the reconcile-model / write-off paths, and the manual account reconciliation widget. Happy to align with #1007 if the maintainers prefer.

## Tests

Regression tests in `tests/test_bank_account_reconcile.py`: single payable/receivable counterpart at the booked rate after a late rate update, the multi-counterpart case, and the write-off button. All existing tests pass.
