### PR TITLE
[19.0][IMP] account_reconcile_oca: always name the reconcile button "Reconcile"

### DIFF
--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -153,8 +153,8 @@
                         <button
                             name="reconcile_bank_line"
                             type="object"
-                            string="Validate"
-                            accesskey="v"
+                            string="Reconcile"
+                            accesskey="r"
                             class="btn btn-primary mx-1"
                             invisible="is_reconciled or not can_reconcile"
                         />


### PR DESCRIPTION
Forward-port of #1025.

The statusbar shows two variants of the same button (`reconcile_bank_line`): the enabled one when the line can be reconciled and a disabled one otherwise. Each had a different label ("Validate" vs "Reconcile"), so the caption changed under the user as soon as the reconciliation was balanced, which is confusing. Use "Reconcile" in both cases, matching the button used in the account reconciliation form view.

cc @Tecnativa TT64256

ping @pedrobaeza @cristina-hidalgo-tecnativa