### PR TITLE
[18.0][FIX] account_reconcile_oca: use the line's company for partner accounts

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -296,12 +296,13 @@ class AccountBankStatementLine(models.Model):
                 )
             else:
                 account = self.journal_id.suspense_account_id
-                if self.partner_id and total_amount > 0:
+                partner = self.partner_id.with_company(self.company_id)
+                if partner and total_amount > 0:
                     can_reconcile = True
-                    account = self.partner_id.property_account_receivable_id
-                elif self.partner_id and total_amount < 0:
+                    account = partner.property_account_receivable_id
+                elif partner and total_amount < 0:
                     can_reconcile = True
-                    account = self.partner_id.property_account_payable_id
+                    account = partner.property_account_payable_id
                 suspense_line = {
                     "reference": f"reconcile_auxiliary;{reconcile_auxiliary_id}",
                     "id": False,

--- a/account_reconcile_oca/tests/test_bank_account_reconcile.py
+++ b/account_reconcile_oca/tests/test_bank_account_reconcile.py
@@ -1473,3 +1473,41 @@ class TestReconciliationWidget(TestAccountReconciliationCommon):
             self.assertEqual(3, len(f.reconcile_data_info["data"]))
             self.assertTrue(f.can_reconcile)
             self.assertEqual(f.reconcile_data_info["data"][-1]["amount"], 3.63)
+
+    def test_partner_accounts_follow_the_line_company(self):
+        """The proposed counterpart uses the statement line's company."""
+        other = self.setup_other_company()
+        other_company = other["company"]
+        self.env.user.company_ids |= other_company
+        partner = self.partner_agrolait
+        partner.with_company(other_company).write(
+            {
+                "property_account_receivable_id": other[
+                    "default_account_receivable"
+                ].id,
+                "property_account_payable_id": other["default_account_payable"].id,
+            }
+        )
+        self.assertNotEqual(other["default_account_receivable"], self.account_rcv)
+        journal = other["default_journal_bank"]
+        cases = (
+            (100, other["default_account_receivable"]),
+            (-100, other["default_account_payable"]),
+        )
+        for amount, expected in cases:
+            line = self.acc_bank_stmt_line_model.create(
+                {
+                    "name": "cross-company",
+                    "journal_id": journal.id,
+                    "amount": amount,
+                    "partner_id": partner.id,
+                    "date": time.strftime("%Y-07-15"),
+                }
+            )
+            counterparts = [
+                data
+                for data in line.reconcile_data_info["data"]
+                if data.get("kind") == "suspense"
+            ]
+            self.assertEqual(len(counterparts), 1)
+            self.assertEqual(counterparts[0]["account_id"][0], expected.id)


### PR DESCRIPTION
Backport of #1040 (same lines at 299–304): the partner's receivable/payable is company-dependent and was read in the current user's company instead of the statement line's. Test fails without the fix.