### PR TITLE
[18.0][FIX] account_reconcile_oca: resolve undefined account label before JSON encoding

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -451,7 +451,7 @@ class AccountBankStatementLine(models.Model):
             "account_id": (
                 [self.manual_account_id.id, self.manual_account_id.display_name]
                 if self.manual_account_id
-                else [False, _lt("Undefined")]
+                else [False, _("Undefined")]
             ),
             "amount": self.manual_amount,
             "credit": -self.manual_amount if self.manual_amount < 0 else 0.0,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from odoo import Command
@@ -92,6 +93,17 @@ class TestAccountReconciliationCommon(TestAccountReconciliationModelCommon):
 @tagged("post_install", "-at_install")
 class TestReconciliationWidget(TestAccountReconciliationCommon):
     # Testing reconcile action
+
+    def test_manual_line_without_account_is_json_serializable(self):
+        bank_stmt_line = self.acc_bank_stmt_line_model.with_context(lang="en_US").new(
+            {"journal_id": self.bank_journal_euro.id}
+        )
+
+        vals = bank_stmt_line._get_manual_reconcile_vals()
+
+        self.assertEqual(
+            json.loads(json.dumps(vals))["account_id"], [False, "Undefined"]
+        )
 
     def test_reconcile_invoice_currency(self):
         inv1 = self.create_invoice(currency_id=self.currency_usd_id, invoice_amount=100)


### PR DESCRIPTION
Fixes #956.

Manual reconciliation without an account puts a `LazyGettext` object into `reconcile_data_info`, causing JSON encoding to fail. Resolve the existing Undefined label immediately using `_()` and add a regression test for the model method's JSON-serializable result.

Repository pre-commit checks and diff whitespace checks pass. Optional Pylint emitted an internal Astroid diagnostic despite exiting successfully; mandatory Pylint passed.

CI has since run: pre-commit, test with Odoo, test with OCB and codecov all pass, including the new regression test. The production change is limited to resolving the label before JSON encoding; no accounting amounts or reconciliation rules are changed.
