### PR TITLE
[18.0][FIX] account_reconcile_oca: partial vendor bill payment suggests full residual

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -682,8 +682,12 @@ class AccountBankStatementLine(models.Model):
                     self.manual_reference,
                 )
             elif res and res.get("amls"):
-                # TODO should be signed in currency get_reconcile_currency
-                amount = self.amount_total_signed
+                # Use the signed statement amount (as in _do_auto_reconcile) so
+                # that _get_reconcile_line can clamp the counterpart to the
+                # remaining amount. amount_total_signed drops the sign (it is
+                # the absolute amount), which prevented the partial clamp for
+                # outgoing payments of vendor bills, applying the full residual.
+                amount = self.amount_currency or self.amount
                 for line in res.get("amls", []):
                     reconcile_auxiliary_id, line_data = self._get_reconcile_line(
                         line,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -455,6 +455,158 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
         self.assertEqual(inv1.amount_residual_signed, -30)
         self.assertEqual(inv2.amount_residual_signed, -70)
 
+    def _suggest_invoice_via_model(self, invoice, account_type, amount):
+        """Build a partner-matching invoice_matching model and a statement line
+        so that ``_default_reconcile_data`` auto-suggests ``invoice``.
+
+        Returns the statement line and the invoice counterpart move line.
+        """
+        counterpart_line = invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == account_type
+        )
+        self.env["account.reconcile.model"].create(
+            {
+                "name": "partner match (no tolerance)",
+                "rule_type": "invoice_matching",
+                "match_partner": True,
+                "allow_payment_tolerance": False,
+                "match_journal_ids": [Command.set(self.bank_journal_euro.ids)],
+                "company_id": self.company.id,
+            }
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "testLine",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": amount,
+                "partner_id": invoice.partner_id.id,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        return bank_stmt_line, counterpart_line
+
+    @mute_logger("odoo.models.unlink")
+    def test_reconcile_model_partial_supplier_suggestion(self):
+        """Auto-suggestion of a partial payment of a supplier bill.
+
+        Regression test: when an ``invoice_matching`` model auto-suggests a
+        vendor bill whose residual is larger than the incoming (outgoing)
+        statement amount, the suggested counterpart must be clamped to the
+        statement amount (partial), not the full residual. Previously the seed
+        amount used ``amount_total_signed`` (which drops the sign), so the
+        clamp in ``_get_reconcile_line`` never triggered for payable lines and
+        the whole residual was applied, leaving an unbalanced suspense line.
+        """
+        invoice = self.create_invoice(
+            currency_id=self.currency_euro_id,
+            invoice_amount=100,
+            move_type="in_invoice",
+        )
+        bank_stmt_line, payable = self._suggest_invoice_via_model(
+            invoice, "liability_payable", -30
+        )
+        data = bank_stmt_line.reconcile_data_info["data"]
+        counterpart = [
+            line for line in data if line.get("counterpart_line_ids") == payable.ids
+        ]
+        self.assertEqual(len(counterpart), 1)
+        # The counterpart must be the partial amount (30), not the full residual.
+        self.assertEqual(counterpart[0]["amount"], 30)
+        # No leftover suspense line: the proposal is balanced and reconcilable.
+        self.assertFalse([line for line in data if line["kind"] == "suspense"])
+        self.assertTrue(bank_stmt_line.reconcile_data_info["can_reconcile"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(invoice.amount_residual_signed, -70)
+
+    @mute_logger("odoo.models.unlink")
+    def test_reconcile_model_full_supplier_suggestion(self):
+        """Auto-suggestion of a full payment of a supplier bill.
+
+        Whole-amount outgoing reconciliation must keep working: the counterpart
+        is the full residual, no suspense line remains and the bill is fully
+        paid.
+        """
+        invoice = self.create_invoice(
+            currency_id=self.currency_euro_id,
+            invoice_amount=100,
+            move_type="in_invoice",
+        )
+        bank_stmt_line, payable = self._suggest_invoice_via_model(
+            invoice, "liability_payable", -100
+        )
+        data = bank_stmt_line.reconcile_data_info["data"]
+        counterpart = [
+            line for line in data if line.get("counterpart_line_ids") == payable.ids
+        ]
+        self.assertEqual(len(counterpart), 1)
+        self.assertEqual(counterpart[0]["amount"], 100)
+        self.assertFalse([line for line in data if line["kind"] == "suspense"])
+        self.assertTrue(bank_stmt_line.reconcile_data_info["can_reconcile"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(invoice.amount_residual_signed, 0)
+
+    @mute_logger("odoo.models.unlink")
+    def test_reconcile_model_partial_customer_suggestion(self):
+        """Auto-suggestion of a partial payment of a customer invoice.
+
+        Money-in counterpart: proves the signed-amount fix stays neutral for
+        receivables, where the seed sign already matched. The counterpart must
+        be clamped to the partial amount.
+        """
+        invoice = self.create_invoice(
+            currency_id=self.currency_euro_id,
+            invoice_amount=100,
+            move_type="out_invoice",
+        )
+        bank_stmt_line, receivable = self._suggest_invoice_via_model(
+            invoice, "asset_receivable", 30
+        )
+        data = bank_stmt_line.reconcile_data_info["data"]
+        counterpart = [
+            line for line in data if line.get("counterpart_line_ids") == receivable.ids
+        ]
+        self.assertEqual(len(counterpart), 1)
+        self.assertEqual(counterpart[0]["amount"], -30)
+        self.assertFalse([line for line in data if line["kind"] == "suspense"])
+        self.assertTrue(bank_stmt_line.reconcile_data_info["can_reconcile"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(invoice.amount_residual_signed, 70)
+
+    @mute_logger("odoo.models.unlink")
+    def test_reconcile_model_full_customer_suggestion(self):
+        """Auto-suggestion of a full payment of a customer invoice.
+
+        Whole-amount incoming reconciliation must keep working: the counterpart
+        is the full residual, no suspense line remains and the invoice is fully
+        paid.
+        """
+        invoice = self.create_invoice(
+            currency_id=self.currency_euro_id,
+            invoice_amount=100,
+            move_type="out_invoice",
+        )
+        bank_stmt_line, receivable = self._suggest_invoice_via_model(
+            invoice, "asset_receivable", 100
+        )
+        data = bank_stmt_line.reconcile_data_info["data"]
+        counterpart = [
+            line for line in data if line.get("counterpart_line_ids") == receivable.ids
+        ]
+        self.assertEqual(len(counterpart), 1)
+        self.assertEqual(counterpart[0]["amount"], -100)
+        self.assertFalse([line for line in data if line["kind"] == "suspense"])
+        self.assertTrue(bank_stmt_line.reconcile_data_info["can_reconcile"])
+        bank_stmt_line.reconcile_bank_line()
+        self.assertEqual(invoice.amount_residual_signed, 0)
+
     @mute_logger("odoo.models.unlink")
     def test_reconcile_model(self):
         """


### PR DESCRIPTION
## Description

Fix `account_reconcile_oca`: when the reconciliation widget **auto-suggests** an
open vendor bill for an **outgoing** bank transaction that only **partially**
pays that bill, the widget proposes the **full residual** of the bill instead of
the paid amount. This produces an unbalanced proposal with a leftover suspense
(`Compte d'attente`) line, and the **Reconcile / Lettrer** button stays disabled,
forcing the user to manually edit the counterpart amount on every partial
supplier payment.

Only **payable** counterparts on **money-out** statement lines are affected.
Customer invoices (receivable, money-in) already reconcile correctly because the
sign matches.

## Root cause

In `account_reconcile_oca/models/account_bank_statement_line.py`,
`_default_reconcile_data()` seeds the counterpart amount from
`self.amount_total_signed` in the model-suggestion branch:

```python
elif res and res.get("amls"):
    # TODO should be signed in currency get_reconcile_currency
    amount = self.amount_total_signed
```

`amount_total_signed` returns the **absolute** amount (it drops the sign):
`amount = -82.75` → `amount_total_signed = +82.75`. For a payable (credit
residual) line the clamp in `_get_reconcile_line()` only triggers when the seed
amount and the residual have matching signs, so with a positive seed the clamp
never fires and the **full residual** is applied. The sibling method
`_do_auto_reconcile()` already uses the correctly signed amount
(`self.amount_currency or self.amount`), so the two paths were inconsistent.

## Fix

Use the signed statement amount, consistent with `_do_auto_reconcile()`:

```python
elif res and res.get("amls"):
    amount = self.amount_currency or self.amount
```

This makes the partial clamp work for both receivable and payable counterparts.
For money-in lines `amount_total_signed == amount`, so this is a no-op there; the
change only affects the previously broken money-out partial case.

## Tests

Added regression tests on the auto-suggestion path (`_default_reconcile_data`)
covering the full partial/full × payable/receivable matrix:

- `test_reconcile_model_partial_supplier_suggestion` — the bug: partial vendor
  bill payment; asserts counterpart clamped to the paid amount, no suspense line,
  and a reconcilable proposal (fails on the old code).
- `test_reconcile_model_full_supplier_suggestion` — whole-amount outgoing still
  applies the full residual with no suspense.
- `test_reconcile_model_partial_customer_suggestion` — partial customer payment
  stays clamped (proves the fix is neutral for receivables).
- `test_reconcile_model_full_customer_suggestion` — whole-amount incoming still
  works.

## How to reproduce (before the fix)

1. Open supplier bill with residual **662.00 €** (`BILL/2025/00013`).
2. Import an **outgoing** bank line for a **partial** amount, e.g. **82.75 €**,
   same partner.
3. Have an active `invoice_matching` model (partner match) so the bill is
   auto-suggested in the reconcile widget.
4. Open the statement line: the counterpart is set to the full 662.00 € with a
   579.25 € suspense line and **Lettrer disabled**.

### Before — buggy auto-suggestion (full 662.00 € + 579.25 € suspense, Lettrer disabled)

<img width="1334" height="610" alt="Schermata_20260714_144025" src="https://github.com/user-attachments/assets/abe64931-0896-445b-9518-2ebce24bca29" />

### After manual workaround / with the fix — counterpart 82.75 €, no suspense, reconcilable

<img width="1324" height="574" alt="Schermata_20260714_144319" src="https://github.com/user-attachments/assets/4255453c-4a2c-48c0-b598-6a75c2149574" />

---

*The fix and its regression tests were written and validated with some
assistance from GitHub Copilot (model Claude Opus 4.8, 200K context window).*