### PR TITLE
[18.0][FIX] account_mass_reconcile: reconciles not being sorted

### DIFF
--- a/account_mass_reconcile/models/mass_reconcile.py
+++ b/account_mass_reconcile/models/mass_reconcile.py
@@ -328,7 +328,7 @@ class AccountMassReconcile(models.Model):
         if run_all:
             reconciles.run_reconcile()
             return True
-        reconciles.sorted(key=_get_date)
+        reconciles = reconciles.sorted(key=_get_date)
         older = reconciles[0]
         older.run_reconcile()
         return True


### PR DESCRIPTION
Porting of https://github.com/OCA/account-reconcile/pull/1016 to 18.0

Original Code:
reconciles.sorted(key=_get_date) # WRONG

New code:
reconciles = reconciles.sorted(key=_get_date) # OK

In the original code the reconciles aren't sorted as the variable is not being updated, this causes to getting the same values and wrong order.