### PR TITLE
[19.0][TEST] account_reconcile_oca: cover existing-line auto reconciliation

### DIFF
--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -553,10 +553,25 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
 
     @mute_logger("odoo.models.unlink")
     def test_reconcile_rule_on_create(self):
-        """
-        Testing the fill of the bank statment line with
-        writeoff suggestion reconcile model with auto_reconcile
-        """
+        """Test auto reconciliation on create and on existing lines."""
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_euro.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        existing_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "DEMO WRITEOFF",
+                "payment_ref": "DEMO WRITEOFF",
+                "journal_id": self.bank_journal_euro.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertFalse(existing_line.is_reconciled)
         model = self.env["account.reconcile.model"].create(
             {
                 "name": "write-off model suggestion",
@@ -570,14 +585,6 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             }
         )
         model.flush_recordset()
-
-        bank_stmt = self.acc_bank_stmt_model.create(
-            {
-                "journal_id": self.bank_journal_euro.id,
-                "date": time.strftime("%Y-07-15"),
-                "name": "test",
-            }
-        )
         bank_stmt_line = self.acc_bank_stmt_line_model.create(
             {
                 "name": "DEMO WRITEOFF",
@@ -589,6 +596,9 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             }
         )
         self.assertTrue(bank_stmt_line.is_reconciled)
+        existing_line.invalidate_recordset()
+        existing_line._auto_reconcile()
+        self.assertTrue(existing_line.is_reconciled)
 
     def test_reconcile_rule_tax(self):
         """


### PR DESCRIPTION
## Summary

- rebuild this contribution on current `19.0`, which already contains the production fix from #1013
- extend the existing `test_reconcile_rule_on_create` case to cover an existing statement line after cache invalidation
- exercise `_auto_reconcile()` on the existing line and confirm it reconciles

The effective diff is test-only. It follows the requested shape by extending the existing method without adding blank lines inside it; there are no production-code changes.

## Context

#1013 corrected the `with_prefetch(to_do.ids)` call for #1019. This PR now supplies the previously missing regression coverage for the cached-invalidated existing-line path.

## Verification

- `python -m compileall -q account_reconcile_oca` — passed
- OCA pre-commit on `account_reconcile_oca/tests/test_bank_account_reconcile.py` — passed, including Ruff, Ruff format and mandatory Pylint
- `git diff --check` — passed
- effective scope check — one existing test file, no model diff

Hosted Odoo, OCB, Runboat and repository checks will validate the rebased head.

## Ownership
I reviewed, understand and take responsibility for every line in this contribution.