### PR TITLE
[18.0[FIX] account_reconcile_sale_order: don't subscribe sales order, picking

### DIFF
--- a/account_reconcile_sale_order/models/account_bank_statement_line.py
+++ b/account_reconcile_sale_order/models/account_bank_statement_line.py
@@ -121,7 +121,18 @@ class AccountBankStatementLine(models.Model):
         Invoice selected sales orders and post the invoices
         """
         if order.state in ("draft", "sent"):
+            order = order.with_context(mail_create_nosubscribe=True)
+            has_pickings = "picking_ids" in order._fields
+            # Track existing pickings to only touch the ones we create
+            pickings_before = (
+                order.picking_ids if has_pickings else self.env["sale.order"].browse()
+            )
             order.action_confirm()
+            # Don't subscribe the reconciling user to the new delivery order(s)
+            if has_pickings:
+                (order.picking_ids - pickings_before).message_unsubscribe(
+                    self.env.user.partner_id.ids
+                )
         invoices = order._create_invoices()
         invoices.action_post()
         return invoices.line_ids.filtered(

--- a/account_reconcile_sale_order/tests/test_account_reconcile_sale_order.py
+++ b/account_reconcile_sale_order/tests/test_account_reconcile_sale_order.py
@@ -65,6 +65,31 @@ class TestAccountReconcileSaleOrder(TestAccountReconciliationCommon):
         self.bank_statement.line_ids.reconcile_bank_line()
         self.assertEqual(self.sale_order.invoice_status, "invoiced")
 
+    def test_reconcile_sale_order_no_user_subscription(self):
+        """Reconciling must not subscribe the current user to the sale order
+        nor to its delivery orders"""
+        self.bank_statement.line_ids.payment_ref = self.sale_order.name
+        self.bank_statement.line_ids.clean_reconcile()
+        self.bank_statement.line_ids.reconcile_bank_line()
+        self.assertEqual(self.sale_order.state, "sale")
+        current_partner = self.env.user.partner_id
+        self.assertNotIn(
+            current_partner,
+            self.sale_order.message_follower_ids.mapped("partner_id"),
+            "The current user should not be subscribed to the sale order"
+            " after reconciliation",
+        )
+        # Delivery orders only exist when sale_stock is installed
+        if "picking_ids" in self.sale_order._fields:
+            self.assertTrue(self.sale_order.picking_ids, "No delivery order created")
+            for picking in self.sale_order.picking_ids:
+                self.assertNotIn(
+                    current_partner,
+                    picking.message_follower_ids.mapped("partner_id"),
+                    "The current user should not be subscribed to the delivery order"
+                    " after reconciliation",
+                )
+
     def test_token_matching(self):
         """Test that we find orders by substrings of statement label"""
         self.model.sudo().sale_order_matching_token_match = True


### PR DESCRIPTION
Until now the user who reconciles subscribes the sale order (and subsequent delivery order). This is not desired for accountants responsible for reconciliation. This fix prevents such subscription.