### PR TITLE
[18.0][FIX] account_partner_reconcile: stat button labels use o_stat_text

### DIFF
--- a/account_partner_reconcile/views/res_partner_view.xml
+++ b/account_partner_reconcile/views/res_partner_view.xml
@@ -16,8 +16,9 @@
                     context="{'reconcile_mode': 'customers'}"
                     icon="fa-usd"
                     groups="account.group_account_invoice"
-                    string="Match Receivables"
-                />
+                >
+                    <span class="o_stat_text">Match Receivables</span>
+                </button>
                 <button
                     class="oe_stat_button"
                     type="object"
@@ -25,8 +26,9 @@
                     context="{'reconcile_mode': 'suppliers'}"
                     groups="account.group_account_invoice"
                     icon="fa-usd"
-                    string="Match Payables"
-                />
+                >
+                    <span class="o_stat_text">Match Payables</span>
+                </button>
             </div>
         </field>
     </record>


### PR DESCRIPTION
The two stat buttons this module adds to the partner form pass their label through the `string` attribute:

```xml
<button class="oe_stat_button" ... string="Match Receivables"/>
```

Odoo renders that label as the button’s raw text, at the default font size. Every other stat button on the partner form wraps its label in `o_stat_text` — directly, or through the `statinfo` widget — so these two are visibly larger than all their neighbours.

Wrapping the label in a `<span class="o_stat_text">` restores the expected sizing:

```xml
<button class="oe_stat_button" ...>
    <span class="o_stat_text">Match Receivables</span>
</button>
```

The label strings themselves are unchanged, so existing translations keep matching and no `.po` update is needed.

Tested on 18.0: both buttons now match the size of the surrounding stat buttons, and the action still opens the reconciliation view for the right mode.