### PR TITLE
[19.0][FIX] account_reconcile_oca: with_prefetch() expects ids, not a recordset

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -949,7 +949,7 @@ class AccountBankStatementLine(models.Model):
         res = self.env["account.reconcile.model"]._get_rules(to_do)
         done = self.browse()
         for record_id, rule_models in res.items():
-            record = self.browse(record_id).with_prefetch(to_do)
+            record = self.browse(record_id).with_prefetch(to_do.ids)
             liquidity_lines, suspense_lines, other_lines = record._seek_for_lines()
             data = []
             reconcile_auxiliary_id = 1


### PR DESCRIPTION
## Bug                                                                                                                                                                             
  `_do_auto_reconcile()` in `account_bank_statement_line.py` calls:                                                                                                                  
                                                                                                                                                                                     
      self.browse(record_id).with_prefetch(to_do)                                                                                                                                    
                                                                                                                                                                                     
  `with_prefetch()` expects an iterable of ids, but `to_do` is a recordset.                                                                                                          
  Iterating a recordset yields single-record sub-recordsets rather than ids,                                                                                                         
  which leak into the ORM's SQL `IN %s` parameter binding and crash with:                                                                                                            
                                                                                                                                                                                     
      psycopg2.ProgrammingError: can't adapt type 'account.bank.statement.line'                                                                                                      
                                                                                                                                                                                     
  This didn't surface on older, more tolerant prefetch implementations, but                                                                                                          
  fails reliably on 19.0's ORM.                                                                                                                                                      
                                                                                                                                                                                     
  ## Fix                                                                                                                                                                             
  Pass `to_do._ids` instead of `to_do`.                                                                                                                                              
                                                                                                                                                                                     
  ## Test                                                                                                                                                                            
  Reproduced and verified against 200 real unreconciled bank statement lines:                                                                                                        
  100% failure before the fix (crashed on the first line), 0 failures after. 