### PR TITLE
[18.0][FIX] account_statement_base: Remove overrides of the actions

### DIFF
--- a/account_statement_base/views/account_bank_statement.xml
+++ b/account_statement_base/views/account_bank_statement.xml
@@ -87,15 +87,6 @@
         </field>
     </record>
 
-    <!-- Add form to view mode. -->
-    <record id="account.action_bank_statement_tree" model="ir.actions.act_window">
-        <field name="res_model">account.bank.statement</field>
-        <field name="view_mode">list,form,pivot,graph</field>
-    </record>
-    <record id="account.action_view_bank_statement_tree" model="ir.actions.act_window">
-        <field name="view_mode">list,form,pivot,graph</field>
-    </record>
-
     <record id="view_bank_statement_tree" model="ir.ui.view">
         <field name="name">account.bank.statement.list</field>
         <field name="model">account.bank.statement</field>


### PR DESCRIPTION
Odoo already includes the form view in the actions:

https://github.com/odoo/odoo/commit/d5c5bffd360b1feab59d02d04e9da1dbe22d272c
https://github.com/odoo/odoo/commit/3e61fd28720e51fac467d1cc7a038933519ef295

so no need of them.

This conclusion comes after detecting the problem in the credit card journals, but seeing that it has been solved upstream just today, and no need of them.

@Tecnativa TT64224