### PR TITLE
[FIX] account_reconcile_oca: compare currency amount against statement currency amount in _check_reconcile_data_changed

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -370,7 +370,7 @@ class AccountBankStatementLine(models.Model):
             stmt_credit += line_data["credit"]
         prec = self.currency_id.rounding
         return (
-            float_compare(move_amount_cur, move_amount_cur, precision_rounding=prec)
+            float_compare(move_amount_cur, stmt_amount_curr, precision_rounding=prec)
             != 0
             or float_compare(move_credit, stmt_credit, precision_rounding=prec) != 0
             or float_compare(move_debit, stmt_debit, precision_rounding=prec) != 0


### PR DESCRIPTION
The first branch of `_check_reconcile_data_changed` compares
`move_amount_cur` with itself, so it always evaluates to `False`.
The variable `stmt_amount_curr` is computed just above but never read.

The two other branches in the same return statement follow the symmetric
pattern `float_compare(move_X, stmt_X)`, so the first branch was meant
to compare the foreign-currency amount of the move against the one
stored in the widget data the same way:

```python
return (
    float_compare(move_amount_cur, move_amount_cur, precision_rounding=prec) != 0  # <-- compares to itself
    or float_compare(move_credit, stmt_credit, precision_rounding=prec) != 0
    or float_compare(move_debit,  stmt_debit,  precision_rounding=prec) != 0
)
```

Without this fix, divergences between the widget's `reconcile_data_info`
and the booked statement move that affect only the foreign-currency
amount (not the company-currency balance) are silently ignored, and the
widget is not re-computed via `_default_reconcile_data()` from
`_synchronize_to_moves`.

The method was introduced in #784. The bug is present identically on
branches 16.0, 17.0, 18.0 and 19.0.
