### PR TITLE
[IMP] account_reconcile_oca: Make it more compatible with mobile

### DIFF
--- a/account_reconcile_oca/static/src/components/account_reconcile_oca_data/account_reconcile_oca_data.scss
+++ b/account_reconcile_oca/static/src/components/account_reconcile_oca_data/account_reconcile_oca_data.scss
@@ -1,4 +1,16 @@
 .o_field_account_reconcile_oca_data {
+    .o_mobile_only {
+        display: none;
+        @include media-breakpoint-down(sm) {
+            display: table-cell;
+        }
+    }
+    .o_desktop_only,
+    thead {
+        @include media-breakpoint-down(sm) {
+            display: none;
+        }
+    }
     .o_field_account_reconcile_oca_balance_float {
         .o_field_account_reconcile_oca_balance_original_float {
             text-decoration: line-through;

--- a/account_reconcile_oca/static/src/components/account_reconcile_oca_data/account_reconcile_oca_data.xml
+++ b/account_reconcile_oca/static/src/components/account_reconcile_oca_data/account_reconcile_oca_data.xml
@@ -28,7 +28,41 @@
                         t-on-click="(ev) => this.selectReconcileLine(ev, reconcile_line)"
                         t-att-class="'o_reconcile_widget_line ' + reconcile_line.kind + (props.record.data.manual_reference == reconcile_line.reference ? ' selected ' :  ' ')"
                     >
-                        <td class="o_account_reconcile_oca_data_line_account">
+                        <td
+                            class="o_mobile_onlye o_account_reconcile_oca_data_line_mobile"
+                        >
+                            <div t-esc="reconcile_line.account_id[1]" />
+                            <div t-if="reconcile_line.move_id">
+                                <a
+                                    t-att-href="'/web#id=' + reconcile_line.move_id + '&amp;view_type=form&amp;model=account.move'"
+                                    class="o_form_uri"
+                                    t-on-click="(ev) => this.openMove(ev, reconcile_line.move_id)"
+                                >
+                                    <small t-esc="reconcile_line.move" />
+                                </a>
+                            </div>
+                            <div
+                                t-esc="reconcile_line.partner_id[1]"
+                                t-if="reconcile_line.partner_id and reconcile_line.partner_id[1]"
+                            />
+                            <div
+                                t-esc="reconcile_line.name"
+                                t-if="reconcile_line.name"
+                            />
+                        </td>
+                        <td
+                            class="o_mobile_only text-end o_field_account_reconcile_oca_balance_float o_account_reconcile_oca_data_line_credit"
+                        >
+                            <div t-esc="reconcile_line.amount_format" />
+                            <div
+                                class="o_field_account_reconcile_oca_balance_original_float"
+                                t-esc="reconcile_line.original_amount_format"
+                                t-if="reconcile_line.original_amount"
+                            />
+                        </td>
+                        <td
+                            class="o_desktop_only o_account_reconcile_oca_data_line_account"
+                        >
                             <div t-esc="reconcile_line.account_id[1]" />
                             <div t-if="reconcile_line.move_id">
                                 <a
@@ -40,14 +74,18 @@
                                 </a>
                             </div>
                         </td>
-                        <td class="o_account_reconcile_oca_data_line_partner">
+                        <td
+                            class="o_desktop_only o_account_reconcile_oca_data_line_partner"
+                        >
                             <span
                                 t-esc="reconcile_line.partner_id[1]"
                                 t-if="reconcile_line.partner_id and reconcile_line.partner_id[1]"
                             />
                         </td>
-                        <td t-esc="reconcile_line.date_format" />
-                        <td class="o_account_reconcile_oca_data_line_name">
+                        <td class="o_desktop_only" t-esc="reconcile_line.date_format" />
+                        <td
+                            class="o_desktop_only o_account_reconcile_oca_data_line_name"
+                        >
                             <span
                                 t-esc="reconcile_line.name"
                                 t-if="reconcile_line.name"
@@ -60,7 +98,7 @@
                             <span t-esc="reconcile_line.amount_currency_format" />
                         </td>
                         <td
-                            class="text-end o_field_account_reconcile_oca_balance_float o_account_reconcile_oca_data_line_debit"
+                            class="o_desktop_only text-end o_field_account_reconcile_oca_balance_float o_account_reconcile_oca_data_line_debit"
                         >
                             <div
                                 t-esc="reconcile_line.debit_format"
@@ -73,7 +111,7 @@
                             />
                         </td>
                         <td
-                            class="text-end o_field_account_reconcile_oca_balance_float o_account_reconcile_oca_data_line_credit"
+                            class="o_desktop_only text-end o_field_account_reconcile_oca_balance_float o_account_reconcile_oca_data_line_credit"
                         >
                             <div
                                 t-esc="reconcile_line.credit_format"

--- a/account_reconcile_oca/static/src/scss/reconcile.scss
+++ b/account_reconcile_oca/static/src/scss/reconcile.scss
@@ -1,7 +1,7 @@
 .o_account_reconcile_oca {
     .o_form_view {
         .o_form_statusbar.o_account_reconcile_oca_statusbar {
-            height: 40px;
+            min-height: 40px;
         }
     }
 }

--- a/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.scss
+++ b/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.scss
@@ -1,3 +1,23 @@
+@include media-breakpoint-down(sm) {
+    .o_account_reconcile_oca_open_selector_click .o_account_reconcile_oca {
+        .o_kanban_renderer {
+            display: block !important;
+        }
+        .o_account_reconcile_oca_info {
+            display: none !important;
+        }
+        .o_account_reconcile_oca_open_selector {
+            left: unset;
+            right: 0px;
+            .o_account_reconcile_oca_close_selector_btn {
+                display: unset;
+            }
+            .o_account_reconcile_oca_open_selector_btn {
+                display: none;
+            }
+        }
+    }
+}
 .o_account_reconcile_oca {
     display: -webkit-box;
     display: -webkit-flex;
@@ -5,6 +25,12 @@
     -webkit-flex-flow: row wrap;
     flex-flow: row wrap;
     height: 100%;
+
+    @include media-breakpoint-down(sm) {
+        .o_kanban_renderer {
+            display: none !important;
+        }
+    }
     .o_kanban_renderer.o_kanban_ungrouped .o_kanban_record {
         &:hover {
             .o_reconcile_create_statement {
@@ -35,6 +61,9 @@
         }
     }
     .o_account_reconcile_oca_selector {
+        @include media-breakpoint-down(sm) {
+            width: 100%;
+        }
         width: 30%;
         height: 100%;
         padding: 0;
@@ -43,8 +72,25 @@
         overflow: auto;
     }
     .o_account_reconcile_oca_info {
+        @include media-breakpoint-down(sm) {
+            width: 100%;
+        }
         width: 70%;
         height: 100%;
         overflow: auto;
+    }
+    .o_account_reconcile_oca_open_selector {
+        position: absolute;
+        top: 50%;
+        left: 0px;
+        z-index: 99;
+        .o_account_reconcile_oca_open_selector_btn,
+        .o_account_reconcile_oca_close_selector_btn {
+            border-radius: 50%;
+            padding: 0.4rem;
+        }
+        .o_account_reconcile_oca_close_selector_btn {
+            display: none;
+        }
     }
 }

--- a/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.scss
+++ b/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.scss
@@ -88,9 +88,12 @@
         .o_account_reconcile_oca_close_selector_btn {
             border-radius: 50%;
             padding: 0.4rem;
-        }
-        .o_account_reconcile_oca_close_selector_btn {
             display: none;
+        }
+        .o_account_reconcile_oca_open_selector_btn {
+            @include media-breakpoint-down(sm) {
+                display: unset;
+            }
         }
     }
 }

--- a/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.xml
+++ b/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile.xml
@@ -70,6 +70,22 @@
             >model.useSampleModel ? 'o_view_sample_data o_account_reconcile_oca' : 'o_account_reconcile_oca'</attribute>
         </xpath>
         <xpath expr="//Layout" position="inside">
+            <div class="o_account_reconcile_oca_open_selector">
+                <i
+                    class="o_account_reconcile_oca_open_selector_btn btn btn-secondary oi oi-chevron-right"
+                    role="img"
+                    aria-label="Select Element"
+                    title="Select element"
+                    t-on-click="() => this.onClickOpenSelector()"
+                />
+                <i
+                    class="o_account_reconcile_oca_close_selector_btn btn btn-secondary oi oi-chevron-left"
+                    role="img"
+                    aria-label="Select Element"
+                    title="Select element"
+                    t-on-click="() => this.onClickCloseSelector()"
+                />
+            </div>
             <div class="o_account_reconcile_oca_info">
                 <t t-if="state.selectedRecordId">
                     <View t-props="viewReconcileInfo" t-key="state.selectedRecordId" />

--- a/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile_controller.esm.js
+++ b/account_reconcile_oca/static/src/views/reconcile_kanban/reconcile_controller.esm.js
@@ -150,7 +150,14 @@ export class ReconcileController extends KanbanController {
         this.updateURL(resId);
     }
     async openRecord(record) {
+        this.rootRef.el.classList.remove("o_account_reconcile_oca_open_selector_click");
         this.selectRecord(record);
+    }
+    async onClickOpenSelector() {
+        this.rootRef.el.classList.add("o_account_reconcile_oca_open_selector_click");
+    }
+    async onClickCloseSelector() {
+        this.rootRef.el.classList.remove("o_account_reconcile_oca_open_selector_click");
     }
     updateURL(resId) {
         router.pushState({id: resId});


### PR DESCRIPTION
The change applied make everything more easy to view on a mobile:

- [x] Buttons on header do not overlap later on.
- [x] On mobile, kanban view is hidden. We can open it with a chevron in the left, making it easier to handle
- [x] Make table more mobile prepared

<img width="758" height="1375" alt="image" src="https://github.com/user-attachments/assets/563c580d-5330-4324-9717-906dbbb15ad2" />
<img width="758" height="1375" alt="image" src="https://github.com/user-attachments/assets/76f6feca-ad5c-4a17-9fdf-bb3bafab5b12" />
