### PR TITLE
[18.0][FIX] account_reconcile_oca: do not spread the raw field context

### DIFF
--- a/account_reconcile_oca/static/src/js/widgets/reconcile_move_line_widget.esm.js
+++ b/account_reconcile_oca/static/src/js/widgets/reconcile_move_line_widget.esm.js
@@ -37,10 +37,7 @@ export class AccountReconcileMatchWidget extends Component {
             resModel: this.props.record.fields[this.props.name].relation,
             searchMenuTypes: ["filter"],
             domain: this.getDomain(),
-            context: {
-                ...this.props.context,
-                ...getFieldContext(this.props.record, this.props.name),
-            },
+            context: getFieldContext(this.props.record, this.props.name),
             // Disables selector
             allowSelectors: false,
             // We need to force the search view in order to show the right one
@@ -59,7 +56,6 @@ AccountReconcileMatchWidget.props = {
     canWrite: {type: Boolean, optional: true},
     canQuickCreate: {type: Boolean, optional: true},
     canCreateEdit: {type: Boolean, optional: true},
-    context: {type: String, optional: true},
     domain: {type: [Array, Function], optional: true},
     nameCreateField: {type: String, optional: true},
     searchLimit: {type: Number, optional: true},
@@ -79,7 +75,7 @@ AccountReconcileMatchWidget.components = {
 export const AccountReconcileMatchWidgetField = {
     component: AccountReconcileMatchWidget,
     supportedTypes: [],
-    extractProps({attrs, context, decorations, options}, dynamicInfo) {
+    extractProps({attrs, decorations, options}, dynamicInfo) {
         const hasCreatePermission = attrs.can_create
             ? evaluateBooleanExpr(attrs.can_create)
             : true;
@@ -94,7 +90,6 @@ export const AccountReconcileMatchWidgetField = {
             canWrite: hasWritePermission,
             canQuickCreate: canCreate && !options.no_quick_create,
             canCreateEdit: canCreate && !options.no_create_edit,
-            context: context,
             decorations,
             domain: dynamicInfo.domain,
         };


### PR DESCRIPTION
`this.props.context` is the `context` attribute of the `add_account_move_line_id` field as written in the arch, unevaluated: a string.

Nothing is lost by dropping it. `getFieldContext()` reads that very same attribute from `record.activeFields[name].context` and returns it evaluated, merged with the context the parent record carries, so `list_view_ref`, `search_view_ref` and the `search_default_partner_id` pre-filter keep working.
See: https://github.com/odoo/odoo/blob/a77d1d69d0319d1fab7285187cf40936d6438946/addons/web/static/src/model/relational_model/utils.js#L296

The prop is unused afterwards, as the template only renders `listViewProperties`, so drop it from the component props and from `extractProps` too instead of leaving a dead prop around.

cc @Tecnativa

ping @pedrobaeza @victoralmau 