### PR TITLE
[16.0][FIX] account_reconcile_oca: cap invoice matching in journal currency

### DIFF
--- a/account_reconcile_oca/__manifest__.py
+++ b/account_reconcile_oca/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Reconcile OCA",
     "summary": """
         Reconcile addons for Odoo CE accounting""",
-    "version": "16.0.2.5.1",
+    "version": "16.0.2.5.2",
     "license": "AGPL-3",
     "author": "CreuBlanca,Dixmit,Odoo Community Association (OCA)",
     "maintainers": ["etobella"],

--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -676,16 +676,19 @@ class AccountBankStatementLine(models.Model):
                 )
             elif res and res.get("amls"):
                 amount = self.amount_total_signed
+                # amount_currency is 0 on a foreign-currency journal without
+                # foreign_currency_id; fall back to the journal amount.
+                journal_amount = self.amount_currency or self.amount
                 for line in res.get("amls", []):
                     max_amount = amount
                     if (
                         line.currency_id == self._get_reconcile_currency()
-                        and self.amount_currency
+                        and journal_amount
                         and self.amount_total_signed
                     ):
                         # convert max amount with rate of statement, not Odoo's rate
                         max_amount = line.currency_id.round(
-                            max_amount * self.amount_currency / self.amount_total_signed
+                            max_amount * journal_amount / self.amount_total_signed
                         )
                     reconcile_auxiliary_id, line_data = self._get_reconcile_line(
                         line,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1557,3 +1557,59 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             reconciled_exchange_line.balance,
             "Proposed reconciliation does not match auto reconciliation",
         )
+
+    def test_invoice_matching_usd_journal_without_amount_currency(self):
+        """USD invoice on a USD journal must be capped in journal currency.
+
+        amount_currency is empty on a foreign-currency journal without
+        foreign_currency_id. The model proposal must not use company-currency
+        amount_total_signed as the USD cap.
+        """
+        self.env["res.currency.rate"].search([]).unlink()
+        self.env["res.currency.rate"].create(
+            {
+                "currency_id": self.env.ref("base.USD").id,
+                "name": time.strftime("%Y-07-13"),
+                "rate": 2,
+            }
+        )
+        self.env["account.reconcile.model"].search([]).unlink()
+        self.env["account.reconcile.model"].create(
+            {
+                "name": "Match USD invoice on USD journal",
+                "rule_type": "invoice_matching",
+                "auto_reconcile": False,
+                "match_same_currency": True,
+                "match_partner": True,
+                "match_text_location_label": True,
+            }
+        )
+        invoice = self.create_invoice(
+            currency_id=self.currency_usd_id, invoice_amount=100
+        )
+        bank_stmt = self.acc_bank_stmt_model.create(
+            {
+                "journal_id": self.bank_journal_usd.id,
+                "date": time.strftime("%Y-07-15"),
+                "name": "test",
+            }
+        )
+        bank_stmt_line = self.acc_bank_stmt_line_model.create(
+            {
+                "name": "Payment for %s" % invoice.name,
+                "partner_id": invoice.partner_id.id,
+                "journal_id": self.bank_journal_usd.id,
+                "statement_id": bank_stmt.id,
+                "amount": 100,
+                "date": time.strftime("%Y-07-15"),
+            }
+        )
+        self.assertFalse(bank_stmt_line.amount_currency)
+        data = bank_stmt_line._default_reconcile_data()
+        counterpart = [
+            line
+            for line in data["data"]
+            if line.get("kind") == "other" and not line.get("is_exchange_counterpart")
+        ]
+        self.assertEqual(len(counterpart), 1)
+        self.assertAlmostEqual(abs(counterpart[0]["currency_amount"]), 100.0)


### PR DESCRIPTION
Fixes #1011

## Summary

- `_default_reconcile_data` converted the invoice-matching cap with `amount_currency / amount_total_signed`
- on a foreign-currency journal without `foreign_currency_id`, `amount_currency` is 0 and the conversion was skipped
- the widget then capped a USD invoice at `amount_total_signed` (company currency)
- use `amount_currency or amount` (journal amount) for that rate, matching the manual add-line path

## Verification

- `python3 -m ast` parse of the changed model and test files
- new test `test_invoice_matching_usd_journal_without_amount_currency`: USD invoice on a USD journal, empty `amount_currency`, proposal `currency_amount` is 100 not the EUR residual
- hosted Odoo / Runboat remain the integration checks (`oca_run_tests`)

## Ownership
I reviewed, understand, and take responsibility for every line in this contribution.